### PR TITLE
Command taxonomy: unify graph under memory; doctor as health + heal hub

### DIFF
--- a/.ckeletin/pkg/config/keys_generated.go
+++ b/.ckeletin/pkg/config/keys_generated.go
@@ -163,6 +163,23 @@ const (
 	KeyAppMemorysummarizeIds            = "app.memorysummarize.ids"             // Comma-separated note IDs (alternative to positional args)
 	KeyAppMemorysummarizeIncludeBody    = "app.memorysummarize.include_body"    // Include body text excerpts
 	KeyAppMemorysummarizeMaxBodyLen     = "app.memorysummarize.max_body_len"    // Max body chars per note (0 = full)
+	KeyAppMemorylinksVault              = "app.memorylinks.vault"               // Path to vault root
+	KeyAppMemorylinksJson               = "app.memorylinks.json"                // Output in JSON format
+	KeyAppMemorylinksEdgeType           = "app.memorylinks.edge_type"           // Filter by edge type
+	KeyAppMemorylinksOut                = "app.memorylinks.out"                 // Show only outbound edges
+	KeyAppMemorylinksIn                 = "app.memorylinks.in"                  // Show only inbound edges (backlinks)
+	KeyAppMemorylinksBoth               = "app.memorylinks.both"                // Show both inbound and outbound edges (default)
+	KeyAppMemoryneighborsVault          = "app.memoryneighbors.vault"           // Path to vault root
+	KeyAppMemoryneighborsJson           = "app.memoryneighbors.json"            // Output in JSON format
+	KeyAppMemoryneighborsDepth          = "app.memoryneighbors.depth"           // Maximum traversal depth
+	KeyAppMemoryneighborsMinConfidence  = "app.memoryneighbors.min_confidence"  // Minimum edge confidence (low, medium, high)
+	KeyAppMemoryneighborsMaxNodes       = "app.memoryneighbors.max_nodes"       // Maximum nodes to return
+	KeyAppMemorypackVault               = "app.memorypack.vault"                // Path to vault root
+	KeyAppMemorypackJson                = "app.memorypack.json"                 // Output in JSON format
+	KeyAppMemorypackBudget              = "app.memorypack.budget"               // Token budget
+	KeyAppMemorypackDepth               = "app.memorypack.depth"                // BFS traversal depth (1 = direct neighbors only)
+	KeyAppMemorypackMaxItems            = "app.memorypack.max_items"            // Max context items (0 = unlimited)
+	KeyAppMemorypackSlim                = "app.memorypack.slim"                 // Slim frontmatter (type, title, status only)
 	KeyAppNoteVault                     = "app.note.vault"                      // Path to vault root
 	KeyAppNoteJson                      = "app.note.json"                       // Output in JSON format
 	KeyAppNoteFrontmatterOnly           = "app.note.frontmatter_only"           // Omit body, headings, blocks

--- a/.ckeletin/pkg/config/keys_generated.go
+++ b/.ckeletin/pkg/config/keys_generated.go
@@ -55,6 +55,12 @@ const (
 	KeyAppDoctorVault                   = "app.doctor.vault"                    // Path to vault root
 	KeyAppDoctorJson                    = "app.doctor.json"                     // Output in JSON format
 	KeyAppDoctorSummary                 = "app.doctor.summary"                  // Print summary counts only (suppress per-link details)
+	KeyAppDoctorhealVault               = "app.doctorheal.vault"                // Path to vault root
+	KeyAppDoctorhealJson                = "app.doctorheal.json"                 // Output in JSON format
+	KeyAppDoctorhealDryRun              = "app.doctorheal.dry_run"              // Preview repairs without writing (default applies)
+	KeyAppDoctorhealwikilinksVault      = "app.doctorhealwikilinks.vault"       // Path to vault root
+	KeyAppDoctorhealwikilinksJson       = "app.doctorhealwikilinks.json"        // Output in JSON format
+	KeyAppDoctorhealwikilinksDryRun     = "app.doctorhealwikilinks.dry_run"     // Preview repairs without writing (default applies)
 	KeyAppExperimentreportExperiment    = "app.experimentreport.experiment"     // Experiment name to report on
 	KeyAppExperimentreportJson          = "app.experimentreport.json"           // Output in JSON format
 	KeyAppExperimentreportK             = "app.experimentreport.k"              // K value for Hit@K metric

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ won't break them.
 **Covered commands (contract tests in `cmd/contract_*_test.go`):**
 - `vaultmind ask --json`: `result.query`, `result.retrieval_mode`,
   `result.top_hits[].{id,type,title,path,score}`, `result.context.target_id`
-- `vaultmind memory context-pack --json`: `result.target_id`,
+- `vaultmind memory pack --json`: `result.target_id`,
   `result.target.id`, `result.used_tokens`, `result.budget_tokens`,
   `result.truncated`, `result.context[].{id,edge_type,body_included}`
 - `vaultmind search --json`: `result.hits[].{id,title,score}`, `result.total`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `links in` → `memory links --in`
   - `links neighbors` → `memory neighbors`
   - `lint` (top-level, removed) and `lint fix-links` → `doctor heal wikilinks`
-  - `vault status` → `doctor --summary` (the `vault` parent is deprecated; it only hosted `status`)
+  - `vault status` → `doctor --summary` (the `vault` parent is deprecated; it only hosted `status`).
+    Note: `vault status --json` now returns the **doctor envelope shape** (the `doctor` result —
+    different from the old `StatusResult`), since the alias delegates to doctor's JSON path. Consumers
+    that decoded the old `vault status --json` payload must update to the doctor result shape.
   - `memory recall` → `memory neighbors`
   - `memory context-pack` → `memory pack`
 - The canonical repair verb is `heal`; `fix` is a permanent cobra alias (help shows "heal (fix)").

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`doctor heal` — repair lives under the health hub.** `vaultmind doctor heal` applies every
+  auto-fixable repair `doctor` found (today: Obsidian-incompatible wikilinks); `doctor heal wikilinks`
+  is the surgical form (the logic moved here from the removed `lint fix-links`). `heal` **applies by
+  default**; `--dry-run` previews. Cobra alias `fix` works on both (`doctor fix`, `doctor fix wikilinks`).
+  All `doctor heal *` paths share one mutation engine (`internal/mutation`).
+- **`doctor --summary` — the cold-start view.** Counts, the per-type breakdown that `vault status`
+  produced, and an errors/warnings rollup, in one read-only command.
+
+### Changed
+- **Graph traversal is unified under `memory`.** `memory links <id> [--out|--in|--both]` (default
+  `--both`; `--in` = backlinks) is a single direction-flagged command that absorbs the old
+  `links out` / `links in`. `memory neighbors <id> [--depth N]` is the BFS neighborhood with full
+  frontmatter (merging the old `links neighbors` and `memory recall`). `memory context-pack` is
+  renamed to `memory pack` (identical behavior). `memory related` / `memory summarize` unchanged.
+- **`doctor` is now the single vault-health hub.** Read-only `doctor` gained the per-type breakdown
+  that `vault status` carried, and repair lives under it via `doctor heal`. The diagnosis remedy for
+  broken links now points at `vaultmind doctor heal wikilinks` (previously an unshipped helper script).
+
+### Deprecated
+- The following invocations are now **hidden deprecated aliases** that print a one-line stderr notice
+  and delegate to the new path. They will be removed in ~2 releases:
+  - `links out` → `memory links --out`
+  - `links in` → `memory links --in`
+  - `links neighbors` → `memory neighbors`
+  - `lint` (top-level, removed) and `lint fix-links` → `doctor heal wikilinks`
+  - `vault status` → `doctor --summary` (the `vault` parent is deprecated; it only hosted `status`)
+  - `memory recall` → `memory neighbors`
+  - `memory context-pack` → `memory pack`
+- The canonical repair verb is `heal`; `fix` is a permanent cobra alias (help shows "heal (fix)").
+  `dataview lint` is a separate domain checker and is **not** affected.
+
 ## [0.1.10] — 2026-06-05
 
 ### Added

--- a/cmd/contract_types_test.go
+++ b/cmd/contract_types_test.go
@@ -39,7 +39,7 @@ type AskEnvelope struct {
 	} `json:"meta"`
 }
 
-// ContextPackEnvelope is the contract shape for `vaultmind memory context-pack --json`.
+// ContextPackEnvelope is the contract shape for `vaultmind memory pack --json`.
 type ContextPackEnvelope struct {
 	SchemaVersion string `json:"schema_version"`
 	Status        string `json:"status"`

--- a/cmd/deprecation_helpers.go
+++ b/cmd/deprecation_helpers.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// newDeprecatedAlias builds a Hidden cobra command that prints a one-line
+// stderr deprecation notice, then delegates to the new command's run path by
+// calling delegate with its own (alias) command and args. Because the alias
+// registers the same flags as the target (via meta.ConfigPrefix), delegate —
+// which is the target's run function — reads flags transparently from the
+// alias command.
+//
+// This helper is shared by every slice of the taxonomy refactor (links→memory,
+// doctor, lint→doctor heal); keep it general.
+func newDeprecatedAlias(meta config.CommandMetadata, notice string, delegate func(*cobra.Command, []string) error) *cobra.Command {
+	cmd := MustNewCommand(meta, func(c *cobra.Command, args []string) error {
+		if _, err := fmt.Fprintln(c.ErrOrStderr(), notice); err != nil {
+			return err
+		}
+		return delegate(c, args)
+	})
+	cmd.Hidden = true
+	return cmd
+}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
@@ -99,6 +100,18 @@ func writeEmbeddingStatus(w io.Writer, emb *query.DoctorEmbeddings) error {
 
 func runDoctor(cmd *cobra.Command, _ []string) error {
 	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppDoctorVault)
+	jsonOut := getConfigValueWithFlags[bool](cmd, "json", config.KeyAppDoctorJson)
+	summaryOnly := getConfigValueWithFlags[bool](cmd, "summary", config.KeyAppDoctorSummary)
+	return runDoctorCore(cmd, vaultPath, jsonOut, summaryOnly)
+}
+
+// runDoctorCore is the doctor health-hub engine, shared by `doctor`,
+// `doctor --summary`, and the deprecated `vault status` alias (which forces
+// summaryOnly=true). It opens the vault, runs the read-only diagnosis, folds
+// in the per-type breakdown + errors/warnings rollup (the merged-in
+// `vault status` view, computed via the shared status.go helpers for SSOT),
+// then renders JSON or the human report.
+func runDoctorCore(cmd *cobra.Command, vaultPath string, jsonOut, summaryOnly bool) error {
 	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "doctor")
 	if err != nil {
 		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
@@ -111,6 +124,17 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	result, err := query.Doctor(vdb.DB, vaultPath, vdb.Reg)
 	if err != nil {
 		return fmt.Errorf("running doctor: %w", err)
+	}
+
+	// Fold in the per-type breakdown + errors/warnings rollup that `vault
+	// status` used to produce. Populated here in cmd/ because the vault config
+	// and schema registry live on vdb — the same reason HookDrift is populated
+	// in this layer. Both come from internal/query/status.go (SSOT).
+	if result.Types, err = query.CollectTypeBreakdown(vdb.DB, vdb.Config); err != nil {
+		return fmt.Errorf("collecting type breakdown: %w", err)
+	}
+	if result.IssuesSummary, err = query.SummarizeValidationIssues(vdb.DB, vdb.Reg); err != nil {
+		return fmt.Errorf("summarizing validation issues: %w", err)
 	}
 
 	// Hook-drift detection — embedded canonical vs installed copies in
@@ -135,7 +159,7 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 		result.Issues.LegacyHooksJSON = hooks.DetectLegacyHooksJSON(projectDir)
 	}
 
-	if getConfigValueWithFlags[bool](cmd, "json", config.KeyAppDoctorJson) {
+	if jsonOut {
 		env := envelope.OK("doctor", result)
 		env.Meta.VaultPath = vaultPath
 		env.Meta.IndexHash = vdb.GetIndexHash()
@@ -148,43 +172,14 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 		result.UnstructuredNotes, result.Issues.UnresolvedLinks); err != nil {
 		return err
 	}
+	if err = writeTypeBreakdown(w, result.Types); err != nil {
+		return err
+	}
 	if err = writeEmbeddingStatus(w, result.Embeddings); err != nil {
 		return err
 	}
-	summaryOnly := getConfigValueWithFlags[bool](cmd, "summary", config.KeyAppDoctorSummary)
-	if result.Issues.ObsidianIncompatibleLinks > 0 {
-		if _, err = fmt.Fprintf(w, "Obsidian-incompatible links: %d\n", result.Issues.ObsidianIncompatibleLinks); err != nil {
-			return err
-		}
-		if summaryOnly {
-			if _, err = fmt.Fprintln(w, "  (run without --summary to see per-link details, or pipe through scripts/fix_wikilinks.py)"); err != nil {
-				return err
-			}
-		} else {
-			for _, il := range result.Issues.IncompatibleLinkDetails {
-				if _, err = fmt.Fprintf(w, "  %s: [[%s]] → [[%s|%s]]\n",
-					il.SourcePath, il.TargetRaw, il.SuggestedFix, il.TargetRaw); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	if result.Issues.PathPseudoIDLinks > 0 {
-		if _, err = fmt.Fprintf(w, "Dead link references: %d\n", result.Issues.PathPseudoIDLinks); err != nil {
-			return err
-		}
-		if summaryOnly {
-			if _, err = fmt.Fprintln(w, "  (run without --summary to see per-link details)"); err != nil {
-				return err
-			}
-		} else {
-			for _, pl := range result.Issues.PathPseudoIDDetails {
-				if _, err = fmt.Fprintf(w, "  %s: [[%s]] → target file does not exist\n",
-					pl.SourcePath, pl.TargetRaw); err != nil {
-					return err
-				}
-			}
-		}
+	if err = writeLinkIssues(w, &result.Issues, summaryOnly); err != nil {
+		return err
 	}
 	if err = writeHookDrift(w, &result.Issues, summaryOnly); err != nil {
 		return err
@@ -192,20 +187,112 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	if err = writeLegacyHooksJSON(w, &result.Issues); err != nil {
 		return err
 	}
-	if result.Issues.StaleIndex > 0 {
-		if _, err = fmt.Fprintf(w,
-			"⚠ Stale index: %d note(s) changed since last index pass\n"+
-				"  run: vaultmind index --vault <vault>\n",
-			result.Issues.StaleIndex); err != nil {
+	if err = writeStaleIndex(w, &result.Issues, summaryOnly); err != nil {
+		return err
+	}
+	// Errors/warnings rollup — the cold-start signal `vault status` used to
+	// emit. Always printed so the operator gets the validation bottom line
+	// from a single `doctor` run.
+	if _, err = fmt.Fprintf(w, "Issues: %d errors, %d warnings\n",
+		result.IssuesSummary.Errors, result.IssuesSummary.Warnings); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeLinkIssues prints the Obsidian-incompatible and dead-link sections.
+// Extracted from runDoctorCore to keep its cyclomatic complexity under the 30
+// ceiling (gocyclo) — same shape as writeHookDrift. Under --summary the
+// per-link detail lines are suppressed and replaced with a one-line pointer.
+func writeLinkIssues(w io.Writer, issues *query.DoctorIssues, summaryOnly bool) error {
+	if issues.ObsidianIncompatibleLinks > 0 {
+		if _, err := fmt.Fprintf(w, "Obsidian-incompatible links: %d\n", issues.ObsidianIncompatibleLinks); err != nil {
 			return err
 		}
-		if !summaryOnly {
-			for _, sv := range result.Issues.StaleIndexDetails {
-				if _, err = fmt.Fprintf(w, "  %s: current_hash=%s stored_hash=%s\n",
-					sv.Path, short(sv.CurrentHash), short(sv.StoredHash)); err != nil {
+		if summaryOnly {
+			if _, err := fmt.Fprintln(w, "  (run without --summary to see per-link details; fix with: vaultmind doctor heal wikilinks)"); err != nil {
+				return err
+			}
+		} else {
+			for _, il := range issues.IncompatibleLinkDetails {
+				if _, err := fmt.Fprintf(w, "  %s: [[%s]] → [[%s|%s]]\n",
+					il.SourcePath, il.TargetRaw, il.SuggestedFix, il.TargetRaw); err != nil {
 					return err
 				}
 			}
+		}
+	}
+	if issues.PathPseudoIDLinks == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintf(w, "Dead link references: %d\n", issues.PathPseudoIDLinks); err != nil {
+		return err
+	}
+	if summaryOnly {
+		_, err := fmt.Fprintln(w, "  (run without --summary to see per-link details)")
+		return err
+	}
+	for _, pl := range issues.PathPseudoIDDetails {
+		if _, err := fmt.Fprintf(w, "  %s: [[%s]] → target file does not exist\n",
+			pl.SourcePath, pl.TargetRaw); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeStaleIndex prints the stale-index drift section. Extracted from
+// runDoctorCore for the same gocyclo reason. Per-note hash details are
+// suppressed under --summary.
+func writeStaleIndex(w io.Writer, issues *query.DoctorIssues, summaryOnly bool) error {
+	if issues.StaleIndex == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintf(w,
+		"⚠ Stale index: %d note(s) changed since last index pass\n"+
+			"  run: vaultmind index --vault <vault>\n",
+		issues.StaleIndex); err != nil {
+		return err
+	}
+	if summaryOnly {
+		return nil
+	}
+	for _, sv := range issues.StaleIndexDetails {
+		if _, err := fmt.Fprintf(w, "  %s: current_hash=%s stored_hash=%s\n",
+			sv.Path, short(sv.CurrentHash), short(sv.StoredHash)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeTypeBreakdown prints the per-type note counts (with each type's valid
+// statuses when defined) that `vault status` used to produce — now folded
+// into the doctor health hub. Types are printed in sorted order so the output
+// is deterministic. Nothing is printed when the vault has no registered types.
+func writeTypeBreakdown(w io.Writer, types map[string]query.StatusTypeInfo) error {
+	if len(types) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(types))
+	for name := range types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if _, err := fmt.Fprintf(w, "Types: %d\n", len(types)); err != nil {
+		return err
+	}
+	for _, name := range names {
+		ti := types[name]
+		if len(ti.Statuses) > 0 {
+			if _, err := fmt.Fprintf(w, "  %s: %d note(s) [statuses: %s]\n",
+				name, ti.Count, strings.Join(ti.Statuses, ", ")); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "  %s: %d note(s)\n", name, ti.Count); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -24,6 +24,12 @@ import (
 // future caller never drift on where the upgrade path is documented.
 const embeddingBackendsDocURL = "https://github.com/peiman/vaultmind/blob/main/docs/embedding-backends.md"
 
+// staleIndexRemedy is the SSOT re-index remedy line. doctor's stale-index
+// drift warning (writeStaleIndex) and heal's "index now stale after apply"
+// warning (runWikilinkFix) must name the same command so the operator sees one
+// consistent instruction.
+const staleIndexRemedy = "vaultmind index --vault <vault>"
+
 var doctorCmd = MustNewCommand(commands.DoctorMetadata, runDoctor)
 
 func init() {
@@ -133,9 +139,16 @@ func runDoctorCore(cmd *cobra.Command, vaultPath string, jsonOut, summaryOnly bo
 	if result.Types, err = query.CollectTypeBreakdown(vdb.DB, vdb.Config); err != nil {
 		return fmt.Errorf("collecting type breakdown: %w", err)
 	}
-	if result.IssuesSummary, err = query.SummarizeValidationIssues(vdb.DB, vdb.Reg); err != nil {
+	// Set IssuesSummary to a non-nil pointer in the cmd path so the JSON
+	// envelope distinguishes "validation ran" (&{...}) from "validation not
+	// run" (nil, the raw query.Doctor shape). DoctorResult.IssuesSummary is a
+	// pointer with omitempty precisely so a raw Doctor result omits the field
+	// instead of emitting a false-zero {errors:0,warnings:0}.
+	summary, err := query.SummarizeValidationIssues(vdb.DB, vdb.Reg)
+	if err != nil {
 		return fmt.Errorf("summarizing validation issues: %w", err)
 	}
+	result.IssuesSummary = &summary
 
 	// Hook-drift detection — embedded canonical vs installed copies in
 	// the project's .claude/scripts/. Resolve the project root by
@@ -192,9 +205,14 @@ func runDoctorCore(cmd *cobra.Command, vaultPath string, jsonOut, summaryOnly bo
 	}
 	// Errors/warnings rollup — the cold-start signal `vault status` used to
 	// emit. Always printed so the operator gets the validation bottom line
-	// from a single `doctor` run.
-	if _, err = fmt.Fprintf(w, "Issues: %d errors, %d warnings\n",
-		result.IssuesSummary.Errors, result.IssuesSummary.Warnings); err != nil {
+	// from a single `doctor` run. runDoctorCore always sets IssuesSummary, but
+	// read nil-safely (0/0) so a future raw-result caller can't panic here.
+	var errCount, warnCount int
+	if result.IssuesSummary != nil {
+		errCount = result.IssuesSummary.Errors
+		warnCount = result.IssuesSummary.Warnings
+	}
+	if _, err = fmt.Fprintf(w, "Issues: %d errors, %d warnings\n", errCount, warnCount); err != nil {
 		return err
 	}
 	return nil
@@ -250,8 +268,8 @@ func writeStaleIndex(w io.Writer, issues *query.DoctorIssues, summaryOnly bool) 
 	}
 	if _, err := fmt.Fprintf(w,
 		"⚠ Stale index: %d note(s) changed since last index pass\n"+
-			"  run: vaultmind index --vault <vault>\n",
-		issues.StaleIndex); err != nil {
+			"  run: %s\n",
+		issues.StaleIndex, staleIndexRemedy); err != nil {
 		return err
 	}
 	if summaryOnly {

--- a/cmd/doctor_heal.go
+++ b/cmd/doctor_heal.go
@@ -89,8 +89,9 @@ func runWikilinkFix(cmd *cobra.Command, vaultPath string, jsonOut, apply bool, m
 		return fmt.Errorf("%s: %w", cmdName, err)
 	}
 
-	// The apply rewrote files only when both apply was requested AND files
-	// actually changed — that's exactly when the index is now stale.
+	// apply was requested AND at least one file had fixable links
+	// (FilesChanged>0) — under apply those files were rewritten, so the index
+	// is now stale.
 	indexStale := apply && result.FilesChanged > 0
 
 	if jsonOut {

--- a/cmd/doctor_heal.go
+++ b/cmd/doctor_heal.go
@@ -49,6 +49,19 @@ func healModeLabel(apply bool) string {
 	return "dry-run"
 }
 
+// healResult is the JSON payload for a wikilink-repair run: the shared
+// FixWikilinks result plus the stale-index fields. When an apply rewrote files
+// the on-disk content no longer matches the index, so StaleIndexAfterHeal is
+// true and StaleIndexRemedy names the re-index command (SSOT: staleIndexRemedy
+// in doctor.go, the same line doctor's drift warning prints). Embedding the
+// mutation result preserves every existing JSON field (files_scanned, etc.) so
+// the envelope shape is a superset, not a breaking change.
+type healResult struct {
+	*mutation.FixWikilinksResult
+	StaleIndexAfterHeal bool   `json:"stale_index_after_heal"`
+	StaleIndexRemedy    string `json:"stale_index_remedy,omitempty"`
+}
+
 // runWikilinkFix is the single cmd-layer engine behind every wikilink repair:
 // `doctor heal`, `doctor heal wikilinks`, and the deprecated `lint fix-links`
 // alias. It opens the vault, calls the shared internal/mutation fixer
@@ -56,6 +69,11 @@ func healModeLabel(apply bool) string {
 // either the JSON envelope or the human report. `apply` decides whether the
 // fixer writes; `modeLabel` is the human-output verb (apply / fix / dry-run);
 // `cmdName` names the operation in error and envelope text.
+//
+// When an apply actually rewrites files, the index goes stale (the indexer's
+// stored hashes no longer match disk), so both outputs surface an actionable
+// re-index warning. A dry-run or a zero-change apply leaves the index intact
+// and emits no warning.
 func runWikilinkFix(cmd *cobra.Command, vaultPath string, jsonOut, apply bool, modeLabel, cmdName string) error {
 	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, cmdName)
 	if err != nil {
@@ -71,8 +89,16 @@ func runWikilinkFix(cmd *cobra.Command, vaultPath string, jsonOut, apply bool, m
 		return fmt.Errorf("%s: %w", cmdName, err)
 	}
 
+	// The apply rewrote files only when both apply was requested AND files
+	// actually changed — that's exactly when the index is now stale.
+	indexStale := apply && result.FilesChanged > 0
+
 	if jsonOut {
-		env := envelope.OK(cmdName, result)
+		payload := healResult{FixWikilinksResult: result, StaleIndexAfterHeal: indexStale}
+		if indexStale {
+			payload.StaleIndexRemedy = staleIndexRemedy
+		}
+		env := envelope.OK(cmdName, payload)
 		env.Meta.VaultPath = vaultPath
 		env.Meta.IndexHash = vdb.GetIndexHash()
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
@@ -85,6 +111,13 @@ func runWikilinkFix(cmd *cobra.Command, vaultPath string, jsonOut, apply bool, m
 	}
 	for _, d := range result.Details {
 		if _, err = fmt.Fprintf(w, "  %s: %s → %s\n", d.Path, d.OldLink, d.NewLink); err != nil {
+			return err
+		}
+	}
+	if indexStale {
+		if _, err = fmt.Fprintf(w,
+			"⚠ Index is now stale (%d file(s) rewritten) — run: %s\n",
+			result.FilesChanged, staleIndexRemedy); err != nil {
 			return err
 		}
 	}

--- a/cmd/doctor_heal.go
+++ b/cmd/doctor_heal.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/cmdutil"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/envelope"
+	"github.com/peiman/vaultmind/internal/mutation"
+	"github.com/spf13/cobra"
+)
+
+// doctorHealCmd applies every auto-fixable repair doctor's diagnosis can
+// resolve. Today that set is exactly the wikilink rewriter, so `doctor heal`
+// runs the same fixer as `doctor heal wikilinks`. The `fix` alias makes
+// `doctor fix` resolve here. heal APPLIES by default; --dry-run previews.
+var doctorHealCmd = func() *cobra.Command {
+	c := MustNewCommand(commands.DoctorHealMetadata, runDoctorHeal)
+	c.Aliases = []string{"fix"}
+	return c
+}()
+
+func init() {
+	doctorCmd.AddCommand(doctorHealCmd)
+	setupCommandConfig(doctorHealCmd)
+}
+
+// runDoctorHeal resolves heal's flags and applies every auto-fixable repair.
+// Today the auto-fixable set is exactly the wikilink fixer, so it routes
+// through the shared runWikilinkFix engine with the "apply"/"dry-run" labels.
+func runDoctorHeal(cmd *cobra.Command, _ []string) error {
+	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppDoctorhealVault)
+	jsonOut := getConfigValueWithFlags[bool](cmd, "json", config.KeyAppDoctorhealJson)
+	dryRun := getConfigValueWithFlags[bool](cmd, "dry-run", config.KeyAppDoctorhealDryRun)
+	return runWikilinkFix(cmd, vaultPath, jsonOut, !dryRun, healModeLabel(!dryRun), "doctor heal")
+}
+
+// healModeLabel maps the apply flag to heal's human-output mode label. heal
+// speaks "apply" (it applies by default), distinct from the deprecated
+// fix-links which speaks "fix" — both share the same engine, only the label
+// differs.
+func healModeLabel(apply bool) string {
+	if apply {
+		return "apply"
+	}
+	return "dry-run"
+}
+
+// runWikilinkFix is the single cmd-layer engine behind every wikilink repair:
+// `doctor heal`, `doctor heal wikilinks`, and the deprecated `lint fix-links`
+// alias. It opens the vault, calls the shared internal/mutation fixer
+// (FixWikilinks — the SAME engine the old lint fix-links used), and renders
+// either the JSON envelope or the human report. `apply` decides whether the
+// fixer writes; `modeLabel` is the human-output verb (apply / fix / dry-run);
+// `cmdName` names the operation in error and envelope text.
+func runWikilinkFix(cmd *cobra.Command, vaultPath string, jsonOut, apply bool, modeLabel, cmdName string) error {
+	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, cmdName)
+	if err != nil {
+		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
+			return nil
+		}
+		return err
+	}
+	defer vdb.Close()
+
+	result, err := mutation.FixWikilinks(vdb.DB, vaultPath, apply)
+	if err != nil {
+		return fmt.Errorf("%s: %w", cmdName, err)
+	}
+
+	if jsonOut {
+		env := envelope.OK(cmdName, result)
+		env.Meta.VaultPath = vaultPath
+		env.Meta.IndexHash = vdb.GetIndexHash()
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
+	}
+
+	w := cmd.OutOrStdout()
+	if _, err = fmt.Fprintf(w, "Mode: %s\nFiles scanned: %d\nFiles changed: %d\nLinks fixed: %d\n",
+		modeLabel, result.FilesScanned, result.FilesChanged, result.LinksFixed); err != nil {
+		return err
+	}
+	for _, d := range result.Details {
+		if _, err = fmt.Fprintf(w, "  %s: %s → %s\n", d.Path, d.OldLink, d.NewLink); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/doctor_heal_test.go
+++ b/cmd/doctor_heal_test.go
@@ -1,0 +1,307 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/index"
+	"github.com/peiman/vaultmind/internal/vault"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildHealableVault creates a tempdir vault containing a note with a bare
+// [[Alpha Concept]] wikilink whose title resolves to a differently-named file
+// (alpha.md). FixWikilinks rewrites that to [[alpha|Alpha Concept]], so this
+// fixture exercises the actual repair path (unlike buildIndexedTestVault, whose
+// links are already in filename form or carry a display alias). Returns the
+// vault root and the relative path of the note that holds the fixable link.
+func buildHealableVault(t *testing.T) (vaultDir, linkNote string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".vaultmind"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".vaultmind", "config.yaml"), []byte(`
+types:
+  concept:
+    required: [title]
+    optional: [tags, related_ids]
+`), 0o644))
+
+	writeTestNote(t, dir, "concepts/alpha.md", `---
+id: concept-alpha
+type: concept
+title: Alpha Concept
+---
+Alpha body, the link target.
+`)
+	// The fixable link: bare [[Alpha Concept]] (title), file is alpha.md →
+	// FixWikilinks rewrites to [[alpha|Alpha Concept]].
+	writeTestNote(t, dir, "concepts/gamma.md", `---
+id: concept-gamma
+type: concept
+title: Gamma Concept
+---
+Gamma references [[Alpha Concept]] by title.
+`)
+
+	cfg, err := vault.LoadConfig(dir)
+	require.NoError(t, err)
+	dbPath := filepath.Join(dir, cfg.Index.DBPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	idxr := index.NewIndexer(dir, dbPath, cfg)
+	_, err = idxr.Rebuild()
+	require.NoError(t, err, "indexer rebuild failed")
+
+	return dir, "concepts/gamma.md"
+}
+
+// doctor heal applies ALL auto-fixable repairs doctor found. Today that set is
+// exactly the wikilink fixer, so `doctor heal` rewrites the title-form wikilink
+// on disk by default (no flag needed). This is the key semantic flip from the
+// old `lint fix-links`, which was dry-run by default.
+func TestDoctorHeal_AppliesByDefault(t *testing.T) {
+	vault, note := buildHealableVault(t)
+	notePath := filepath.Join(vault, note)
+
+	before, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(before), "[[Alpha Concept]]",
+		"precondition: note must contain the title-form (fixable) wikilink")
+
+	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault, "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			FilesChanged int `json:"files_changed"`
+			LinksFixed   int `json:"links_fixed"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Greater(t, env.Result.LinksFixed, 0, "heal applies by default, so links must be fixed")
+
+	after, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(after), "[[alpha|Alpha Concept]]",
+		"heal must rewrite the title-form link to filename|title form on disk by default")
+}
+
+// doctor heal --dry-run previews without touching disk. This is the inverse of
+// the apply-by-default behavior and what the old fix-links did without --fix.
+func TestDoctorHeal_DryRunPreviewsNoDiskChange(t *testing.T) {
+	vault, note := buildHealableVault(t)
+	notePath := filepath.Join(vault, note)
+
+	before, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+
+	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault, "--dry-run", "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			LinksFixed int `json:"links_fixed"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Greater(t, env.Result.LinksFixed, 0,
+		"--dry-run still reports the planned fix")
+
+	after, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"--dry-run must NOT change the file on disk even though it reports the planned fix")
+}
+
+// doctor heal human output reports the mode so operators see whether the action
+// was applied. Default (no flag) is "apply".
+func TestDoctorHeal_HumanOutputShowsApplyMode(t *testing.T) {
+	vault, _ := buildHealableVault(t)
+	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault)
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Mode: apply",
+		"heal applies by default; the mode line must say apply")
+}
+
+// doctor heal --dry-run flips the mode label to dry-run.
+func TestDoctorHeal_DryRunModeLabel(t *testing.T) {
+	vault, _ := buildHealableVault(t)
+	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault, "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Mode: dry-run")
+}
+
+// doctor heal wikilinks is the surgical wikilink repair (the moved
+// `lint fix-links` logic). It applies by default and shares the same fixer
+// engine, so it also rewrites the title-form link on disk.
+func TestDoctorHealWikilinks_AppliesByDefault(t *testing.T) {
+	vault, note := buildHealableVault(t)
+	notePath := filepath.Join(vault, note)
+
+	out, _, err := runRootCmd(t, "doctor", "heal", "wikilinks", "--vault", vault, "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			LinksFixed int `json:"links_fixed"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Greater(t, env.Result.LinksFixed, 0)
+
+	after, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(after), "[[alpha|Alpha Concept]]")
+}
+
+// doctor heal wikilinks --dry-run previews only.
+func TestDoctorHealWikilinks_DryRunPreviews(t *testing.T) {
+	vault, note := buildHealableVault(t)
+	notePath := filepath.Join(vault, note)
+
+	before, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+
+	out, _, err := runRootCmd(t, "doctor", "heal", "wikilinks", "--vault", vault, "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Mode: dry-run")
+
+	after, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after))
+}
+
+// doctor fix is the cobra alias for doctor heal: it must apply by default too.
+func TestDoctorFix_AliasOfHeal(t *testing.T) {
+	vault, note := buildHealableVault(t)
+	notePath := filepath.Join(vault, note)
+
+	_, _, err := runRootCmd(t, "doctor", "fix", "--vault", vault)
+	require.NoError(t, err)
+
+	after, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(after), "[[alpha|Alpha Concept]]",
+		"doctor fix is an alias of doctor heal and must apply by default")
+}
+
+// doctor fix wikilinks must also resolve via the alias and apply.
+func TestDoctorFixWikilinks_AliasResolves(t *testing.T) {
+	vault, _ := buildHealableVault(t)
+	out, _, err := runRootCmd(t, "doctor", "fix", "wikilinks", "--vault", vault, "--json")
+	require.NoError(t, err)
+	var env struct {
+		Result struct {
+			LinksFixed int `json:"links_fixed"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Greater(t, env.Result.LinksFixed, 0)
+}
+
+// The doctor heal help surface must read "heal (fix)" so the alias is
+// discoverable from the help text, per the locked taxonomy.
+func TestDoctorHeal_HelpReadsHealFix(t *testing.T) {
+	out, _, err := runRootCmd(t, "doctor", "heal", "--help")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "heal (fix)",
+		"help should read 'heal (fix)' so the alias is visible")
+}
+
+// ---- Top-level lint removal + deprecation aliases. ----
+
+// The top-level `lint` parent must no longer appear in the visible root
+// listing: linting/fixing moved under `doctor heal`. It survives as a hidden
+// parent so the deprecated `lint fix-links` alias still resolves.
+func TestTopLevelLint_HiddenFromRootListing(t *testing.T) {
+	for _, c := range RootCmd.Commands() {
+		if c.Name() == "lint" {
+			assert.True(t, c.Hidden, "top-level 'lint' must be hidden from the root listing")
+			return
+		}
+	}
+}
+
+// The agent root-help cheat-sheet must no longer advertise `lint` as an
+// infrastructure command — it was removed from the top level.
+func TestRootHelp_DropsLintFromInfrastructureList(t *testing.T) {
+	out, _, err := runRootCmd(t, "--help")
+	require.NoError(t, err)
+	assert.NotContains(t, out.String(), "lint,",
+		"root help must not list the removed top-level lint command")
+}
+
+// lint fix-links is a hidden deprecated alias of `doctor heal wikilinks`: it
+// prints a one-line stderr notice and still delegates to the shared fixer.
+// Because the OLD command was dry-run-by-default (--fix to apply), the alias
+// preserves THAT contract: no --fix means preview, so disk is untouched.
+func TestDeprecated_LintFixLinks_WarnsAndPreviewsByDefault(t *testing.T) {
+	vault, note := buildHealableVault(t)
+	notePath := filepath.Join(vault, note)
+	before, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+
+	out, errOut, err := runRootCmd(t, "lint", "fix-links", "--vault", vault, "--json")
+	require.NoError(t, err)
+	assertOneLineDeprecation(t, errOut.String(), "doctor heal wikilinks")
+
+	// Delegated output is still a real fix-links envelope.
+	var env struct {
+		Result struct {
+			FilesScanned int `json:"files_scanned"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Greater(t, env.Result.FilesScanned, 0)
+
+	// Old contract: no --fix means dry-run, so disk is untouched.
+	after, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"deprecated lint fix-links keeps its dry-run-by-default contract")
+}
+
+// lint fix-links --fix still applies (old contract preserved), delegating to
+// the shared fixer engine and emitting the deprecation notice.
+func TestDeprecated_LintFixLinks_FixApplies(t *testing.T) {
+	vault, note := buildHealableVault(t)
+	notePath := filepath.Join(vault, note)
+
+	_, errOut, err := runRootCmd(t, "lint", "fix-links", "--vault", vault, "--fix")
+	require.NoError(t, err)
+	assertOneLineDeprecation(t, errOut.String(), "doctor heal wikilinks")
+
+	after, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(after), "[[alpha|Alpha Concept]]",
+		"lint fix-links --fix must still apply via the shared engine")
+}
+
+// The deprecation notice for lint fix-links must be exactly one line.
+func TestDeprecated_LintFixLinks_NoticeIsSingleLine(t *testing.T) {
+	vault, _ := buildHealableVault(t)
+	_, errOut, err := runRootCmd(t, "lint", "fix-links", "--vault", vault)
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimRight(errOut.String(), "\n"), "\n")
+	require.Len(t, lines, 1, "deprecation notice must be exactly one line: %q", errOut.String())
+	assert.Contains(t, lines[0], "deprecated")
+}
+
+// dataview lint is a SEPARATE domain checker and must remain untouched by the
+// top-level lint removal — it still runs and reports its files-checked count.
+func TestDataviewLint_SurvivesLintRemoval(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "dataview", "lint", "--vault", vault, "--json")
+	require.NoError(t, err)
+	var env struct {
+		Result struct {
+			FilesChecked int `json:"files_checked"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Greater(t, env.Result.FilesChecked, 0)
+}

--- a/cmd/doctor_heal_test.go
+++ b/cmd/doctor_heal_test.go
@@ -135,6 +135,74 @@ func TestDoctorHeal_DryRunModeLabel(t *testing.T) {
 	assert.Contains(t, out.String(), "Mode: dry-run")
 }
 
+// After a successful apply that rewrote files, heal must warn that the index
+// is now stale so the operator knows to re-index (M2). Human output names the
+// remedy; this asserts the human path.
+func TestDoctorHeal_WarnsIndexStaleAfterApply(t *testing.T) {
+	vault, _ := buildHealableVault(t)
+	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault)
+	require.NoError(t, err)
+	text := out.String()
+	assert.Contains(t, text, "Index is now stale",
+		"applying a heal that rewrote files must warn the index is stale")
+	assert.Contains(t, text, "vaultmind index --vault",
+		"the stale-index warning must name the re-index remedy")
+}
+
+// The stale-index warning also appears in the JSON envelope after an apply that
+// changed files, via a dedicated field with a remedy string (M2).
+func TestDoctorHeal_JSONReportsStaleIndexAfterApply(t *testing.T) {
+	vault, _ := buildHealableVault(t)
+	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault, "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			FilesChanged        int    `json:"files_changed"`
+			StaleIndexAfterHeal bool   `json:"stale_index_after_heal"`
+			StaleIndexRemedy    string `json:"stale_index_remedy"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	require.Greater(t, env.Result.FilesChanged, 0, "precondition: the apply rewrote files")
+	assert.True(t, env.Result.StaleIndexAfterHeal,
+		"JSON must flag the stale index after an apply that changed files")
+	assert.Contains(t, env.Result.StaleIndexRemedy, "vaultmind index --vault",
+		"JSON remedy must name the re-index command")
+}
+
+// --dry-run must NOT warn about a stale index: nothing was written, so the
+// index is not stale (M2).
+func TestDoctorHeal_DryRunDoesNotWarnStaleIndex(t *testing.T) {
+	vault, _ := buildHealableVault(t)
+	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault, "--dry-run")
+	require.NoError(t, err)
+	assert.NotContains(t, out.String(), "Index is now stale",
+		"--dry-run changed nothing on disk, so it must not warn about a stale index")
+}
+
+// A heal that changed zero files (already-clean vault) must NOT warn about a
+// stale index (M2).
+func TestDoctorHeal_NoWarnWhenZeroChanges(t *testing.T) {
+	// buildIndexedTestVault's links are already filename/alias form, so heal
+	// finds nothing to fix → zero files changed.
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault, "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			FilesChanged        int  `json:"files_changed"`
+			StaleIndexAfterHeal bool `json:"stale_index_after_heal"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	require.Equal(t, 0, env.Result.FilesChanged, "precondition: nothing to fix")
+	assert.False(t, env.Result.StaleIndexAfterHeal,
+		"zero files changed must not flag a stale index")
+	assert.NotContains(t, out.String(), "Index is now stale")
+}
+
 // doctor heal wikilinks is the surgical wikilink repair (the moved
 // `lint fix-links` logic). It applies by default and shares the same fixer
 // engine, so it also rewrites the title-form link on disk.

--- a/cmd/doctor_heal_wikilinks.go
+++ b/cmd/doctor_heal_wikilinks.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/spf13/cobra"
+)
+
+// doctorHealWikilinksCmd is the surgical wikilink repair — the moved logic of
+// the old `lint fix-links`. It applies by default; --dry-run previews. The
+// `fix` alias makes `doctor fix wikilinks` resolve here. It shares the
+// runWikilinkFix engine (internal/mutation.FixWikilinks) with `doctor heal`.
+var doctorHealWikilinksCmd = func() *cobra.Command {
+	c := MustNewCommand(commands.DoctorHealWikilinksMetadata, runDoctorHealWikilinks)
+	c.Aliases = []string{"fix"}
+	return c
+}()
+
+func init() {
+	doctorHealCmd.AddCommand(doctorHealWikilinksCmd)
+	setupCommandConfig(doctorHealWikilinksCmd)
+}
+
+// runDoctorHealWikilinks resolves the wikilinks flags and applies (or, under
+// --dry-run, previews) the Obsidian-incompatible wikilink rewrite via the
+// shared runWikilinkFix engine.
+func runDoctorHealWikilinks(cmd *cobra.Command, _ []string) error {
+	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppDoctorhealwikilinksVault)
+	jsonOut := getConfigValueWithFlags[bool](cmd, "json", config.KeyAppDoctorhealwikilinksJson)
+	dryRun := getConfigValueWithFlags[bool](cmd, "dry-run", config.KeyAppDoctorhealwikilinksDryRun)
+	return runWikilinkFix(cmd, vaultPath, jsonOut, !dryRun, healModeLabel(!dryRun), "doctor heal wikilinks")
+}

--- a/cmd/doctor_summary_test.go
+++ b/cmd/doctor_summary_test.go
@@ -57,14 +57,21 @@ func TestDoctor_JSONIncludesIssuesSummary(t *testing.T) {
 }
 
 // doctor human output (no --summary) prints the per-type breakdown so the
-// terminal user sees the type registry, not just the totals.
+// terminal user sees the type registry, not just the totals. Assert the
+// breakdown's DISTINCTIVE "name: N note(s)" format (what writeTypeBreakdown
+// emits) — a bare Contains("concept") also matches the incompatible-link
+// detail lines, so it wouldn't actually prove the breakdown rendered.
 func TestDoctor_HumanOutputShowsPerTypeBreakdown(t *testing.T) {
 	vault := buildIndexedTestVault(t)
 	out, _, err := runRootCmd(t, "doctor", "--vault", vault)
 	require.NoError(t, err)
 	text := out.String()
-	assert.Contains(t, text, "concept", "per-type breakdown must name the concept type")
-	assert.Contains(t, text, "project", "per-type breakdown must name the project type")
+	// project carries statuses; concept does not — match the real rendered
+	// lines (the fixture has 2 concepts, 1 project).
+	assert.Contains(t, text, "concept: 2 note(s)",
+		"per-type breakdown must render the concept count in its distinctive format")
+	assert.Contains(t, text, "project: 1 note(s)",
+		"per-type breakdown must render the project count in its distinctive format")
 }
 
 // doctor --summary is the cold-start view: totals + per-type breakdown +

--- a/cmd/doctor_summary_test.go
+++ b/cmd/doctor_summary_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// doctor (read-only diagnosis) now GAINS the per-type breakdown that
+// `vault status` used to produce: per-type note counts plus the required
+// fields and valid statuses for each type. The breakdown must appear in the
+// JSON envelope regardless of --summary.
+func TestDoctor_JSONIncludesPerTypeBreakdown(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "--vault", vault, "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			Types map[string]struct {
+				Count    int      `json:"count"`
+				Required []string `json:"required"`
+				Statuses []string `json:"statuses"`
+			} `json:"types"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	require.Contains(t, env.Result.Types, "concept")
+	require.Contains(t, env.Result.Types, "project")
+	assert.Equal(t, 2, env.Result.Types["concept"].Count, "two concept notes in the test vault")
+	assert.Equal(t, 1, env.Result.Types["project"].Count, "one project note in the test vault")
+	assert.Contains(t, env.Result.Types["concept"].Required, "title")
+	assert.Contains(t, env.Result.Types["project"].Statuses, "active",
+		"valid statuses must carry through from the registry")
+}
+
+// doctor JSON also carries the errors/warnings rollup that the cold-start
+// view needs. The clean test vault has zero errors.
+func TestDoctor_JSONIncludesIssuesSummary(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "--vault", vault, "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			IssuesSummary struct {
+				Errors   int `json:"errors"`
+				Warnings int `json:"warnings"`
+			} `json:"issues_summary"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Equal(t, 0, env.Result.IssuesSummary.Errors, "clean vault has no errors")
+}
+
+// doctor human output (no --summary) prints the per-type breakdown so the
+// terminal user sees the type registry, not just the totals.
+func TestDoctor_HumanOutputShowsPerTypeBreakdown(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "--vault", vault)
+	require.NoError(t, err)
+	text := out.String()
+	assert.Contains(t, text, "concept", "per-type breakdown must name the concept type")
+	assert.Contains(t, text, "project", "per-type breakdown must name the project type")
+}
+
+// doctor --summary is the cold-start view: totals + per-type breakdown +
+// the errors/warnings rollup, and it still suppresses the noisy per-link
+// detail lines (that's what --summary always did).
+func TestDoctorSummary_ColdStartView(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "--summary", "--vault", vault)
+	require.NoError(t, err)
+	text := out.String()
+	assert.Contains(t, text, "Vault: ", "cold-start view shows the vault path")
+	assert.Contains(t, text, "Notes: ", "cold-start view shows note counts")
+	assert.Contains(t, text, "concept", "cold-start view shows the per-type breakdown")
+	assert.Contains(t, text, "Issues:", "cold-start view shows the errors/warnings rollup")
+	// --summary keeps suppressing the verbose per-link enumeration.
+	assert.NotContains(t, text, "→ [[",
+		"--summary must not print per-link incompatible-link detail lines")
+}
+
+// The deprecated `vault status` is a hidden alias that prints a one-line
+// stderr deprecation notice mentioning `doctor --summary`, then delegates to
+// the doctor summary path — producing the same cold-start view on stdout.
+func TestDeprecated_VaultStatus_WarnsAndDelegatesToDoctorSummary(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, errOut, err := runRootCmd(t, "vault", "status", "--vault", vault)
+	require.NoError(t, err)
+	text := out.String()
+	assert.Contains(t, text, "Vault: ", "delegated cold-start view must reach stdout")
+	assert.Contains(t, text, "concept", "delegated view must carry the per-type breakdown")
+	assert.Contains(t, text, "Issues:", "delegated view must carry the errors/warnings rollup")
+	assertOneLineDeprecation(t, errOut.String(), "doctor --summary")
+}
+
+// The deprecated `vault status --json` must still emit a machine-readable
+// envelope (delegating to doctor's JSON path) alongside the stderr notice.
+func TestDeprecated_VaultStatus_JSONDelegates(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, errOut, err := runRootCmd(t, "vault", "status", "--vault", vault, "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Status string `json:"status"`
+		Result struct {
+			Types map[string]json.RawMessage `json:"types"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Equal(t, "ok", env.Status)
+	assert.Contains(t, env.Result.Types, "concept",
+		"delegated JSON must carry the per-type breakdown")
+	assertOneLineDeprecation(t, errOut.String(), "doctor --summary")
+}
+
+// The `vault` parent dissolves: it only ever hosted `status`, so it is now
+// hidden from the root listing (its single subcommand survives as the
+// deprecated alias).
+func TestVaultParent_HiddenFromRootListing(t *testing.T) {
+	for _, c := range RootCmd.Commands() {
+		if c.Name() == "vault" {
+			assert.True(t, c.Hidden, "the 'vault' parent must be hidden from the root listing")
+			return
+		}
+	}
+	t.Fatal("vault parent command not found")
+}
+
+// The deprecation notice for vault status must be exactly one line and must
+// mention the new path. (Shared assert lives in memory_taxonomy_test.go;
+// this guards the contract locally too.)
+func TestVaultStatus_DeprecationNoticeIsSingleLine(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	_, errOut, err := runRootCmd(t, "vault", "status", "--vault", vault)
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimRight(errOut.String(), "\n"), "\n")
+	require.Len(t, lines, 1, "deprecation notice must be exactly one line: %q", errOut.String())
+	assert.Contains(t, lines[0], "deprecated")
+}

--- a/cmd/help_template.go
+++ b/cmd/help_template.go
@@ -121,7 +121,7 @@ PAIRS WELL TOGETHER
 INFRASTRUCTURE COMMANDS (you usually won't reach for these directly)
 ──────────────────────────────────────────────────────────────────────────────
 
-  Indexing & maintenance:  index, apply, frontmatter, lint, schema
+  Indexing & maintenance:  index, apply, frontmatter, schema
   Internals:               memory (low-level primitives behind ask), resolve,
                            dataview, episode, experiment
   Setup:                   config, completion, docs, version

--- a/cmd/help_template.go
+++ b/cmd/help_template.go
@@ -121,7 +121,7 @@ PAIRS WELL TOGETHER
 INFRASTRUCTURE COMMANDS (you usually won't reach for these directly)
 ──────────────────────────────────────────────────────────────────────────────
 
-  Indexing & maintenance:  index, apply, frontmatter, lint, links, schema, vault
+  Indexing & maintenance:  index, apply, frontmatter, lint, schema, vault
   Internals:               memory (low-level primitives behind ask), resolve,
                            dataview, episode, experiment
   Setup:                   config, completion, docs, version

--- a/cmd/help_template.go
+++ b/cmd/help_template.go
@@ -121,7 +121,7 @@ PAIRS WELL TOGETHER
 INFRASTRUCTURE COMMANDS (you usually won't reach for these directly)
 ──────────────────────────────────────────────────────────────────────────────
 
-  Indexing & maintenance:  index, apply, frontmatter, lint, schema, vault
+  Indexing & maintenance:  index, apply, frontmatter, lint, schema
   Internals:               memory (low-level primitives behind ask), resolve,
                            dataview, episode, experiment
   Setup:                   config, completion, docs, version

--- a/cmd/links.go
+++ b/cmd/links.go
@@ -2,48 +2,14 @@ package cmd
 
 import "github.com/spf13/cobra"
 
+// linksCmd is the DEPRECATED top-level `links` parent. Graph traversal moved
+// under `memory` (memory links / memory neighbors). The parent is hidden from
+// the root listing; its subcommands remain as hidden deprecated aliases that
+// delegate to the new `memory` paths. Kept for ~2 releases.
 var linksCmd = &cobra.Command{
-	Use:   "links",
-	Short: "Trace note graph edges for context discovery",
-	Long: `Explore the vault's note graph by querying directed link relationships.
-
-Link operations let you follow edges between notes: find what a note
-references (out), find what references it (in), or explore its full
-local neighborhood (neighbors). Together these support associative
-context-packing — surfacing related notes without a keyword search.
-
-SUBCOMMANDS
-
-  out <id-or-path>
-      Return all outbound edges from a note: the notes it links to,
-      with edge type and confidence. Use when you have a note and want
-      to know what concepts it depends on or cites.
-
-  in <id-or-path>
-      Return all inbound edges pointing to a note: the notes that
-      reference it. Use when you want to find all callers, dependents,
-      or consumers of a concept.
-
-  neighbors <id-or-path>
-      Breadth-first traversal from a note up to a configurable depth.
-      Returns every reachable node with distance and edge metadata.
-      Use when you want the full local cluster around a topic, not
-      just one direction of edges.
-
-WHEN TO USE
-
-  You know a note id and want its direct dependencies  ->  links out
-  You want to know who references a concept            ->  links in
-  You want the full local graph neighborhood           ->  links neighbors
-  You want to search by content, not by graph position ->  search or ask
-
-EXAMPLES
-
-  vaultmind links out concept-spreading-activation --vault ./vault   # outbound edges from one note
-  vaultmind links in  concept-spreading-activation --vault ./vault   # inbound edges to one note
-  vaultmind links out concept-spreading-activation --json            # machine-readable output
-  vaultmind links neighbors concept-hebbian --depth 2 --max-nodes 50 # 2-hop neighborhood
-  vaultmind links neighbors concept-hebbian --min-confidence medium  # filter weak edges`,
+	Use:    "links",
+	Short:  "Deprecated: use 'memory links' / 'memory neighbors'",
+	Hidden: true,
 }
 
 func init() {

--- a/cmd/links_in.go
+++ b/cmd/links_in.go
@@ -1,41 +1,19 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
-
-	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
-	"github.com/peiman/vaultmind/internal/cmdutil"
 	"github.com/peiman/vaultmind/internal/config/commands"
-	"github.com/peiman/vaultmind/internal/query"
 	"github.com/spf13/cobra"
 )
 
-var linksInCmd = MustNewCommand(commands.LinksInMetadata, runLinksIn)
+// links in is DEPRECATED: use `memory links --in`. This hidden alias prints a
+// one-line notice and delegates to runLinksDirection with direction "in".
+var linksInCmd = newDeprecatedAlias(commands.LinksInMetadata,
+	"vaultmind: 'links in' is deprecated; use 'memory links --in' instead",
+	func(cmd *cobra.Command, args []string) error {
+		return runLinksDirection(cmd, args, "in")
+	})
 
 func init() {
 	linksCmd.AddCommand(linksInCmd)
 	setupCommandConfig(linksInCmd)
-}
-
-func runLinksIn(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("usage: vaultmind links in <id-or-path>")
-	}
-	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppLinksVault)
-	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "links in")
-	if err != nil {
-		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
-			return nil
-		}
-		return err
-	}
-	defer vdb.Close()
-
-	return query.RunLinks(vdb.DB, query.LinksConfig{
-		Input: args[0], Direction: "in", VaultPath: vaultPath,
-		EdgeType:   getConfigValueWithFlags[string](cmd, "edge-type", config.KeyAppLinksEdgeType),
-		JSONOutput: getConfigValueWithFlags[bool](cmd, "json", config.KeyAppLinksJson),
-		IndexHash:  vdb.GetIndexHash(),
-	}, cmd.OutOrStdout())
 }

--- a/cmd/links_neighbors.go
+++ b/cmd/links_neighbors.go
@@ -1,15 +1,32 @@
 package cmd
 
 import (
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
 	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/spf13/cobra"
 )
+
+// linksNeighborsKeys preserves the OLD `links neighbors` defaults (depth 1,
+// min-confidence low, max-nodes 200) when the merged `memory neighbors` engine
+// runs. The canonical `memory neighbors` defaults are high/50 — narrowing the
+// alias to those would be a silent back-compat break, so the alias keeps
+// reading its own linksneighbors.* keys (M1).
+var linksNeighborsKeys = neighborsKeys{
+	depthKey:         config.KeyAppLinksneighborsDepth,
+	minConfidenceKey: config.KeyAppLinksneighborsMinConfidence,
+	maxNodesKey:      config.KeyAppLinksneighborsMaxNodes,
+}
 
 // links neighbors is DEPRECATED: merged into `memory neighbors` (BFS traversal
 // with full frontmatter). This hidden alias prints a one-line notice and
-// delegates to runMemoryNeighbors. Kept for ~2 releases.
+// delegates to the shared neighbors engine — but with the alias's OWN default
+// keys so an unchanged `links neighbors <id>` still uses low/200, not the
+// canonical high/50.
 var linksNeighborsCmd = newDeprecatedAlias(commands.LinksNeighborsMetadata,
 	"vaultmind: 'links neighbors' is deprecated; use 'memory neighbors' instead",
-	runMemoryNeighbors)
+	func(cmd *cobra.Command, args []string) error {
+		return runNeighborsWithKeys(cmd, args, linksNeighborsKeys)
+	})
 
 func init() {
 	linksCmd.AddCommand(linksNeighborsCmd)

--- a/cmd/links_neighbors.go
+++ b/cmd/links_neighbors.go
@@ -1,78 +1,17 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-
-	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
-	"github.com/peiman/vaultmind/internal/cmdutil"
 	"github.com/peiman/vaultmind/internal/config/commands"
-	"github.com/peiman/vaultmind/internal/envelope"
-	"github.com/peiman/vaultmind/internal/graph"
-	"github.com/peiman/vaultmind/internal/query"
-	"github.com/spf13/cobra"
 )
 
-var linksNeighborsCmd = MustNewCommand(commands.LinksNeighborsMetadata, runLinksNeighbors)
+// links neighbors is DEPRECATED: merged into `memory neighbors` (BFS traversal
+// with full frontmatter). This hidden alias prints a one-line notice and
+// delegates to runMemoryNeighbors. Kept for ~2 releases.
+var linksNeighborsCmd = newDeprecatedAlias(commands.LinksNeighborsMetadata,
+	"vaultmind: 'links neighbors' is deprecated; use 'memory neighbors' instead",
+	runMemoryNeighbors)
 
 func init() {
 	linksCmd.AddCommand(linksNeighborsCmd)
 	setupCommandConfig(linksNeighborsCmd)
-}
-
-func runLinksNeighbors(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("usage: links neighbors <id-or-path>")
-	}
-	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppLinksneighborsVault)
-	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "links neighbors")
-	if err != nil {
-		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
-			return nil
-		}
-		return err
-	}
-	defer vdb.Close()
-
-	resolver := graph.NewResolver(vdb.DB)
-	depth := getConfigValueWithFlags[int](cmd, "depth", config.KeyAppLinksneighborsDepth)
-	minConf := getConfigValueWithFlags[string](cmd, "min-confidence", config.KeyAppLinksneighborsMinConfidence)
-	maxNodes := getConfigValueWithFlags[int](cmd, "max-nodes", config.KeyAppLinksneighborsMaxNodes)
-
-	result, err := query.Neighbors(resolver, args[0], depth, minConf, maxNodes)
-	if err != nil {
-		return fmt.Errorf("neighbors: %w", err)
-	}
-
-	if getConfigValueWithFlags[bool](cmd, "json", config.KeyAppLinksneighborsJson) {
-		env := envelope.OK("links neighbors", result)
-		env.Meta.VaultPath = vaultPath
-		env.Meta.IndexHash = vdb.GetIndexHash()
-		return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
-	}
-
-	return formatNeighbors(result, cmd.OutOrStdout())
-}
-
-func formatNeighbors(result *query.NeighborsResult, w io.Writer) error {
-	for _, n := range result.Nodes {
-		if n.Distance == 0 {
-			if _, err := fmt.Fprintf(w, "%s (depth 0)\n", n.ID); err != nil {
-				return err
-			}
-		} else if n.EdgeFrom != nil {
-			if _, err := fmt.Fprintf(w, "  → %s (%s, %s) depth %d\n",
-				n.ID, n.EdgeFrom.EdgeType, n.EdgeFrom.Confidence, n.Distance); err != nil {
-				return err
-			}
-		}
-	}
-	suffix := ""
-	if result.MaxNodesReached {
-		suffix = " (max reached)"
-	}
-	_, err := fmt.Fprintf(w, "%d nodes%s\n", len(result.Nodes), suffix)
-	return err
 }

--- a/cmd/links_out.go
+++ b/cmd/links_out.go
@@ -1,41 +1,19 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
-
-	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
-	"github.com/peiman/vaultmind/internal/cmdutil"
 	"github.com/peiman/vaultmind/internal/config/commands"
-	"github.com/peiman/vaultmind/internal/query"
 	"github.com/spf13/cobra"
 )
 
-var linksOutCmd = MustNewCommand(commands.LinksOutMetadata, runLinksOut)
+// links out is DEPRECATED: use `memory links --out`. This hidden alias prints
+// a one-line notice and delegates to runLinksDirection with direction "out".
+var linksOutCmd = newDeprecatedAlias(commands.LinksOutMetadata,
+	"vaultmind: 'links out' is deprecated; use 'memory links --out' instead",
+	func(cmd *cobra.Command, args []string) error {
+		return runLinksDirection(cmd, args, "out")
+	})
 
 func init() {
 	linksCmd.AddCommand(linksOutCmd)
 	setupCommandConfig(linksOutCmd)
-}
-
-func runLinksOut(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("usage: vaultmind links out <id-or-path>")
-	}
-	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppLinksVault)
-	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "links out")
-	if err != nil {
-		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
-			return nil
-		}
-		return err
-	}
-	defer vdb.Close()
-
-	return query.RunLinks(vdb.DB, query.LinksConfig{
-		Input: args[0], Direction: "out", VaultPath: vaultPath,
-		EdgeType:   getConfigValueWithFlags[string](cmd, "edge-type", config.KeyAppLinksEdgeType),
-		JSONOutput: getConfigValueWithFlags[bool](cmd, "json", config.KeyAppLinksJson),
-		IndexHash:  vdb.GetIndexHash(),
-	}, cmd.OutOrStdout())
 }

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -2,35 +2,16 @@ package cmd
 
 import "github.com/spf13/cobra"
 
+// lintCmd is the DEPRECATED top-level `lint` parent. Wikilink repair moved
+// under the doctor health hub (`doctor heal wikilinks`); `dataview lint` is a
+// separate domain checker and is unaffected. The parent is hidden from the
+// root listing; its `fix-links` subcommand survives as a hidden deprecated
+// alias that delegates to the new `doctor heal wikilinks` path. Kept for ~2
+// releases.
 var lintCmd = &cobra.Command{
-	Use:   "lint",
-	Short: "Check and fix vault structure (wikilinks, dataview syntax)",
-	Long: `Lint commands detect and fix structural issues in vault content.
-
-Use lint after bulk imports, migrations, or when Obsidian reports broken links.
-Lint is structural (syntax, file naming) — not semantic (content accuracy).
-
-AVAILABLE SUBCOMMANDS
-
-  fix-links
-      Rewrite [[Title]] wikilinks that will not resolve in Obsidian to the
-      [[filename|Title]] format that Obsidian requires. Scans every markdown
-      file in the vault, reports each rewrite as "old -> new", and prints a
-      summary of files scanned, files changed, and links fixed.
-      Default mode is dry-run (preview only); pass --fix to apply changes.
-
-WHEN TO USE
-
-  - Obsidian reports unresolved links after an import or bulk rename
-  - You migrated notes from another tool and wikilinks use display titles
-    rather than filenames
-  - You want to preview what would change before committing rewrites
-
-EXAMPLES
-
-  vaultmind lint fix-links --vault ./my-vault          # preview broken wikilinks (dry-run)
-  vaultmind lint fix-links --vault ./my-vault --fix    # apply the rewrites
-  vaultmind lint fix-links --json                      # machine-readable output`,
+	Use:    "lint",
+	Short:  "Deprecated: use 'doctor heal wikilinks'",
+	Hidden: true,
 }
 
 func init() {

--- a/cmd/lint_fix_links.go
+++ b/cmd/lint_fix_links.go
@@ -1,64 +1,43 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
-	"github.com/peiman/vaultmind/internal/cmdutil"
 	"github.com/peiman/vaultmind/internal/config/commands"
-	"github.com/peiman/vaultmind/internal/envelope"
-	"github.com/peiman/vaultmind/internal/mutation"
 	"github.com/spf13/cobra"
 )
 
-var lintFixLinksCmd = MustNewCommand(commands.LintFixLinksMetadata, runLintFixLinks)
+// lint fix-links is DEPRECATED: the wikilink repair moved to the doctor health
+// hub as `doctor heal wikilinks`. This hidden alias prints a one-line stderr
+// notice and delegates to the SAME shared fixer engine (runWikilinkFix →
+// internal/mutation.FixWikilinks). It preserves the OLD contract — dry-run by
+// default, --fix to apply, and the "Mode: fix"/"Mode: dry-run" labels — so
+// existing scripts keep working. Kept for ~2 releases.
+var lintFixLinksCmd = newDeprecatedAlias(commands.LintFixLinksMetadata,
+	"vaultmind: 'lint fix-links' is deprecated; use 'doctor heal wikilinks' instead",
+	runLintFixLinks)
 
 func init() {
 	lintCmd.AddCommand(lintFixLinksCmd)
 	setupCommandConfig(lintFixLinksCmd)
 }
 
+// runLintFixLinks resolves the alias's own app.lintfixlinks.* flags and
+// delegates to the shared wikilink-fix engine. --fix (default false) maps to
+// apply; without it the alias previews (dry-run) — the old contract, the
+// inverse of the new heal default.
 func runLintFixLinks(cmd *cobra.Command, _ []string) error {
 	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppLintfixlinksVault)
 	jsonOut := getConfigValueWithFlags[bool](cmd, "json", config.KeyAppLintfixlinksJson)
-	fix := getConfigValueWithFlags[bool](cmd, "fix", config.KeyAppLintfixlinksFix)
+	apply := getConfigValueWithFlags[bool](cmd, "fix", config.KeyAppLintfixlinksFix)
+	return runWikilinkFix(cmd, vaultPath, jsonOut, apply, fixLinksModeLabel(apply), "lint fix-links")
+}
 
-	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "lint fix-links")
-	if err != nil {
-		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
-			return nil
-		}
-		return err
+// fixLinksModeLabel preserves the legacy fix-links human-output labels:
+// "fix" when applying, "dry-run" when previewing. (heal uses "apply" instead;
+// both share the same engine, only the label differs.)
+func fixLinksModeLabel(apply bool) string {
+	if apply {
+		return "fix"
 	}
-	defer vdb.Close()
-
-	result, err := mutation.FixWikilinks(vdb.DB, vaultPath, fix)
-	if err != nil {
-		return fmt.Errorf("fix-links: %w", err)
-	}
-
-	if jsonOut {
-		env := envelope.OK("lint fix-links", result)
-		env.Meta.VaultPath = vaultPath
-		env.Meta.IndexHash = vdb.GetIndexHash()
-		return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
-	}
-
-	w := cmd.OutOrStdout()
-	mode := "dry-run"
-	if fix {
-		mode = "fix"
-	}
-	if _, err = fmt.Fprintf(w, "Mode: %s\nFiles scanned: %d\nFiles changed: %d\nLinks fixed: %d\n",
-		mode, result.FilesScanned, result.FilesChanged, result.LinksFixed); err != nil {
-		return err
-	}
-	for _, d := range result.Details {
-		if _, err = fmt.Fprintf(w, "  %s: %s → %s\n", d.Path, d.OldLink, d.NewLink); err != nil {
-			return err
-		}
-	}
-	return nil
+	return "dry-run"
 }

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -4,16 +4,22 @@ import "github.com/spf13/cobra"
 
 var memoryCmd = &cobra.Command{
 	Use:   "memory",
-	Short: "Traverse associative graph neighborhoods and assemble context for agent consumption",
-	Long: `Query associative relationships in your vault: traverse graph neighborhoods,
-list connected notes, assemble token-budgeted context payloads, or gather
-note material for agent-driven synthesis.
+	Short: "Traverse the note graph and assemble context for agent consumption",
+	Long: `Query associative relationships in your vault: follow directed links,
+traverse graph neighborhoods, list connected notes, assemble token-budgeted
+context payloads, or gather note material for agent-driven synthesis.
 
 CHOOSE A SUBCOMMAND BY INTENT
 
-  memory recall <id-or-path>
-      BFS traversal starting from a note. Loads all neighbors within
-      a depth limit and returns full frontmatter for every node in the
+  memory links <id-or-path> [--out|--in|--both]
+      Directed wikilink edges of a note. --out is outbound (what the note
+      references), --in is inbound (backlinks: what references the note),
+      --both (default) shows both directions. Use to follow a single hop
+      of explicit edges in a known direction.
+
+  memory neighbors <id-or-path>
+      BFS traversal starting from a note. Loads all neighbors within a
+      depth limit and returns full frontmatter for every node in the
       expanded neighborhood. Use when you want the enriched graph around
       a note — not just its direct connections.
 
@@ -23,7 +29,7 @@ CHOOSE A SUBCOMMAND BY INTENT
       mixed). Use when you want a simple ranked list without deeper
       traversal.
 
-  memory context-pack <id-or-path>
+  memory pack <id-or-path>
       Token-budgeted context assembly. Loads the target note, then fills
       a token budget with ranked context items (graph neighbors). Truncates
       when the budget is exhausted. Use when you want a ready-to-ship
@@ -37,10 +43,10 @@ CHOOSE A SUBCOMMAND BY INTENT
 
 EXAMPLES
 
-  vaultmind memory recall concept-foo                            # full neighborhood at depth 1
-  vaultmind memory recall concept-foo --depth 2 --json          # deeper BFS, machine-readable
+  vaultmind memory links concept-foo --out                       # outbound edges only
+  vaultmind memory neighbors concept-foo --depth 2 --json        # deeper BFS, machine-readable
   vaultmind memory related concept-foo --mode explicit           # only explicit edges
-  vaultmind memory context-pack concept-foo --budget 3000        # cap at 3000 tokens
+  vaultmind memory pack concept-foo --budget 3000                # cap at 3000 tokens
   vaultmind memory summarize note-a note-b note-c --include-body # gather bodies for synthesis
 
 Run 'vaultmind memory <subcommand> --help' for per-command flags and defaults.`,

--- a/cmd/memory_context_pack.go
+++ b/cmd/memory_context_pack.go
@@ -1,103 +1,17 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-
-	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
-	"github.com/peiman/vaultmind/internal/cmdutil"
 	"github.com/peiman/vaultmind/internal/config/commands"
-	"github.com/peiman/vaultmind/internal/envelope"
-	"github.com/peiman/vaultmind/internal/experiment"
-	"github.com/peiman/vaultmind/internal/graph"
-	memory "github.com/peiman/vaultmind/internal/memory"
-	"github.com/spf13/cobra"
 )
 
-var memoryContextPackCmd = MustNewCommand(commands.MemoryContextPackMetadata, runMemoryContextPack)
+// memory context-pack is DEPRECATED: renamed to `memory pack` (identical
+// behavior). This hidden alias prints a one-line notice and delegates to
+// runMemoryPack. Kept for ~2 releases.
+var memoryContextPackCmd = newDeprecatedAlias(commands.MemoryContextPackMetadata,
+	"vaultmind: 'memory context-pack' is deprecated; use 'memory pack' instead",
+	runMemoryPack)
 
 func init() {
 	memoryCmd.AddCommand(memoryContextPackCmd)
 	setupCommandConfig(memoryContextPackCmd)
-}
-
-func runMemoryContextPack(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("usage: memory context-pack <id-or-path>")
-	}
-	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppMemorycontextpackVault)
-	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "memory context-pack")
-	if err != nil {
-		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
-			return nil
-		}
-		return err
-	}
-	defer vdb.Close()
-
-	jsonOut := getConfigValueWithFlags[bool](cmd, "json", config.KeyAppMemorycontextpackJson)
-	resolver := graph.NewResolver(vdb.DB)
-
-	activationScores := computeActivationScores(cmd.Context(), nil, 0)
-
-	result, err := memory.ContextPack(resolver, vdb.DB, memory.ContextPackConfig{
-		Input:            args[0],
-		Budget:           getConfigValueWithFlags[int](cmd, "budget", config.KeyAppMemorycontextpackBudget),
-		Depth:            getConfigValueWithFlags[int](cmd, "depth", config.KeyAppMemorycontextpackDepth),
-		MaxItems:         getConfigValueWithFlags[int](cmd, "max-items", config.KeyAppMemorycontextpackMaxItems),
-		Slim:             getConfigValueWithFlags[bool](cmd, "slim", config.KeyAppMemorycontextpackSlim),
-		ActivationScores: activationScores,
-	})
-	if err != nil {
-		if jsonOut {
-			return cmdutil.WriteJSONError(cmd.OutOrStdout(), "memory context-pack", "context_pack_error", err.Error())
-		}
-		return fmt.Errorf("context-pack: %w", err)
-	}
-
-	// Log experiment event with shadow variant scores
-	if session := experiment.FromContext(cmd.Context()); session != nil {
-		session.SetVaultPath(vaultPath)
-		exps := loadExperimentDefs()
-		if actDef, ok := exps["activation"]; ok && actDef.Enabled {
-			_, _ = session.LogContextPackEvent(map[string]any{
-				"primary_variant": actDef.Primary,
-				"target_id":       result.TargetID,
-				"variants":        experiment.BuildShadowVariantResults(session, actDef, contextNoteIDs(result.Context)),
-			})
-		} else {
-			_, _ = session.LogContextPackEvent(map[string]any{
-				"target_id":     result.TargetID,
-				"context_items": len(result.Context),
-				"variants":      map[string]any{"none": map[string]any{"results": []any{}}},
-			})
-		}
-	}
-
-	if jsonOut {
-		env := envelope.OK("memory context-pack", result)
-		env.Meta.VaultPath = vaultPath
-		env.Meta.IndexHash = vdb.GetIndexHash()
-		return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
-	}
-	return formatContextPack(result, cmd.OutOrStdout())
-}
-
-func formatContextPack(result *memory.ContextPackResult, w io.Writer) error {
-	if result.Target != nil {
-		if _, err := fmt.Fprintf(w, "target: %s\n", result.Target.ID); err != nil {
-			return err
-		}
-	}
-	truncStr := ""
-	if result.Truncated {
-		truncStr = " (truncated)"
-	}
-	if _, err := fmt.Fprintf(w, "tokens: %d / %d%s\n", result.UsedTokens, result.BudgetTokens, truncStr); err != nil {
-		return err
-	}
-	_, err := fmt.Fprintf(w, "%d context items\n", len(result.Context))
-	return err
 }

--- a/cmd/memory_coverage_test.go
+++ b/cmd/memory_coverage_test.go
@@ -1,0 +1,292 @@
+package cmd
+
+// memory_coverage_test.go — behavior tests targeting uncovered branches in
+// memory_links.go (runLinksBoth human path + CollectBoth error path),
+// memory_neighbors_helpers.go (formatRecall MaxNodesReached suffix),
+// memory_pack.go (error + JSON error paths),
+// memory_pack_helpers.go (formatContextPack Truncated=true),
+// and doctor_heal.go (zero-change human output without stale-index warning).
+//
+// All tests assert on outputs or error messages — no vacuous line-hit tests.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"bytes"
+)
+
+// ---- memory links human output for --both --------------------------------
+
+// memory links --both (default) without --json renders two headed sections:
+// "outbound:" then "inbound:". Each link appears under the correct section.
+// This exercises the runLinksBoth human-output path (the JSON path is covered
+// by TestMemoryLinks_DefaultBothShowsBothDirections).
+func TestMemoryLinksBoth_HumanOutputShowsTwoSections(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--vault", vault)
+	require.NoError(t, err)
+
+	text := out.String()
+	outIdx := strings.Index(text, "outbound:")
+	inIdx := strings.Index(text, "inbound:")
+	require.NotEqual(t, -1, outIdx, "human --both output must include an 'outbound:' header")
+	require.NotEqual(t, -1, inIdx, "human --both output must include an 'inbound:' header")
+	assert.Less(t, outIdx, inIdx, "outbound section must appear before inbound section")
+}
+
+// memory links --both human output must list links under the outbound section.
+// proj-beta references alpha (back-link) AND alpha references proj-beta
+// (forward link), so both sections must contain proj-beta.
+func TestMemoryLinksBoth_HumanOutputContainsLinks(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--vault", vault)
+	require.NoError(t, err)
+
+	text := out.String()
+	// At least one of the sections must mention proj-beta.
+	assert.Contains(t, text, "proj-beta",
+		"human --both output must include proj-beta in at least one direction")
+}
+
+// memory links --both with an unresolvable ID in human mode must return a
+// Go error (no JSON) that is not empty.
+func TestMemoryLinksBoth_HumanOutputUnresolvableErrors(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	_, _, err := runRootCmd(t, "memory", "links", "no-such-id",
+		"--vault", vault)
+	require.Error(t, err,
+		"human mode with unresolvable ID must return a Go error")
+}
+
+// memory links --both --json with an unresolvable ID must write a JSON error
+// envelope to stdout and return nil (so callers can parse the failure code).
+func TestMemoryLinksBoth_JSONUnresolvableWritesErrorEnvelope(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "links", "no-such-id",
+		"--both", "--vault", vault, "--json")
+	require.NoError(t, err,
+		"JSON mode must encode errors in the envelope, not as a Go error")
+
+	var env struct {
+		Status string `json:"status"`
+		Errors []struct {
+			Code string `json:"code"`
+		} `json:"errors"`
+	}
+	require.True(t, json.Valid(out.Bytes()), "error output must be valid JSON")
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Equal(t, "error", env.Status,
+		"envelope status must be 'error' for unresolvable input")
+}
+
+// ---- memory links --out / --in human output --------------------------------
+
+// memory links --out human output: each row has the format
+// %-20s %-20s %s (target_id/raw, edge_type, confidence). No direction header
+// is printed for single-direction commands (unlike --both).
+func TestMemoryLinksOut_HumanOutputNoSectionHeader(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--out", "--vault", vault)
+	require.NoError(t, err)
+
+	text := out.String()
+	assert.NotContains(t, text, "outbound:", "--out human output must NOT print a section header")
+	assert.NotContains(t, text, "inbound:", "--out human output must NOT print an inbound header")
+	assert.Contains(t, text, "proj-beta", "--out output must list the outbound link target")
+}
+
+// memory links --in human output: similar contract to --out, no section header.
+func TestMemoryLinksIn_HumanOutputNoSectionHeader(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--in", "--vault", vault)
+	require.NoError(t, err)
+
+	text := out.String()
+	assert.NotContains(t, text, "outbound:", "--in human output must NOT print a section header")
+	assert.NotContains(t, text, "inbound:", "--in human output must NOT print an inbound header")
+	assert.Contains(t, text, "proj-beta", "--in output must list proj-beta as a backlink source")
+}
+
+// ---- memory neighbors human output + formatRecall branches ----------------
+
+// memory neighbors human output (no --json) calls formatRecall. When the
+// traversal fits within the node budget (MaxNodesReached=false), there must be
+// no "(max reached)" suffix on the count line. This pins the "not reached"
+// branch of formatRecall.
+func TestMemoryNeighbors_HumanOutputNormalCountLine(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "neighbors", "concept-alpha",
+		"--vault", vault, "--depth", "1", "--max-nodes", "50")
+	require.NoError(t, err)
+
+	text := out.String()
+	assert.Contains(t, text, "nodes", "human output must end with a 'N nodes' line")
+	assert.NotContains(t, text, "(max reached)",
+		"no max-reached suffix when the node budget was not hit")
+}
+
+// formatRecall MaxNodesReached branch: when max-nodes is set to 1 on a vault
+// with at least 2 reachable notes, the traversal must truncate and append
+// the "(max reached)" suffix to the count line.
+func TestFormatRecall_MaxNodesReachedSuffix(t *testing.T) {
+	// Build the result directly and pass it to formatRecall so the test is
+	// decoupled from vault I/O while still verifying real behavior.
+	result := &memory.RecallResult{
+		Nodes: []memory.RecallNode{
+			{ID: "concept-alpha", Type: "concept", Title: "Alpha", Distance: 0},
+			{ID: "proj-beta", Type: "project", Title: "Beta", Distance: 1},
+		},
+		MaxNodesReached: true,
+	}
+
+	var buf bytes.Buffer
+	err := formatRecall(result, &buf)
+	require.NoError(t, err)
+
+	text := buf.String()
+	assert.Contains(t, text, "2 nodes", "count must reflect the two nodes in the result")
+	assert.Contains(t, text, "(max reached)",
+		"MaxNodesReached=true must append the '(max reached)' suffix to the count line")
+}
+
+// formatRecall renders the target node at depth 0 with its ID, type, and title.
+// Neighbor nodes at depth≥1 are indented with "→". This pins the two render
+// branches without needing a live vault.
+func TestFormatRecall_RendersDepthZeroAndNeighbors(t *testing.T) {
+	result := &memory.RecallResult{
+		Nodes: []memory.RecallNode{
+			{ID: "concept-alpha", Type: "concept", Title: "Alpha", Distance: 0},
+			{ID: "proj-beta", Type: "project", Title: "Beta", Distance: 1},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, formatRecall(result, &buf))
+	text := buf.String()
+
+	// Depth-0 line: no "→" prefix, contains (depth 0) marker.
+	assert.Contains(t, text, "concept-alpha", "depth-0 node must include its ID")
+	assert.Contains(t, text, "(depth 0)", "depth-0 line must be tagged with '(depth 0)'")
+
+	// Depth-1 line: "→" prefix and depth label.
+	assert.Contains(t, text, "→", "neighbor at depth≥1 must use '→' prefix")
+	assert.Contains(t, text, "proj-beta", "neighbor ID must appear")
+	assert.Contains(t, text, "depth 1", "neighbor must carry its distance label")
+}
+
+// ---- memory pack branches --------------------------------------------------
+
+// memory pack --json error path: when the note cannot be resolved, the JSON
+// error envelope is written to stdout (not stderr) and the command returns nil.
+func TestMemoryPack_JSONErrorEnvelopeOnUnresolvableID(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "pack", "no-such-note",
+		"--vault", vault, "--budget", "4000", "--max-items", "8", "--json")
+	require.NoError(t, err,
+		"JSON mode must encode errors in the envelope, not return a Go error")
+
+	require.True(t, json.Valid(out.Bytes()),
+		"error envelope must be valid JSON")
+	var env struct {
+		Status string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Equal(t, "error", env.Status,
+		"unresolvable note must yield an error-status envelope")
+}
+
+// memory pack human error path: when the note cannot be resolved and --json is
+// not set, a Go error is returned (not written to stdout).
+func TestMemoryPack_HumanErrorOnUnresolvableID(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	_, _, err := runRootCmd(t, "memory", "pack", "no-such-note",
+		"--vault", vault, "--budget", "4000", "--max-items", "8")
+	require.Error(t, err,
+		"human mode must return a Go error when the note cannot be resolved")
+}
+
+// formatContextPack with Truncated=true appends " (truncated)" to the token
+// line. Without this, operators cannot tell from the output that some context
+// was dropped to fit the budget.
+func TestFormatContextPack_TruncatedFlag(t *testing.T) {
+	result := &memory.ContextPackResult{
+		TargetID:     "concept-alpha",
+		BudgetTokens: 100,
+		UsedTokens:   95,
+		Truncated:    true,
+	}
+
+	var buf bytes.Buffer
+	err := formatContextPack(result, &buf)
+	require.NoError(t, err)
+
+	text := buf.String()
+	assert.Contains(t, text, "tokens: 95 / 100", "token line must show used/budget")
+	assert.Contains(t, text, "(truncated)",
+		"Truncated=true must append '(truncated)' to the token line")
+}
+
+// formatContextPack with Truncated=false must NOT append the truncated marker.
+func TestFormatContextPack_NotTruncated(t *testing.T) {
+	result := &memory.ContextPackResult{
+		TargetID:     "concept-alpha",
+		BudgetTokens: 4000,
+		UsedTokens:   200,
+		Truncated:    false,
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, formatContextPack(result, &buf))
+	assert.NotContains(t, buf.String(), "(truncated)",
+		"Truncated=false must not append the truncated marker")
+	assert.Contains(t, buf.String(), "tokens: 200 / 4000")
+}
+
+// formatContextPack with a non-nil Target prints the target ID on the first line.
+func TestFormatContextPack_WithTarget(t *testing.T) {
+	result := &memory.ContextPackResult{
+		TargetID:     "concept-alpha",
+		BudgetTokens: 4000,
+		UsedTokens:   50,
+		Target: &memory.ContextPackTarget{
+			ID: "concept-alpha",
+		},
+		Context: []memory.ContextItem{{ID: "x"}},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, formatContextPack(result, &buf))
+	text := buf.String()
+	assert.Contains(t, text, "target: concept-alpha",
+		"formatContextPack must print the target line when Target is non-nil")
+	assert.Contains(t, text, "1 context items",
+		"formatContextPack must count context items")
+}
+
+// ---- doctor heal stale-index: zero-change human output ---------------------
+
+// doctor heal on a vault that has no fixable links (zero changes) must NOT
+// warn about a stale index in human output — the index is still valid when
+// nothing was written. This pins the "zero changes" branch of runWikilinkFix
+// human output.
+func TestDoctorHeal_ZeroChangesHumanOutputNoStaleWarning(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault)
+	require.NoError(t, err)
+
+	text := out.String()
+	assert.Contains(t, text, "Files changed: 0",
+		"precondition: the vault has no fixable links, so 0 files are changed")
+	assert.NotContains(t, text, "Index is now stale",
+		"zero-change heal must NOT warn about a stale index")
+}

--- a/cmd/memory_links.go
+++ b/cmd/memory_links.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/cmdutil"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/query"
+	"github.com/spf13/cobra"
+)
+
+var memoryLinksCmd = MustNewCommand(commands.MemoryLinksMetadata, runMemoryLinks)
+
+func init() {
+	memoryCmd.AddCommand(memoryLinksCmd)
+	setupCommandConfig(memoryLinksCmd)
+}
+
+func runMemoryLinks(cmd *cobra.Command, args []string) error {
+	return runLinksDirection(cmd, args, linksDirectionFromFlags(cmd))
+}
+
+// linksDirectionFromFlags maps the --out/--in/--both flags to a direction.
+// Default (no flag or --both) is "both".
+func linksDirectionFromFlags(cmd *cobra.Command) string {
+	if getConfigValueWithFlags[bool](cmd, "out", config.KeyAppMemorylinksOut) {
+		return "out"
+	}
+	if getConfigValueWithFlags[bool](cmd, "in", config.KeyAppMemorylinksIn) {
+		return "in"
+	}
+	return "both"
+}
+
+// runLinksDirection executes the links query for the given direction, reusing
+// internal/query.RunLinks for each direction. "both" runs out then in.
+func runLinksDirection(cmd *cobra.Command, args []string, direction string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: vaultmind memory links <id-or-path>")
+	}
+	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppMemorylinksVault)
+	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "memory links")
+	if err != nil {
+		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
+			return nil
+		}
+		return err
+	}
+	defer vdb.Close()
+
+	cfg := query.LinksConfig{
+		Input:      args[0],
+		VaultPath:  vaultPath,
+		EdgeType:   getConfigValueWithFlags[string](cmd, "edge-type", config.KeyAppMemorylinksEdgeType),
+		JSONOutput: getConfigValueWithFlags[bool](cmd, "json", config.KeyAppMemorylinksJson),
+		IndexHash:  vdb.GetIndexHash(),
+	}
+	for _, dir := range linkDirections(direction) {
+		cfg.Direction = dir
+		if err := query.RunLinks(vdb.DB, cfg, cmd.OutOrStdout()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// linkDirections expands a requested direction into the ordered set of
+// concrete directions to query. "both" -> out then in.
+func linkDirections(direction string) []string {
+	if direction == "both" {
+		return []string{"out", "in"}
+	}
+	return []string{direction}
+}

--- a/cmd/memory_links.go
+++ b/cmd/memory_links.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
 	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
 	"github.com/peiman/vaultmind/internal/cmdutil"
 	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/envelope"
 	"github.com/peiman/vaultmind/internal/query"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +18,9 @@ var memoryLinksCmd = MustNewCommand(commands.MemoryLinksMetadata, runMemoryLinks
 func init() {
 	memoryCmd.AddCommand(memoryLinksCmd)
 	setupCommandConfig(memoryLinksCmd)
+	// Tri-state direction is mutually exclusive: --out, --in, and --both
+	// cannot be combined. Cobra rejects the combination before RunE.
+	memoryLinksCmd.MarkFlagsMutuallyExclusive("out", "in", "both")
 }
 
 func runMemoryLinks(cmd *cobra.Command, args []string) error {
@@ -23,7 +28,9 @@ func runMemoryLinks(cmd *cobra.Command, args []string) error {
 }
 
 // linksDirectionFromFlags maps the --out/--in/--both flags to a direction.
-// Default (no flag or --both) is "both".
+// Default (no flag) is "both"; an explicit --both also yields "both" so the
+// flag is not dead. --out/--in/--both are mutually exclusive (enforced by
+// MarkFlagsMutuallyExclusive), so at most one is set.
 func linksDirectionFromFlags(cmd *cobra.Command) string {
 	if getConfigValueWithFlags[bool](cmd, "out", config.KeyAppMemorylinksOut) {
 		return "out"
@@ -31,11 +38,16 @@ func linksDirectionFromFlags(cmd *cobra.Command) string {
 	if getConfigValueWithFlags[bool](cmd, "in", config.KeyAppMemorylinksIn) {
 		return "in"
 	}
+	if getConfigValueWithFlags[bool](cmd, "both", config.KeyAppMemorylinksBoth) {
+		return "both"
+	}
 	return "both"
 }
 
-// runLinksDirection executes the links query for the given direction, reusing
-// internal/query.RunLinks for each direction. "both" runs out then in.
+// runLinksDirection executes the links query for the given direction. Single
+// directions ("out"/"in") render one envelope via query.RunLinks. "both"
+// aggregates BOTH directions: in JSON it is ONE combined envelope (out before
+// in); in human output it is two section-headed blocks.
 func runLinksDirection(cmd *cobra.Command, args []string, direction string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: vaultmind memory links <id-or-path>")
@@ -52,25 +64,59 @@ func runLinksDirection(cmd *cobra.Command, args []string, direction string) erro
 
 	cfg := query.LinksConfig{
 		Input:      args[0],
+		Direction:  direction,
 		VaultPath:  vaultPath,
 		EdgeType:   getConfigValueWithFlags[string](cmd, "edge-type", config.KeyAppMemorylinksEdgeType),
 		JSONOutput: getConfigValueWithFlags[bool](cmd, "json", config.KeyAppMemorylinksJson),
 		IndexHash:  vdb.GetIndexHash(),
 	}
-	for _, dir := range linkDirections(direction) {
-		cfg.Direction = dir
-		if err := query.RunLinks(vdb.DB, cfg, cmd.OutOrStdout()); err != nil {
+
+	if direction == "both" {
+		return runLinksBoth(cmd, vdb, cfg)
+	}
+	return query.RunLinks(vdb.DB, cfg, cmd.OutOrStdout())
+}
+
+// runLinksBoth renders both directions. JSON: one combined envelope so stdout
+// is a single valid JSON value. Human: an "outbound:" block then an "inbound:"
+// block so directions are distinguishable.
+func runLinksBoth(cmd *cobra.Command, vdb *cmdutil.VaultDB, cfg query.LinksConfig) error {
+	both, _, err := query.CollectBoth(vdb.DB, cfg)
+	if err != nil {
+		if cfg.JSONOutput {
+			return cmdutil.WriteJSONError(cmd.OutOrStdout(), "memory links",
+				"resolution_failed", err.Error())
+		}
+		return err
+	}
+
+	w := cmd.OutOrStdout()
+	if cfg.JSONOutput {
+		env := envelope.OK("memory links", both)
+		env.Meta.VaultPath = cfg.VaultPath
+		env.Meta.IndexHash = cfg.IndexHash
+		return json.NewEncoder(w).Encode(env)
+	}
+
+	if _, err := fmt.Fprintln(w, "outbound:"); err != nil {
+		return err
+	}
+	for _, l := range both.Out.Links {
+		id := l.TargetRaw
+		if l.TargetID != nil {
+			id = *l.TargetID
+		}
+		if _, err := fmt.Fprintf(w, "  %-20s %-20s %s\n", id, l.EdgeType, l.Confidence); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w, "inbound:"); err != nil {
+		return err
+	}
+	for _, l := range both.In.Links {
+		if _, err := fmt.Fprintf(w, "  %-20s %-20s %s\n", l.SourceID, l.EdgeType, l.Confidence); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// linkDirections expands a requested direction into the ordered set of
-// concrete directions to query. "both" -> out then in.
-func linkDirections(direction string) []string {
-	if direction == "both" {
-		return []string{"out", "in"}
-	}
-	return []string{direction}
 }

--- a/cmd/memory_neighbors.go
+++ b/cmd/memory_neighbors.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/cmdutil"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/envelope"
+	"github.com/peiman/vaultmind/internal/experiment"
+	"github.com/peiman/vaultmind/internal/graph"
+	memory "github.com/peiman/vaultmind/internal/memory"
+	"github.com/spf13/cobra"
+)
+
+var memoryNeighborsCmd = MustNewCommand(commands.MemoryNeighborsMetadata, runMemoryNeighbors)
+
+func init() {
+	memoryCmd.AddCommand(memoryNeighborsCmd)
+	setupCommandConfig(memoryNeighborsCmd)
+}
+
+func runMemoryNeighbors(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: vaultmind memory neighbors <id-or-path>")
+	}
+	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppMemoryneighborsVault)
+	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "memory neighbors")
+	if err != nil {
+		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
+			return nil
+		}
+		return err
+	}
+	defer vdb.Close()
+
+	jsonOut := getConfigValueWithFlags[bool](cmd, "json", config.KeyAppMemoryneighborsJson)
+	resolver := graph.NewResolver(vdb.DB)
+	result, err := memory.Recall(resolver, vdb.DB, memory.RecallConfig{
+		Input:         args[0],
+		Depth:         getConfigValueWithFlags[int](cmd, "depth", config.KeyAppMemoryneighborsDepth),
+		MinConfidence: getConfigValueWithFlags[string](cmd, "min-confidence", config.KeyAppMemoryneighborsMinConfidence),
+		MaxNodes:      getConfigValueWithFlags[int](cmd, "max-nodes", config.KeyAppMemoryneighborsMaxNodes),
+	})
+	if err != nil {
+		if jsonOut {
+			return cmdutil.WriteJSONError(cmd.OutOrStdout(), "memory neighbors", "neighbors_error", err.Error())
+		}
+		return fmt.Errorf("neighbors: %w", err)
+	}
+
+	// Log note access for experiment outcome linkage (non-blocking).
+	if session := experiment.FromContext(cmd.Context()); session != nil {
+		session.SetVaultPath(vaultPath)
+		_, _ = session.LogNoteAccessEvent(args[0], "neighbors")
+	}
+
+	if jsonOut {
+		env := envelope.OK("memory neighbors", result)
+		env.Meta.VaultPath = vaultPath
+		env.Meta.IndexHash = vdb.GetIndexHash()
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
+	}
+	return formatRecall(result, cmd.OutOrStdout())
+}

--- a/cmd/memory_neighbors.go
+++ b/cmd/memory_neighbors.go
@@ -22,7 +22,36 @@ func init() {
 	setupCommandConfig(memoryNeighborsCmd)
 }
 
+// neighborsKeys names the viper keys a neighbors invocation reads its
+// depth/min-confidence/max-nodes defaults from. The canonical `memory
+// neighbors` path uses the memoryneighbors.* keys (high/50); the deprecated
+// `links neighbors` alias uses the linksneighbors.* keys (low/200) so its
+// historical defaults are preserved across the merge (M1).
+type neighborsKeys struct {
+	depthKey         string
+	minConfidenceKey string
+	maxNodesKey      string
+}
+
+// memoryNeighborsKeys is the canonical key set for `memory neighbors`.
+var memoryNeighborsKeys = neighborsKeys{
+	depthKey:         config.KeyAppMemoryneighborsDepth,
+	minConfidenceKey: config.KeyAppMemoryneighborsMinConfidence,
+	maxNodesKey:      config.KeyAppMemoryneighborsMaxNodes,
+}
+
 func runMemoryNeighbors(cmd *cobra.Command, args []string) error {
+	return runNeighborsWithKeys(cmd, args, memoryNeighborsKeys)
+}
+
+// runNeighborsWithKeys is the shared neighbors engine. It reads the
+// depth/min-confidence/max-nodes defaults from the supplied key set (so the
+// deprecated links-neighbors alias keeps its low/200 defaults) and the
+// vault/json flags from the memoryneighbors.* keys (shared by both paths since
+// the flags carry the same registered values). When a flag was explicitly set
+// on the command line, getConfigValueWithFlags returns the flag value
+// regardless of which default key was consulted.
+func runNeighborsWithKeys(cmd *cobra.Command, args []string, keys neighborsKeys) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: vaultmind memory neighbors <id-or-path>")
 	}
@@ -40,9 +69,9 @@ func runMemoryNeighbors(cmd *cobra.Command, args []string) error {
 	resolver := graph.NewResolver(vdb.DB)
 	result, err := memory.Recall(resolver, vdb.DB, memory.RecallConfig{
 		Input:         args[0],
-		Depth:         getConfigValueWithFlags[int](cmd, "depth", config.KeyAppMemoryneighborsDepth),
-		MinConfidence: getConfigValueWithFlags[string](cmd, "min-confidence", config.KeyAppMemoryneighborsMinConfidence),
-		MaxNodes:      getConfigValueWithFlags[int](cmd, "max-nodes", config.KeyAppMemoryneighborsMaxNodes),
+		Depth:         getConfigValueWithFlags[int](cmd, "depth", keys.depthKey),
+		MinConfidence: getConfigValueWithFlags[string](cmd, "min-confidence", keys.minConfidenceKey),
+		MaxNodes:      getConfigValueWithFlags[int](cmd, "max-nodes", keys.maxNodesKey),
 	})
 	if err != nil {
 		if jsonOut {

--- a/cmd/memory_neighbors_helpers.go
+++ b/cmd/memory_neighbors_helpers.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	memory "github.com/peiman/vaultmind/internal/memory"
+)
+
+// formatRecall renders the human-readable neighbors traversal: the target at
+// depth 0, then each neighbor with its distance. Shared by memory neighbors
+// and its deprecated alias memory recall.
+func formatRecall(result *memory.RecallResult, w io.Writer) error {
+	for _, n := range result.Nodes {
+		if n.Distance == 0 {
+			if _, err := fmt.Fprintf(w, "%s [%s] %q (depth 0)\n", n.ID, n.Type, n.Title); err != nil {
+				return err
+			}
+		} else {
+			if _, err := fmt.Fprintf(w, "  → %s [%s] %q depth %d\n", n.ID, n.Type, n.Title, n.Distance); err != nil {
+				return err
+			}
+		}
+	}
+	suffix := ""
+	if result.MaxNodesReached {
+		suffix = " (max reached)"
+	}
+	_, err := fmt.Fprintf(w, "%d nodes%s\n", len(result.Nodes), suffix)
+	return err
+}

--- a/cmd/memory_pack.go
+++ b/cmd/memory_pack.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/cmdutil"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/graph"
+	memory "github.com/peiman/vaultmind/internal/memory"
+	"github.com/spf13/cobra"
+)
+
+var memoryPackCmd = MustNewCommand(commands.MemoryPackMetadata, runMemoryPack)
+
+func init() {
+	memoryCmd.AddCommand(memoryPackCmd)
+	setupCommandConfig(memoryPackCmd)
+}
+
+func runMemoryPack(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: vaultmind memory pack <id-or-path>")
+	}
+	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppMemorypackVault)
+	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "memory pack")
+	if err != nil {
+		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
+			return nil
+		}
+		return err
+	}
+	defer vdb.Close()
+
+	jsonOut := getConfigValueWithFlags[bool](cmd, "json", config.KeyAppMemorypackJson)
+	resolver := graph.NewResolver(vdb.DB)
+	result, err := memory.ContextPack(resolver, vdb.DB, memory.ContextPackConfig{
+		Input:            args[0],
+		Budget:           getConfigValueWithFlags[int](cmd, "budget", config.KeyAppMemorypackBudget),
+		Depth:            getConfigValueWithFlags[int](cmd, "depth", config.KeyAppMemorypackDepth),
+		MaxItems:         getConfigValueWithFlags[int](cmd, "max-items", config.KeyAppMemorypackMaxItems),
+		Slim:             getConfigValueWithFlags[bool](cmd, "slim", config.KeyAppMemorypackSlim),
+		ActivationScores: computeActivationScores(cmd.Context(), nil, 0),
+	})
+	if err != nil {
+		if jsonOut {
+			return cmdutil.WriteJSONError(cmd.OutOrStdout(), "memory pack", "pack_error", err.Error())
+		}
+		return fmt.Errorf("pack: %w", err)
+	}
+
+	logPackEvent(cmd, vaultPath, result)
+
+	if jsonOut {
+		return writePackEnvelope(cmd, vaultPath, vdb.GetIndexHash(), result)
+	}
+	return formatContextPack(result, cmd.OutOrStdout())
+}

--- a/cmd/memory_pack_helpers.go
+++ b/cmd/memory_pack_helpers.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/peiman/vaultmind/internal/envelope"
+	"github.com/peiman/vaultmind/internal/experiment"
+	memory "github.com/peiman/vaultmind/internal/memory"
+	"github.com/spf13/cobra"
+)
+
+// logPackEvent records the context-pack experiment event (with shadow variant
+// scores when an activation experiment is enabled). Non-blocking.
+func logPackEvent(cmd *cobra.Command, vaultPath string, result *memory.ContextPackResult) {
+	session := experiment.FromContext(cmd.Context())
+	if session == nil {
+		return
+	}
+	session.SetVaultPath(vaultPath)
+	exps := loadExperimentDefs()
+	if actDef, ok := exps["activation"]; ok && actDef.Enabled {
+		_, _ = session.LogContextPackEvent(map[string]any{
+			"primary_variant": actDef.Primary,
+			"target_id":       result.TargetID,
+			"variants":        experiment.BuildShadowVariantResults(session, actDef, contextNoteIDs(result.Context)),
+		})
+		return
+	}
+	_, _ = session.LogContextPackEvent(map[string]any{
+		"target_id":     result.TargetID,
+		"context_items": len(result.Context),
+		"variants":      map[string]any{"none": map[string]any{"results": []any{}}},
+	})
+}
+
+// writePackEnvelope encodes the pack result as a JSON envelope.
+func writePackEnvelope(cmd *cobra.Command, vaultPath, indexHash string, result *memory.ContextPackResult) error {
+	env := envelope.OK("memory pack", result)
+	env.Meta.VaultPath = vaultPath
+	env.Meta.IndexHash = indexHash
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
+}
+
+// formatContextPack renders the human-readable pack summary.
+func formatContextPack(result *memory.ContextPackResult, w io.Writer) error {
+	if result.Target != nil {
+		if _, err := fmt.Fprintf(w, "target: %s\n", result.Target.ID); err != nil {
+			return err
+		}
+	}
+	truncStr := ""
+	if result.Truncated {
+		truncStr = " (truncated)"
+	}
+	if _, err := fmt.Fprintf(w, "tokens: %d / %d%s\n", result.UsedTokens, result.BudgetTokens, truncStr); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "%d context items\n", len(result.Context))
+	return err
+}

--- a/cmd/memory_recall.go
+++ b/cmd/memory_recall.go
@@ -1,88 +1,17 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-
-	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
-	"github.com/peiman/vaultmind/internal/cmdutil"
 	"github.com/peiman/vaultmind/internal/config/commands"
-	"github.com/peiman/vaultmind/internal/envelope"
-	"github.com/peiman/vaultmind/internal/experiment"
-	"github.com/peiman/vaultmind/internal/graph"
-	memory "github.com/peiman/vaultmind/internal/memory"
-	"github.com/spf13/cobra"
 )
 
-var memoryRecallCmd = MustNewCommand(commands.MemoryRecallMetadata, runMemoryRecall)
+// memory recall is DEPRECATED: merged into `memory neighbors` (BFS traversal
+// with full frontmatter). This hidden alias prints a one-line notice and
+// delegates to runMemoryNeighbors. Kept for ~2 releases.
+var memoryRecallCmd = newDeprecatedAlias(commands.MemoryRecallMetadata,
+	"vaultmind: 'memory recall' is deprecated; use 'memory neighbors' instead",
+	runMemoryNeighbors)
 
 func init() {
 	memoryCmd.AddCommand(memoryRecallCmd)
 	setupCommandConfig(memoryRecallCmd)
-}
-
-func runMemoryRecall(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return fmt.Errorf("usage: memory recall <id-or-path>")
-	}
-	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppMemoryrecallVault)
-	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "memory recall")
-	if err != nil {
-		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
-			return nil
-		}
-		return err
-	}
-	defer vdb.Close()
-
-	jsonOut := getConfigValueWithFlags[bool](cmd, "json", config.KeyAppMemoryrecallJson)
-	resolver := graph.NewResolver(vdb.DB)
-	result, err := memory.Recall(resolver, vdb.DB, memory.RecallConfig{
-		Input:         args[0],
-		Depth:         getConfigValueWithFlags[int](cmd, "depth", config.KeyAppMemoryrecallDepth),
-		MinConfidence: getConfigValueWithFlags[string](cmd, "min-confidence", config.KeyAppMemoryrecallMinConfidence),
-		MaxNodes:      getConfigValueWithFlags[int](cmd, "max-nodes", config.KeyAppMemoryrecallMaxNodes),
-	})
-	if err != nil {
-		if jsonOut {
-			return cmdutil.WriteJSONError(cmd.OutOrStdout(), "memory recall", "recall_error", err.Error())
-		}
-		return fmt.Errorf("recall: %w", err)
-	}
-
-	// Log note access for experiment outcome linkage (non-blocking)
-	if session := experiment.FromContext(cmd.Context()); session != nil {
-		session.SetVaultPath(vaultPath)
-		_, _ = session.LogNoteAccessEvent(args[0], "recall")
-	}
-
-	if jsonOut {
-		env := envelope.OK("memory recall", result)
-		env.Meta.VaultPath = vaultPath
-		env.Meta.IndexHash = vdb.GetIndexHash()
-		return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
-	}
-	return formatRecall(result, cmd.OutOrStdout())
-}
-
-func formatRecall(result *memory.RecallResult, w io.Writer) error {
-	for _, n := range result.Nodes {
-		if n.Distance == 0 {
-			if _, err := fmt.Fprintf(w, "%s [%s] %q (depth 0)\n", n.ID, n.Type, n.Title); err != nil {
-				return err
-			}
-		} else {
-			if _, err := fmt.Fprintf(w, "  → %s [%s] %q depth %d\n", n.ID, n.Type, n.Title, n.Distance); err != nil {
-				return err
-			}
-		}
-	}
-	suffix := ""
-	if result.MaxNodesReached {
-		suffix = " (max reached)"
-	}
-	_, err := fmt.Fprintf(w, "%d nodes%s\n", len(result.Nodes), suffix)
-	return err
 }

--- a/cmd/memory_taxonomy_test.go
+++ b/cmd/memory_taxonomy_test.go
@@ -34,7 +34,7 @@ type linksBothEnvelope struct {
 			Links    []struct {
 				SourceID string `json:"source_id"`
 				EdgeType string `json:"edge_type"`
-			} `json:"in_links"`
+			} `json:"links"`
 		} `json:"in"`
 	} `json:"result"`
 }
@@ -323,15 +323,11 @@ func TestTopLevelLinks_HiddenFromRootListing(t *testing.T) {
 // newDeprecatedAlias-built commands must be Hidden so they don't clutter help
 // while still resolving. Concretely: the `recall` and `context-pack`
 // subcommands under the VISIBLE `memory` parent must have Hidden==true (L3).
+//
+// Uses the package-global memoryCmd directly (not via RootCmd) so the test is
+// independent of docs_test.go / root_test.go reassigning RootCmd under adverse
+// test ordering.
 func TestDeprecatedAliases_AreHidden(t *testing.T) {
-	var memoryCmd *cobra.Command
-	for _, c := range RootCmd.Commands() {
-		if c.Name() == "memory" {
-			memoryCmd = c
-			break
-		}
-	}
-	require.NotNil(t, memoryCmd, "the visible 'memory' parent must exist")
 	require.False(t, memoryCmd.Hidden, "the 'memory' parent itself must stay visible")
 
 	for _, name := range []string{"recall", "context-pack"} {

--- a/cmd/memory_taxonomy_test.go
+++ b/cmd/memory_taxonomy_test.go
@@ -1,0 +1,232 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memory links --out surfaces the outbound wikilink/related_ids edge.
+// This is the new home for the old `links out`.
+func TestMemoryLinks_OutFindsOutboundReferences(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--out", "--vault", vault, "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "proj-beta",
+		"--out must surface the outbound edge alpha -> beta")
+}
+
+// memory links --in surfaces the inbound backlink (beta references alpha).
+func TestMemoryLinks_InFindsInboundReferences(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--in", "--vault", vault, "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "proj-beta",
+		"--in must surface the backlink beta -> alpha")
+}
+
+// memory links with no direction flag defaults to --both: it runs out then in,
+// so both directions appear. Default must not be empty.
+func TestMemoryLinks_DefaultBothShowsBothDirections(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--vault", vault, "--json")
+	require.NoError(t, err)
+	// Both directions reference proj-beta in this vault; the contract we lock
+	// is that default produces two JSON envelopes (out + in), not zero.
+	body := out.String()
+	assert.GreaterOrEqual(t, strings.Count(body, "\"status\""), 2,
+		"default --both must emit both an outbound and an inbound envelope")
+	assert.Contains(t, body, "proj-beta")
+}
+
+// memory links --both explicitly behaves like the default.
+func TestMemoryLinks_BothFlagShowsBothDirections(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--both", "--vault", vault, "--json")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, strings.Count(out.String(), "\"status\""), 2)
+}
+
+// memory links without an argument is a usage error.
+func TestMemoryLinks_MissingArgErrors(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	_, _, err := runRootCmd(t, "memory", "links", "--vault", vault)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "usage")
+}
+
+// memory neighbors places the target at depth 0 and a 1-hop neighbor at
+// depth 1, and (unlike the old links neighbors) carries full frontmatter
+// (type + title) — that's the merge of recall + links neighbors.
+func TestMemoryNeighbors_TargetAndNeighborWithFrontmatter(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "neighbors", "concept-alpha",
+		"--vault", vault, "--depth", "1", "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			Nodes []struct {
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Title    string `json:"title"`
+				Distance int    `json:"distance"`
+			} `json:"nodes"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+
+	var haveTarget, haveNeighbor, haveFrontmatter bool
+	for _, n := range env.Result.Nodes {
+		if n.ID == "concept-alpha" && n.Distance == 0 {
+			haveTarget = true
+			if n.Type != "" && n.Title != "" {
+				haveFrontmatter = true
+			}
+		}
+		if n.Distance == 1 {
+			haveNeighbor = true
+		}
+	}
+	assert.True(t, haveTarget, "target must be at depth 0")
+	assert.True(t, haveNeighbor, "at depth=1 there should be at least one neighbor")
+	assert.True(t, haveFrontmatter, "neighbors must carry full frontmatter (type+title)")
+}
+
+// memory neighbors without an argument is a usage error.
+func TestMemoryNeighbors_MissingArgErrors(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	_, _, err := runRootCmd(t, "memory", "neighbors", "--vault", vault)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "usage")
+}
+
+// memory pack includes the target — the rename of memory context-pack must
+// preserve the protocol-level contract that the anchor note is always present.
+func TestMemoryPack_IncludesTarget(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "pack", "concept-alpha",
+		"--vault", vault, "--budget", "4000", "--max-items", "8", "--slim", "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			TargetID string `json:"target_id"`
+			Target   struct {
+				ID string `json:"id"`
+			} `json:"target"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Equal(t, "concept-alpha", env.Result.TargetID)
+	assert.Equal(t, "concept-alpha", env.Result.Target.ID)
+}
+
+// memory pack human output reports the token budget line.
+func TestMemoryPack_HumanOutputReportsBudget(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "memory", "pack", "concept-alpha",
+		"--vault", vault, "--budget", "4000", "--max-items", "8", "--slim")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "tokens:")
+	assert.Contains(t, out.String(), "4000")
+}
+
+// The top-level `links` command must no longer appear in the visible root
+// listing: graph traversal lives under `memory` now. (It survives as a hidden
+// parent so the deprecated subcommands still resolve.)
+func TestTopLevelLinks_HiddenFromRootListing(t *testing.T) {
+	for _, c := range RootCmd.Commands() {
+		if c.Name() == "links" {
+			assert.True(t, c.Hidden, "top-level 'links' must be hidden from the root listing")
+			return
+		}
+	}
+}
+
+// ---- Deprecation aliases: must still run, delegate correctly, and warn. ----
+
+// links out is a hidden deprecated alias of `memory links --out`: it prints a
+// one-line stderr notice and still returns the outbound edge.
+func TestDeprecated_LinksOut_WarnsAndDelegates(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, errOut, err := runRootCmd(t, "links", "out", "concept-alpha",
+		"--vault", vault, "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "proj-beta", "delegated output must still appear on stdout")
+	assertOneLineDeprecation(t, errOut.String(), "memory links --out")
+}
+
+// links in is a hidden deprecated alias of `memory links --in`.
+func TestDeprecated_LinksIn_WarnsAndDelegates(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, errOut, err := runRootCmd(t, "links", "in", "concept-alpha",
+		"--vault", vault, "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "proj-beta")
+	assertOneLineDeprecation(t, errOut.String(), "memory links --in")
+}
+
+// links neighbors is a hidden deprecated alias of `memory neighbors`.
+func TestDeprecated_LinksNeighbors_WarnsAndDelegates(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, errOut, err := runRootCmd(t, "links", "neighbors", "concept-alpha",
+		"--vault", vault, "--depth", "1", "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "concept-alpha")
+	assertOneLineDeprecation(t, errOut.String(), "memory neighbors")
+}
+
+// memory recall is a hidden deprecated alias of `memory neighbors`.
+func TestDeprecated_MemoryRecall_WarnsAndDelegates(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, errOut, err := runRootCmd(t, "memory", "recall", "concept-alpha",
+		"--vault", vault, "--depth", "1", "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "concept-alpha")
+	assertOneLineDeprecation(t, errOut.String(), "memory neighbors")
+}
+
+// memory context-pack is a hidden deprecated alias of `memory pack`.
+func TestDeprecated_MemoryContextPack_WarnsAndDelegates(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	out, errOut, err := runRootCmd(t, "memory", "context-pack", "concept-alpha",
+		"--vault", vault, "--budget", "4000", "--max-items", "8", "--slim", "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			TargetID string `json:"target_id"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Equal(t, "concept-alpha", env.Result.TargetID, "delegation to memory pack must preserve target")
+	assertOneLineDeprecation(t, errOut.String(), "memory pack")
+}
+
+// assertOneLineDeprecation checks that stderr carries exactly one non-empty
+// deprecation line and that it names the new command path.
+func assertOneLineDeprecation(t *testing.T, stderr, mustMention string) {
+	t.Helper()
+	lines := nonEmptyLines(stderr)
+	require.Len(t, lines, 1, "deprecation notice must be exactly one line, got: %q", stderr)
+	assert.Contains(t, lines[0], "deprecated")
+	assert.Contains(t, lines[0], mustMention)
+}
+
+func nonEmptyLines(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if strings.TrimSpace(l) != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/cmd/memory_taxonomy_test.go
+++ b/cmd/memory_taxonomy_test.go
@@ -2,56 +2,168 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/peiman/vaultmind/internal/index"
+	"github.com/peiman/vaultmind/internal/vault"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// linksBothEnvelope decodes the combined --both JSON envelope: one envelope
+// whose result carries an "out" and an "in" payload. The structural
+// discriminators (source_id/target_id and the per-link target_id/source_id)
+// let a test detect a direction swap.
+type linksBothEnvelope struct {
+	Status string `json:"status"`
+	Result struct {
+		Out struct {
+			SourceID string `json:"source_id"`
+			Links    []struct {
+				TargetID *string `json:"target_id"`
+				EdgeType string  `json:"edge_type"`
+			} `json:"links"`
+		} `json:"out"`
+		In struct {
+			TargetID string `json:"target_id"`
+			Links    []struct {
+				SourceID string `json:"source_id"`
+				EdgeType string `json:"edge_type"`
+			} `json:"in_links"`
+		} `json:"in"`
+	} `json:"result"`
+}
+
+// linksOutEnvelope decodes a single-direction --out envelope.
+type linksOutEnvelope struct {
+	Result struct {
+		SourceID string `json:"source_id"`
+		Links    []struct {
+			TargetID *string `json:"target_id"`
+		} `json:"links"`
+	} `json:"result"`
+}
+
+// linksInEnvelope decodes a single-direction --in envelope.
+type linksInEnvelope struct {
+	Result struct {
+		TargetID string `json:"target_id"`
+		Links    []struct {
+			SourceID string `json:"source_id"`
+		} `json:"links"`
+	} `json:"result"`
+}
+
 // memory links --out surfaces the outbound wikilink/related_ids edge.
-// This is the new home for the old `links out`.
+// This is the new home for the old `links out`. Asserts the STRUCTURAL
+// discriminator (source_id == the queried note, a link whose target_id is
+// proj-beta) so a direction swap — which also contains "proj-beta" via the
+// fixture back-ref — fails.
 func TestMemoryLinks_OutFindsOutboundReferences(t *testing.T) {
 	vault := buildIndexedTestVault(t)
 	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
 		"--out", "--vault", vault, "--json")
 	require.NoError(t, err)
-	assert.Contains(t, out.String(), "proj-beta",
-		"--out must surface the outbound edge alpha -> beta")
+
+	var env linksOutEnvelope
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Equal(t, "concept-alpha", env.Result.SourceID,
+		"--out envelope's source_id must be the queried note")
+	var found bool
+	for _, l := range env.Result.Links {
+		if l.TargetID != nil && *l.TargetID == "proj-beta" {
+			found = true
+		}
+	}
+	assert.True(t, found, "--out must surface a link whose target_id is proj-beta")
 }
 
 // memory links --in surfaces the inbound backlink (beta references alpha).
+// Asserts the structural discriminator (target_id == the queried note, a link
+// whose source_id is proj-beta) so a direction swap fails.
 func TestMemoryLinks_InFindsInboundReferences(t *testing.T) {
 	vault := buildIndexedTestVault(t)
 	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
 		"--in", "--vault", vault, "--json")
 	require.NoError(t, err)
-	assert.Contains(t, out.String(), "proj-beta",
-		"--in must surface the backlink beta -> alpha")
+
+	var env linksInEnvelope
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	assert.Equal(t, "concept-alpha", env.Result.TargetID,
+		"--in envelope's target_id must be the queried note")
+	var found bool
+	for _, l := range env.Result.Links {
+		if l.SourceID == "proj-beta" {
+			found = true
+		}
+	}
+	assert.True(t, found, "--in must surface a backlink whose source_id is proj-beta")
 }
 
-// memory links with no direction flag defaults to --both: it runs out then in,
-// so both directions appear. Default must not be empty.
+// memory links with no direction flag defaults to --both: the WHOLE stdout
+// must unmarshal as ONE envelope carrying both an "out" and an "in" payload,
+// with out before in. Two concatenated envelopes (invalid JSON) must fail.
 func TestMemoryLinks_DefaultBothShowsBothDirections(t *testing.T) {
 	vault := buildIndexedTestVault(t)
 	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
 		"--vault", vault, "--json")
 	require.NoError(t, err)
-	// Both directions reference proj-beta in this vault; the contract we lock
-	// is that default produces two JSON envelopes (out + in), not zero.
-	body := out.String()
-	assert.GreaterOrEqual(t, strings.Count(body, "\"status\""), 2,
-		"default --both must emit both an outbound and an inbound envelope")
-	assert.Contains(t, body, "proj-beta")
+
+	body := out.Bytes()
+	// The whole stdout must be exactly ONE JSON value — two concatenated
+	// envelopes would error here.
+	require.True(t, json.Valid(body), "default --both must emit a single valid JSON envelope")
+	var env linksBothEnvelope
+	require.NoError(t, json.Unmarshal(body, &env))
+	assert.Equal(t, "ok", env.Status)
+
+	// out direction: source_id is the queried note, link points at proj-beta.
+	assert.Equal(t, "concept-alpha", env.Result.Out.SourceID)
+	var haveOut bool
+	for _, l := range env.Result.Out.Links {
+		if l.TargetID != nil && *l.TargetID == "proj-beta" {
+			haveOut = true
+		}
+	}
+	assert.True(t, haveOut, "combined envelope must carry the outbound edge to proj-beta")
+
+	// in direction: target_id is the queried note, link comes from proj-beta.
+	assert.Equal(t, "concept-alpha", env.Result.In.TargetID)
+	var haveIn bool
+	for _, l := range env.Result.In.Links {
+		if l.SourceID == "proj-beta" {
+			haveIn = true
+		}
+	}
+	assert.True(t, haveIn, "combined envelope must carry the inbound backlink from proj-beta")
+
+	// Pin out-then-in key order in the serialized payload.
+	outIdx := strings.Index(out.String(), "\"out\"")
+	inIdx := strings.Index(out.String(), "\"in\"")
+	require.NotEqual(t, -1, outIdx)
+	require.NotEqual(t, -1, inIdx)
+	assert.Less(t, outIdx, inIdx, "combined payload must serialize out before in")
 }
 
-// memory links --both explicitly behaves like the default.
+// memory links --both explicitly behaves like the default: ONE envelope with
+// both directions.
 func TestMemoryLinks_BothFlagShowsBothDirections(t *testing.T) {
 	vault := buildIndexedTestVault(t)
 	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
 		"--both", "--vault", vault, "--json")
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, strings.Count(out.String(), "\"status\""), 2)
+
+	body := out.Bytes()
+	require.True(t, json.Valid(body), "--both must emit a single valid JSON envelope")
+	var env linksBothEnvelope
+	require.NoError(t, json.Unmarshal(body, &env))
+	assert.Equal(t, "concept-alpha", env.Result.Out.SourceID)
+	assert.Equal(t, "concept-alpha", env.Result.In.TargetID)
 }
 
 // memory links without an argument is a usage error.
@@ -60,6 +172,63 @@ func TestMemoryLinks_MissingArgErrors(t *testing.T) {
 	_, _, err := runRootCmd(t, "memory", "links", "--vault", vault)
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "usage")
+}
+
+// memory links --out --in is rejected: the direction flags are mutually
+// exclusive (M3). Cobra errors before RunE runs.
+func TestMemoryLinks_OutAndInMutuallyExclusive(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	_, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--out", "--in", "--vault", vault)
+	require.Error(t, err)
+	// Cobra's MarkFlagsMutuallyExclusive emits: "if any flags in the group
+	// [out in both] are set none of the others can be ...".
+	assert.Contains(t, err.Error(), "none of the others can be")
+	assert.Contains(t, err.Error(), "out")
+	assert.Contains(t, err.Error(), "in")
+}
+
+// memory links --edge-type filters the surfaced edges. The outbound edge
+// alpha -> beta carries edge type "related" (frontmatter related_ids); filtering
+// to a non-matching type must drop it, while filtering to the matching type
+// keeps it. This guards that --edge-type is actually plumbed through.
+func TestMemoryLinks_EdgeTypeFilters(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+
+	// Discover the real edge type of the alpha -> beta outbound edge.
+	out, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--out", "--vault", vault, "--json")
+	require.NoError(t, err)
+	var env struct {
+		Result struct {
+			Links []struct {
+				TargetID *string `json:"target_id"`
+				EdgeType string  `json:"edge_type"`
+			} `json:"links"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+	var betaEdgeType string
+	for _, l := range env.Result.Links {
+		if l.TargetID != nil && *l.TargetID == "proj-beta" {
+			betaEdgeType = l.EdgeType
+		}
+	}
+	require.NotEmpty(t, betaEdgeType, "fixture must have an alpha -> beta outbound edge")
+
+	// Filtering to the matching edge type keeps the edge.
+	keepOut, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--out", "--edge-type", betaEdgeType, "--vault", vault, "--json")
+	require.NoError(t, err)
+	assert.Contains(t, keepOut.String(), "proj-beta",
+		"--edge-type matching the edge must keep it")
+
+	// Filtering to a non-matching edge type drops the edge.
+	dropOut, _, err := runRootCmd(t, "memory", "links", "concept-alpha",
+		"--out", "--edge-type", "no-such-edge-type", "--vault", vault, "--json")
+	require.NoError(t, err)
+	assert.NotContains(t, dropOut.String(), "proj-beta",
+		"--edge-type with a non-matching type must filter the edge out")
 }
 
 // memory neighbors places the target at depth 0 and a 1-hop neighbor at
@@ -151,6 +320,33 @@ func TestTopLevelLinks_HiddenFromRootListing(t *testing.T) {
 	}
 }
 
+// newDeprecatedAlias-built commands must be Hidden so they don't clutter help
+// while still resolving. Concretely: the `recall` and `context-pack`
+// subcommands under the VISIBLE `memory` parent must have Hidden==true (L3).
+func TestDeprecatedAliases_AreHidden(t *testing.T) {
+	var memoryCmd *cobra.Command
+	for _, c := range RootCmd.Commands() {
+		if c.Name() == "memory" {
+			memoryCmd = c
+			break
+		}
+	}
+	require.NotNil(t, memoryCmd, "the visible 'memory' parent must exist")
+	require.False(t, memoryCmd.Hidden, "the 'memory' parent itself must stay visible")
+
+	for _, name := range []string{"recall", "context-pack"} {
+		var sub *cobra.Command
+		for _, c := range memoryCmd.Commands() {
+			if c.Name() == name {
+				sub = c
+				break
+			}
+		}
+		require.NotNilf(t, sub, "memory %s alias must be registered", name)
+		assert.Truef(t, sub.Hidden, "memory %s is a deprecated alias and must be Hidden", name)
+	}
+}
+
 // ---- Deprecation aliases: must still run, delegate correctly, and warn. ----
 
 // links out is a hidden deprecated alias of `memory links --out`: it prints a
@@ -182,6 +378,77 @@ func TestDeprecated_LinksNeighbors_WarnsAndDelegates(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), "concept-alpha")
 	assertOneLineDeprecation(t, errOut.String(), "memory neighbors")
+}
+
+// buildLowConfidenceNeighborVault makes a vault where concept-a and concept-b
+// share a RARE tag (high TF-IDF specificity, lifted above the 1.0 threshold by
+// six decoy notes carrying a different common tag). The indexer writes a
+// LOW-confidence tag_overlap edge a→b. So:
+//   - high-confidence default (memory neighbors) DROPS concept-b
+//   - low-confidence default (links neighbors) SURFACES concept-b
+//
+// That divergence is what the M1 back-compat fix protects: the merged
+// neighbors engine must keep the alias's old low/200 defaults.
+func buildLowConfidenceNeighborVault(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".vaultmind"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".vaultmind", "config.yaml"),
+		[]byte("types:\n  concept:\n    required: [title]\n    optional: [tags]\n"), 0o644))
+	writeTestNote(t, dir, "a.md", "---\nid: concept-a\ntype: concept\ntitle: A\ntags: [rare]\n---\nBody A.\n")
+	writeTestNote(t, dir, "b.md", "---\nid: concept-b\ntype: concept\ntitle: B\ntags: [rare]\n---\nBody B.\n")
+	for i := 0; i < 6; i++ {
+		writeTestNote(t, dir, fmt.Sprintf("d%d.md", i),
+			fmt.Sprintf("---\nid: decoy-%d\ntype: concept\ntitle: D%d\ntags: [common]\n---\nBody.\n", i, i))
+	}
+	cfg, err := vault.LoadConfig(dir)
+	require.NoError(t, err)
+	dbPath := filepath.Join(dir, cfg.Index.DBPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	_, err = index.NewIndexer(dir, dbPath, cfg).Rebuild()
+	require.NoError(t, err, "indexer rebuild failed")
+	return dir
+}
+
+// The deprecated `links neighbors` alias must preserve its OLD defaults
+// (min-confidence low, max-nodes 200) even though it now delegates to the
+// merged `memory neighbors` engine whose defaults are high/50. A low-confidence
+// tag_overlap neighbor that the high default would drop must still surface (M1).
+func TestDeprecated_LinksNeighbors_PreservesLowConfidenceDefault(t *testing.T) {
+	vault := buildLowConfidenceNeighborVault(t)
+
+	// Canonical memory neighbors (high default) drops the low-confidence edge.
+	high, _, err := runRootCmd(t, "memory", "neighbors", "concept-a",
+		"--vault", vault, "--json")
+	require.NoError(t, err)
+	assert.NotContains(t, high.String(), "concept-b",
+		"memory neighbors' high default must drop the low-confidence neighbor")
+
+	// Deprecated links neighbors (low default) still surfaces it.
+	low, _, err := runRootCmd(t, "links", "neighbors", "concept-a",
+		"--vault", vault, "--json")
+	require.NoError(t, err)
+	assert.Contains(t, low.String(), "concept-b",
+		"links neighbors must keep its low-confidence default and surface the neighbor")
+	assert.Contains(t, low.String(), "tag_overlap",
+		"the surfaced edge must be the low-confidence tag_overlap edge")
+}
+
+// The links-neighbors alias preserves the old max-nodes default (200), not the
+// canonical 50, when the user does not override it.
+func TestDeprecated_LinksNeighbors_PreservesMaxNodesDefault(t *testing.T) {
+	vault := buildIndexedTestVault(t)
+	low, _, err := runRootCmd(t, "links", "neighbors", "concept-alpha",
+		"--vault", vault, "--json")
+	require.NoError(t, err)
+	var env struct {
+		Result struct {
+			MaxNodes int `json:"max_nodes"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(low.Bytes(), &env))
+	assert.Equal(t, 200, env.Result.MaxNodes,
+		"links neighbors must keep the old max-nodes default of 200")
 }
 
 // memory recall is a hidden deprecated alias of `memory neighbors`.

--- a/cmd/misc_runners_test.go
+++ b/cmd/misc_runners_test.go
@@ -197,6 +197,12 @@ func TestDoctor_SummaryFlagSuppressesLinkDetails(t *testing.T) {
 	// And the hint on how to see them is present.
 	assert.Contains(t, summary.String(), "without --summary",
 		"summary must point the user at the full output flag")
+	// Seam-3: the remedy must point at the shipped `doctor heal wikilinks`
+	// command, NOT the unshipped scripts/fix_wikilinks.py helper.
+	assert.Contains(t, summary.String(), "vaultmind doctor heal wikilinks",
+		"summary must point the user at the shipped heal command")
+	assert.NotContains(t, summary.String(), "fix_wikilinks.py",
+		"summary must NOT reference the unshipped scripts/fix_wikilinks.py")
 	// Sanity: the full output DID have the arrows.
 	assert.Contains(t, full.String(), "→ [[",
 		"full output must show per-link arrows so the test catches a regression in either direction")

--- a/cmd/remaining_runners_test.go
+++ b/cmd/remaining_runners_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/peiman/vaultmind/internal/experiment"
 	"github.com/peiman/vaultmind/internal/index"
 	"github.com/peiman/vaultmind/internal/marker"
-	"github.com/peiman/vaultmind/internal/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,26 +53,6 @@ func TestLinksNeighbors_MissingArgErrors(t *testing.T) {
 	vault := buildIndexedTestVault(t)
 	_, _, err := runRootCmd(t, "links", "neighbors", "--vault", vault)
 	require.Error(t, err)
-}
-
-// formatNeighbors renders depth-0 target and depth>0 neighbors distinctly,
-// and appends "(max reached)" only when the traversal hit its cap. The
-// visual distinction is what makes the output scannable.
-func TestFormatNeighbors_DistinguishesTargetAndMaxReached(t *testing.T) {
-	r := &query.NeighborsResult{
-		Nodes: []query.NeighborNode{
-			{ID: "t-1", Distance: 0},
-			{ID: "t-2", Distance: 1, EdgeFrom: &query.NeighborEdge{EdgeType: "related", Confidence: "high"}},
-		},
-		MaxNodesReached: true,
-	}
-	var buf bytes.Buffer
-	require.NoError(t, formatNeighbors(r, &buf))
-	out := buf.String()
-	assert.Contains(t, out, "t-1 (depth 0)")
-	assert.Contains(t, out, "t-2")
-	assert.Contains(t, out, "related")
-	assert.Contains(t, out, "(max reached)")
 }
 
 // note create without --type must fail with a clear usage error — the alt

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -2,24 +2,15 @@ package cmd
 
 import "github.com/spf13/cobra"
 
+// vaultCmd is the DEPRECATED `vault` parent. It only ever hosted `status`,
+// whose role is now the doctor health hub (`doctor --summary`). The parent is
+// hidden from the root listing; its single subcommand survives as a hidden
+// deprecated alias that delegates to the doctor summary path. Kept for ~2
+// releases.
 var vaultCmd = &cobra.Command{
-	Use:   "vault",
-	Short: "Vault operations",
-	Long: `Inspect and diagnose the vault itself — note counts, index freshness, and validation issues.
-
-Reach for vault subcommands when you need a top-level view of vault health rather
-than retrieving specific notes. Use ask, search, or note for content retrieval.
-
-SUBCOMMANDS
-
-  status   Print a cold-start summary: total notes, domain vs unstructured split,
-           type-registry size, and issue counts (errors, warnings). Accepts --json
-           for machine-readable output.
-
-EXAMPLES
-
-  vaultmind vault status --vault ./my-vault          # human-readable health summary
-  vaultmind vault status --vault ./my-vault --json   # machine-readable envelope`,
+	Use:    "vault",
+	Short:  "Deprecated: use 'doctor' / 'doctor --summary'",
+	Hidden: true,
 }
 
 func init() {

--- a/cmd/vault_status.go
+++ b/cmd/vault_status.go
@@ -1,50 +1,29 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-
 	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
-	"github.com/peiman/vaultmind/internal/cmdutil"
 	"github.com/peiman/vaultmind/internal/config/commands"
-	"github.com/peiman/vaultmind/internal/envelope"
-	"github.com/peiman/vaultmind/internal/query"
 	"github.com/spf13/cobra"
 )
 
-var vaultStatusCmd = MustNewCommand(commands.VaultStatusMetadata, runVaultStatus)
+// vault status is DEPRECATED: doctor is now the single vault-health hub, and
+// the cold-start view it produced is `doctor --summary`. This hidden alias
+// prints a one-line stderr notice and delegates to the doctor summary path
+// (forcing summaryOnly=true). It keeps its own app.vaultstatus.* flags so the
+// existing --vault/--json invocations resolve unchanged. Kept for ~2 releases.
+var vaultStatusCmd = newDeprecatedAlias(commands.VaultStatusMetadata,
+	"vaultmind: 'vault status' is deprecated; use 'doctor --summary' instead",
+	runVaultStatus)
 
 func init() {
 	vaultCmd.AddCommand(vaultStatusCmd)
 	setupCommandConfig(vaultStatusCmd)
 }
 
+// runVaultStatus resolves the alias's own vault/json flags and delegates to
+// the shared doctor health-hub engine with the summary view forced on.
 func runVaultStatus(cmd *cobra.Command, _ []string) error {
 	vaultPath := getConfigValueWithFlags[string](cmd, "vault", config.KeyAppVaultstatusVault)
-	vdb, err := cmdutil.OpenVaultDBOrWriteErr(cmd, vaultPath, "vault status")
-	if err != nil {
-		if errors.Is(err, cmdutil.ErrAlreadyWritten) {
-			return nil
-		}
-		return err
-	}
-	defer vdb.Close()
-
-	result, err := query.VaultStatus(vdb.DB, vaultPath, vdb.Config, vdb.Reg)
-	if err != nil {
-		return fmt.Errorf("vault status: %w", err)
-	}
-
-	if getConfigValueWithFlags[bool](cmd, "json", config.KeyAppVaultstatusJson) {
-		env := envelope.OK("vault status", result)
-		env.Meta.VaultPath = vaultPath
-		env.Meta.IndexHash = vdb.GetIndexHash()
-		return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
-	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(),
-		"Vault: %s\nNotes: %d (%d domain, %d unstructured)\nTypes: %d\nIssues: %d errors, %d warnings\n",
-		result.VaultPath, result.TotalFiles, result.DomainNotes, result.UnstructuredNotes,
-		len(result.Types), result.IssuesSummary.Errors, result.IssuesSummary.Warnings)
-	return err
+	jsonOut := getConfigValueWithFlags[bool](cmd, "json", config.KeyAppVaultstatusJson)
+	return runDoctorCore(cmd, vaultPath, jsonOut, true)
 }

--- a/docs/AGENT_USAGE.md
+++ b/docs/AGENT_USAGE.md
@@ -53,20 +53,20 @@ Use when you want a hit list without the context-pack overhead. Supports `--mode
 vaultmind search "judgment gap" --vault examples/ada-vault --limit 10 --json
 ```
 
-### `vaultmind memory context-pack <target-id>` — expand around a specific note
+### `vaultmind memory pack <target-id>` — expand around a specific note
 
 Use when you already know the target note and want its token-budgeted neighborhood.
 
 ```bash
-vaultmind memory context-pack arc-ask-before-assuming --vault examples/ada-vault --budget 4000 --max-items 8
+vaultmind memory pack arc-ask-before-assuming --vault examples/ada-vault --budget 4000 --max-items 8
 ```
 
-### `vaultmind memory recall <note-id>` — just the note's body
+### `vaultmind memory neighbors <note-id>` — the note's graph neighborhood with full frontmatter
 
-Use when you want one specific note's content with no expansion.
+Use when you want the enriched neighborhood (BFS to a depth) around a known note.
 
 ```bash
-vaultmind memory recall identity-who-am-i --vault examples/ada-vault
+vaultmind memory neighbors identity-who-am-i --vault examples/ada-vault
 ```
 
 ### `vaultmind note get <id>` — full note with frontmatter
@@ -81,8 +81,9 @@ vaultmind note get arc-ask-before-assuming --vault examples/ada-vault --json
 
 - **Conversational "what do I know about X?"** → `vaultmind ask` (gives you top hits + context)
 - **"Find all notes mentioning Y"** → `vaultmind search`
-- **"Read this specific note"** → `vaultmind memory recall` or `vaultmind note get`
-- **"Expand around this known target"** → `vaultmind memory context-pack`
+- **"Read this specific note"** → `vaultmind note get`
+- **"Explore the graph around a note"** → `vaultmind memory neighbors`
+- **"Expand around this known target"** → `vaultmind memory pack`
 
 ## 3. Saving
 

--- a/docs/adr/101-command-taxonomy.md
+++ b/docs/adr/101-command-taxonomy.md
@@ -1,0 +1,119 @@
+# ADR-101: Command Taxonomy — Graph Under `memory`, Doctor as the Health + Heal Hub
+
+## Status
+
+Accepted
+
+## Context
+
+The CLI's surface had grown three overlapping seams that confused agents and humans alike:
+
+1. **Graph traversal was split across two parents.** A top-level `links` command
+   (`links out` / `links in` / `links neighbors`) overlapped with `memory` (`memory recall`,
+   `memory context-pack`). `links out`/`links in` were the same query with opposite directions
+   shipped as two commands; `links neighbors` (BFS) and `memory recall` (traverse + full
+   frontmatter) did nearly the same thing under different parents. An agent reaching for "what's
+   connected to this note" had to know which of two trees to enter.
+
+2. **Vault health was split across `doctor` and `vault status`.** `doctor` diagnosed; `vault status`
+   gave the cold-start counts + per-type breakdown. The `vault` parent existed only to host `status`.
+
+3. **The diagnosis remedy pointed at vaporware.** `doctor` told users to repair broken links by running
+   an unshipped `scripts/fix_wikilinks.py`, while the actual repair logic lived under a top-level
+   `lint fix-links` — a third, unrelated parent. (`lint` collided conceptually with `task lint`
+   / `golangci-lint`, the CI tooling.)
+
+The result was three ways to ask "what's near this note", two ways to ask "is my vault healthy",
+and a fix-it instruction that named a script that does not exist.
+
+## Decision
+
+**1. Unify all graph traversal under `memory`.** The top-level `links` parent is removed.
+
+- `memory links <id> [--out|--in|--both]` — directed wikilink edges, default `--both`; `--in` =
+  backlinks. One direction-flagged command absorbs `links out` (outbound) and `links in` (inbound).
+- `memory neighbors <id> [--depth N]` — multi-hop neighborhood with full frontmatter. Merges
+  `links neighbors` (BFS) and `memory recall` (traverse + full frontmatter) into one.
+- `memory pack <id> [--budget N]` — rename of `memory context-pack` (identical behavior).
+- `memory related`, `memory summarize` — unchanged.
+
+**2. Make `doctor` the single vault-health hub.**
+
+- `doctor` — read-only diagnosis, and it now carries the per-type breakdown `vault status` had.
+- `doctor --summary` — the cold-start view (counts + per-type breakdown + errors/warnings rollup);
+  this is what `vault status` produced.
+- Repair lives under doctor: `doctor heal` applies every auto-fixable repair doctor found (today:
+  wikilinks); `doctor heal wikilinks` is the surgical form (logic moved from `lint fix-links`).
+  `heal` is the canonical verb; `fix` is a permanent cobra alias (`doctor fix`, `doctor fix wikilinks`;
+  help shows "heal (fix)"). `heal` **applies by default**; `--dry-run` previews. All `doctor heal *`
+  paths share one engine (`internal/mutation`).
+- The `vault` parent dissolves (deprecated). Top-level `lint` is removed; there is **no** top-level
+  `fix`/`heal`. `dataview lint` is a separate domain checker and stays.
+
+**3. Fix the seam-3 remedy.** `doctor`'s broken-links remedy now points at
+`vaultmind doctor heal wikilinks` instead of the unshipped `scripts/fix_wikilinks.py`.
+
+**Deprecation policy (in scope; ~2 releases).** Every removed/renamed invocation
+(`links out`/`in`/`neighbors`, `lint`, `lint fix-links`, `vault status`, `vault`, `memory recall`,
+`memory context-pack`) becomes a **hidden deprecated command** that prints a one-line stderr
+deprecation notice and delegates to the new path by calling the **same internal function**. They are
+kept for roughly two releases, then removed.
+
+**Out of scope.** No behavior changes beyond this re-wiring — the refactor is re-wiring + aliasing,
+reusing the existing `internal/query`, `internal/memory`, `internal/mutation`, and `internal/graph`
+functions, not reimplementing them.
+
+## Alternatives Considered
+
+### Alternative 1: Keep `links` as its own parent, just dedupe `recall`/`neighbors`
+
+**Pros:** Smaller diff; `links` is a familiar noun.
+
+**Why not chosen:** It leaves two graph parents. Agents still have to learn which tree holds which
+traversal, and the `links out`/`links in` two-command split for one directional query remains.
+
+### Alternative 2: Keep `lint`/`vault` parents and just retarget the remedy string
+
+**Pros:** Minimal change; fixes the vaporware remedy alone.
+
+**Why not chosen:** It preserves `vault` (a parent whose only child is `status`) and `lint` (which
+collides with the CI `task lint` mental model and hosts repair logic that belongs next to the
+diagnosis that surfaces it). Co-locating heal with doctor is the SSOT win.
+
+### Alternative 3: `fix` as the canonical verb, `heal` as the alias
+
+**Pros:** `fix` is the more common CLI verb.
+
+**Why not chosen:** `fix` collides with the `lint fix-links` and `task lint --fix` lineage we're
+moving away from, and reads as a flag-style action. `heal` is distinctive, reads as "restore the
+vault to health", and pairs cleanly with the `doctor` metaphor. `fix` stays as a permanent alias so
+muscle memory and the deprecated `lint fix-links` path still resolve.
+
+## Consequences
+
+### Positive
+
+- One place to traverse the graph (`memory`) and one place to check + repair vault health (`doctor`).
+- The fix-it instruction now names a command that exists and works.
+- Repair shares a single mutation engine, so new `doctor heal *` repairs reuse it rather than forking.
+- Smaller, more discoverable root help.
+
+### Negative
+
+- Breaking surface change for anyone scripting the old invocations until the deprecated aliases are
+  removed (~2 releases). Mitigated by hidden aliases that delegate to the same internal function.
+- Two verbs for one repair (`heal` + `fix` alias) is mild surface duplication, accepted for migration.
+
+### Neutral
+
+- Help now shows "heal (fix)"; docs, hooks, and onboarding prose reference the new forms.
+
+## References
+
+- CHANGELOG `[Unreleased]` — Added / Changed / Deprecated entries for this taxonomy.
+- ADR-001 (ultra-thin commands) and ADR-002/005 (config SSOT) — the conventions the refactor preserves.
+
+---
+
+**Decision Date:** 2026-06-07
+**Decision Makers:** VaultMind maintainer

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,6 +66,7 @@ docs/adr/
 ## Project ADR Index
 
 - [ADR-100](100-plugin-architecture.md) - Plugin/Extension Architecture (Deferred)
+- [ADR-101](101-command-taxonomy.md) - Command Taxonomy: graph under `memory`, doctor as health + heal hub (Accepted)
 
 <!-- Add new project ADRs above this line -->
 

--- a/docs/wikilink-convention.md
+++ b/docs/wikilink-convention.md
@@ -23,9 +23,9 @@ Obsidian resolves `[[target]]` by matching `target` against filenames (without `
 
 CLI commands are NOT vault notes. Use backtick code format, not wikilinks:
 
-**Correct:** The `memory recall` command traverses the graph.
+**Correct:** The `memory neighbors` command traverses the graph.
 
-**Wrong:** The `[[memory-recall|memory recall]]` command traverses the graph.
+**Wrong:** The `[[memory-neighbors|memory neighbors]]` command traverses the graph.
 
 ## Detection
 

--- a/docs/wikilink-convention.md
+++ b/docs/wikilink-convention.md
@@ -39,4 +39,4 @@ Doctor reports `Obsidian-incompatible links` with suggested fixes showing the co
 
 ## Enforcement
 
-Use `vaultmind lint --fix-links` to bulk-fix all incompatible wikilinks across the vault.
+Use `vaultmind doctor heal wikilinks` to bulk-fix all incompatible wikilinks across the vault.

--- a/internal/config/commands/doctor_config.go
+++ b/internal/config/commands/doctor_config.go
@@ -4,9 +4,19 @@ import "github.com/peiman/vaultmind/.ckeletin/pkg/config"
 
 // DoctorMetadata defines the metadata for the doctor command.
 var DoctorMetadata = config.CommandMetadata{
-	Use:          "doctor",
-	Short:        "Vault health summary",
-	Long:         "Run diagnostics on the vault index and report issues. By default prints summary counts plus per-link details (can be hundreds of lines on a noisy vault). Use --summary for counts only.",
+	Use:   "doctor",
+	Short: "Vault health hub: diagnose the vault and report issues",
+	Long: `Run read-only diagnostics on the vault and report its health.
+
+doctor is the single vault-health command. It reports note counts, the per-type
+breakdown (per-type counts, required fields, valid statuses), embedding
+readiness, hook drift, unresolved/incompatible/dead links, stale-index drift,
+and an errors/warnings rollup.
+
+By default doctor also prints per-link details, which can run to hundreds of
+lines on a noisy vault. Use --summary for the cold-start view: counts, per-type
+breakdown, and the errors/warnings rollup, with the verbose per-link detail
+lines suppressed. (--summary replaces the former 'vault status'.)`,
 	ConfigPrefix: "app.doctor",
 	FlagOverrides: map[string]string{
 		"app.doctor.vault":   "vault",

--- a/internal/config/commands/doctor_config.go
+++ b/internal/config/commands/doctor_config.go
@@ -16,7 +16,10 @@ and an errors/warnings rollup.
 By default doctor also prints per-link details, which can run to hundreds of
 lines on a noisy vault. Use --summary for the cold-start view: counts, per-type
 breakdown, and the errors/warnings rollup, with the verbose per-link detail
-lines suppressed. (--summary replaces the former 'vault status'.)`,
+lines suppressed. (--summary replaces the former 'vault status'.)
+
+To repair what doctor finds, run 'doctor heal' (all auto-fixable) or
+'doctor heal wikilinks'.`,
 	ConfigPrefix: "app.doctor",
 	FlagOverrides: map[string]string{
 		"app.doctor.vault":   "vault",

--- a/internal/config/commands/doctor_heal_config.go
+++ b/internal/config/commands/doctor_heal_config.go
@@ -1,0 +1,92 @@
+package commands
+
+import "github.com/peiman/vaultmind/.ckeletin/pkg/config"
+
+// DoctorHealMetadata defines the metadata for the `doctor heal` command.
+// heal APPLIES every auto-fixable repair doctor found (today that set is the
+// wikilink rewriter); --dry-run previews instead. The `fix` alias is wired in
+// cmd/ so `doctor fix` resolves here too.
+var DoctorHealMetadata = config.CommandMetadata{
+	Use:   "heal",
+	Short: "heal (fix): apply all auto-fixable repairs doctor found",
+	Long: `heal (fix): apply every auto-fixable repair that doctor's diagnosis can resolve.
+
+heal is the repair half of the doctor health hub. Today the auto-fixable set is
+exactly the Obsidian-incompatible wikilink rewriter, so 'doctor heal' rewrites
+[[Title]] links that won't resolve in Obsidian to the [[filename|Title]] form.
+As doctor learns to auto-fix more issues, they join this command.
+
+heal APPLIES changes by default. Pass --dry-run to preview the planned repairs
+without touching disk. (This is the inverse of the old 'lint fix-links', which
+was dry-run by default.)
+
+The 'fix' alias makes 'doctor fix' an exact synonym.
+
+SUBCOMMANDS
+
+  wikilinks   Surgically rewrite only Obsidian-incompatible wikilinks.
+
+EXAMPLES
+
+  vaultmind doctor heal --vault ./my-vault            # apply all auto-fixes
+  vaultmind doctor heal --vault ./my-vault --dry-run  # preview only
+  vaultmind doctor heal wikilinks --vault ./my-vault  # just the wikilink repair
+  vaultmind doctor fix --vault ./my-vault             # 'fix' alias`,
+	ConfigPrefix: "app.doctorheal",
+	FlagOverrides: map[string]string{
+		"app.doctorheal.vault":   "vault",
+		"app.doctorheal.json":    "json",
+		"app.doctorheal.dry_run": "dry-run",
+	},
+}
+
+// DoctorHealWikilinksMetadata defines the metadata for the
+// `doctor heal wikilinks` subcommand — the surgical wikilink repair that the
+// old `lint fix-links` performed. Applies by default; --dry-run previews.
+var DoctorHealWikilinksMetadata = config.CommandMetadata{
+	Use:   "wikilinks",
+	Short: "Rewrite Obsidian-incompatible wikilinks to [[filename|Title]]",
+	Long: `Detect [[Title]] wikilinks that won't resolve in Obsidian and rewrite them to
+the [[filename|Title]] form Obsidian requires. Scans every markdown file in the
+vault, reports each rewrite as "old -> new", and prints a summary of files
+scanned, files changed, and links fixed.
+
+Applies changes by default; pass --dry-run to preview without writing. The
+'fix' alias makes 'doctor fix wikilinks' an exact synonym.
+
+EXAMPLES
+
+  vaultmind doctor heal wikilinks --vault ./my-vault            # apply the rewrites
+  vaultmind doctor heal wikilinks --vault ./my-vault --dry-run  # preview only
+  vaultmind doctor heal wikilinks --json                        # machine-readable`,
+	ConfigPrefix: "app.doctorhealwikilinks",
+	FlagOverrides: map[string]string{
+		"app.doctorhealwikilinks.vault":   "vault",
+		"app.doctorhealwikilinks.json":    "json",
+		"app.doctorhealwikilinks.dry_run": "dry-run",
+	},
+}
+
+// DoctorHealOptions returns configuration options for `doctor heal`.
+func DoctorHealOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.doctorheal.vault", DefaultValue: ".", Description: "Path to vault root", Type: "string"},
+		{Key: "app.doctorheal.json", DefaultValue: false, Description: "Output in JSON format", Type: "bool"},
+		{Key: "app.doctorheal.dry_run", DefaultValue: false, Description: "Preview repairs without writing (default applies)", Type: "bool"},
+	}
+}
+
+// DoctorHealWikilinksOptions returns configuration options for
+// `doctor heal wikilinks`.
+func DoctorHealWikilinksOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.doctorhealwikilinks.vault", DefaultValue: ".", Description: "Path to vault root", Type: "string"},
+		{Key: "app.doctorhealwikilinks.json", DefaultValue: false, Description: "Output in JSON format", Type: "bool"},
+		{Key: "app.doctorhealwikilinks.dry_run", DefaultValue: false, Description: "Preview repairs without writing (default applies)", Type: "bool"},
+	}
+}
+
+func init() {
+	config.RegisterOptionsProvider(DoctorHealOptions)
+	config.RegisterOptionsProvider(DoctorHealWikilinksOptions)
+}

--- a/internal/config/commands/memory_config.go
+++ b/internal/config/commands/memory_config.go
@@ -118,8 +118,8 @@ WHEN TO USE
 
   Use related for a flat list of directly linked notes when you already know
   the target. For a depth-traversal that follows edges transitively, use
-  "memory recall". For a token-budgeted agent payload, use
-  "memory context-pack".`,
+  "memory neighbors". For a token-budgeted agent payload, use
+  "memory pack".`,
 	ConfigPrefix: "app.memoryrelated",
 	FlagOverrides: map[string]string{
 		"app.memoryrelated.vault": "vault",

--- a/internal/config/commands/memory_config.go
+++ b/internal/config/commands/memory_config.go
@@ -238,6 +238,202 @@ func MemoryContextPackOptions() []config.ConfigOption {
 	}
 }
 
+// MemoryLinksMetadata defines metadata for the memory links command.
+// It unifies directed wikilink-edge queries: outbound (--out), inbound
+// (--in, backlinks), or both (--both, default). Absorbs the old top-level
+// `links out` and `links in` commands into one direction-flagged command.
+var MemoryLinksMetadata = config.CommandMetadata{
+	Use:   "links <id-or-path>",
+	Short: "List directed wikilink edges for a note (outbound, inbound, or both)",
+	Long: `List the directed link edges of a note. By default shows both directions;
+use --out for outbound edges only or --in for inbound edges (backlinks) only.
+
+Outbound edges are the notes this note references, cites, or extends.
+Inbound edges (backlinks) are the notes that reference this one — useful for
+finding callers, dependents, or consumers of a concept.
+
+Each edge includes its type (e.g., "cites", "extends", "references") and a
+confidence label (high, medium, low) reflecting how strongly it was detected.
+
+FLAGS
+
+  --out           Show only outbound edges (notes this note references).
+  --in            Show only inbound edges (backlinks: notes that reference this one).
+  --both          Show both directions (default). Mutually exclusive with --out/--in.
+  --edge-type     Filter to a specific edge type (e.g., "cites"). Omit to show all types.
+  --json          Output in machine-readable JSON.
+  --vault         Path to vault root (default: current directory).
+
+EXAMPLES
+
+  vaultmind memory links concept-spreading-activation
+      Show both inbound and outbound edges for the note.
+
+  vaultmind memory links concept-spreading-activation --out
+      Show only outbound edges (what the note references).
+
+  vaultmind memory links concept-spreading-activation --in
+      Show only backlinks (what references the note).
+
+  vaultmind memory links concept-spreading-activation --out --json
+      Machine-readable output; pipe to jq or an agent tool.`,
+	ConfigPrefix: "app.memorylinks",
+	FlagOverrides: map[string]string{
+		"app.memorylinks.vault":     "vault",
+		"app.memorylinks.json":      "json",
+		"app.memorylinks.edge_type": "edge-type",
+		"app.memorylinks.out":       "out",
+		"app.memorylinks.in":        "in",
+		"app.memorylinks.both":      "both",
+	},
+}
+
+// MemoryNeighborsMetadata defines metadata for the memory neighbors command.
+// It merges the old `links neighbors` (BFS traversal) and `memory recall`
+// (full-frontmatter enrichment) into one: BFS to a depth limit, returning
+// every reachable node with its full frontmatter.
+var MemoryNeighborsMetadata = config.CommandMetadata{
+	Use:   "neighbors <id-or-path>",
+	Short: "Traverse the graph from a note (BFS) and return neighbors with full frontmatter",
+	Long: `Perform a breadth-first traversal starting from a target note and return all
+neighbors within the specified depth. Every node carries its full frontmatter,
+so callers get a rich, typed neighborhood without follow-up note-get calls.
+
+BFS (breadth-first search) means depth=1 returns only direct neighbors,
+depth=2 includes their neighbors as well, and so on.
+
+CONFIDENCE LEVELS
+
+  Edges carry a confidence level (low, medium, high). --min-confidence sets
+  the floor: only edges at or above that level are traversed. The default is
+  "high" so traversal stays precise; lower it to include weaker, LLM-inferred
+  relationships.
+
+FLAGS
+
+  --depth <n>            Maximum traversal depth. Default: 1.
+  --max-nodes <n>        Safety limit on result size. Default: 50.
+  --min-confidence <l>   Minimum edge confidence (low, medium, high). Default: high.
+  --vault <path>         Path to vault root. Default: ".".
+  --json                 Output as a JSON envelope instead of text.
+
+EXAMPLES
+
+  vaultmind memory neighbors concept-spreading-activation
+      # direct neighbors (depth 1) at high confidence, with full frontmatter
+
+  vaultmind memory neighbors concept-spreading-activation --depth 2 --max-nodes 20
+      # up to depth 2, capped at 20 nodes
+
+  vaultmind memory neighbors concept-spreading-activation --min-confidence medium --json
+      # include medium-confidence edges, machine-readable output
+
+WHEN TO USE
+
+  Use neighbors when you want the full enriched neighborhood around a known
+  note. For a flat list of edge-typed relations, use "memory related". For a
+  token-budgeted payload ready for agent consumption, use "memory pack".`,
+	ConfigPrefix: "app.memoryneighbors",
+	FlagOverrides: map[string]string{
+		"app.memoryneighbors.vault":          "vault",
+		"app.memoryneighbors.json":           "json",
+		"app.memoryneighbors.depth":          "depth",
+		"app.memoryneighbors.min_confidence": "min-confidence",
+		"app.memoryneighbors.max_nodes":      "max-nodes",
+	},
+}
+
+// MemoryPackMetadata defines metadata for the memory pack command.
+// It is a rename of the old `memory context-pack` (identical behavior).
+var MemoryPackMetadata = config.CommandMetadata{
+	Use:   "pack <id-or-path>",
+	Short: "Pack the target note and ranked context items within a token budget",
+	Long: `Load a target note, then fill a token budget with its ranked neighbors,
+stopping when the budget is exhausted. Designed to produce an agent-ready
+payload: the target is always included, followed by context items in
+priority order (explicit relations first, then inferred edges).
+
+TOKEN BUDGET
+
+  The budget is a soft limit on tokens. Context items are added one by one
+  in ranked order; as soon as adding the next item would exceed the budget,
+  it is skipped and the "truncated" field in the output is set to true. The
+  target note itself is always included regardless of its size.
+
+  Use --slim to reduce the token footprint of context item frontmatter when
+  the budget is tight.
+
+FLAGS
+
+  --budget <tokens>   Token budget for context assembly. Default: 4096.
+  --depth <n>         BFS traversal depth for candidate context items. Default: 1.
+  --max-items <n>     Max context items. 0 means no limit beyond the budget. Default: 0.
+  --slim              Reduce each context item's frontmatter to {type, title, status}.
+  --vault <path>      Path to vault root. Default: ".".
+  --json              Output as a JSON envelope instead of text.
+
+EXAMPLES
+
+  vaultmind memory pack concept-spreading-activation
+      # default 4096-token pack around the target
+
+  vaultmind memory pack concept-spreading-activation --budget 2000 --slim
+      # tight budget, slim frontmatter to fit more items
+
+  vaultmind memory pack concept-spreading-activation --max-items 8 --slim --json
+      # cap at 8 items, slim, machine-readable (preferred for agent hooks)
+
+WHEN TO USE
+
+  Use pack when an agent needs a self-contained, token-bounded working context
+  around a topic. For a full neighborhood traversal without a budget, use
+  "memory neighbors". For a flat list of related notes, use "memory related".`,
+	ConfigPrefix: "app.memorypack",
+	FlagOverrides: map[string]string{
+		"app.memorypack.vault":     "vault",
+		"app.memorypack.json":      "json",
+		"app.memorypack.budget":    "budget",
+		"app.memorypack.depth":     "depth",
+		"app.memorypack.max_items": "max-items",
+		"app.memorypack.slim":      "slim",
+	},
+}
+
+// MemoryLinksOptions returns config options for memory links.
+func MemoryLinksOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.memorylinks.vault", DefaultValue: ".", Description: "Path to vault root", Type: "string"},
+		{Key: "app.memorylinks.json", DefaultValue: false, Description: "Output in JSON format", Type: "bool"},
+		{Key: "app.memorylinks.edge_type", DefaultValue: "", Description: "Filter by edge type", Type: "string"},
+		{Key: "app.memorylinks.out", DefaultValue: false, Description: "Show only outbound edges", Type: "bool"},
+		{Key: "app.memorylinks.in", DefaultValue: false, Description: "Show only inbound edges (backlinks)", Type: "bool"},
+		{Key: "app.memorylinks.both", DefaultValue: false, Description: "Show both inbound and outbound edges (default)", Type: "bool"},
+	}
+}
+
+// MemoryNeighborsOptions returns config options for memory neighbors.
+func MemoryNeighborsOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.memoryneighbors.vault", DefaultValue: ".", Description: "Path to vault root", Type: "string"},
+		{Key: "app.memoryneighbors.json", DefaultValue: false, Description: "Output in JSON format", Type: "bool"},
+		{Key: "app.memoryneighbors.depth", DefaultValue: 1, Description: "Maximum traversal depth", Type: "int"},
+		{Key: "app.memoryneighbors.min_confidence", DefaultValue: "high", Description: "Minimum edge confidence (low, medium, high)", Type: "string"},
+		{Key: "app.memoryneighbors.max_nodes", DefaultValue: 50, Description: "Maximum nodes to return", Type: "int"},
+	}
+}
+
+// MemoryPackOptions returns config options for memory pack.
+func MemoryPackOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.memorypack.vault", DefaultValue: ".", Description: "Path to vault root", Type: "string"},
+		{Key: "app.memorypack.json", DefaultValue: false, Description: "Output in JSON format", Type: "bool"},
+		{Key: "app.memorypack.budget", DefaultValue: 4096, Description: "Token budget", Type: "int"},
+		{Key: "app.memorypack.depth", DefaultValue: 1, Description: "BFS traversal depth (1 = direct neighbors only)", Type: "int"},
+		{Key: "app.memorypack.max_items", DefaultValue: 0, Description: "Max context items (0 = unlimited)", Type: "int"},
+		{Key: "app.memorypack.slim", DefaultValue: false, Description: "Slim frontmatter (type, title, status only)", Type: "bool"},
+	}
+}
+
 // MemorySummarizeMetadata defines metadata for the memory summarize command.
 var MemorySummarizeMetadata = config.CommandMetadata{
 	Use:          "summarize [id1 id2 ...]",
@@ -269,4 +465,7 @@ func init() {
 	config.RegisterOptionsProvider(MemoryRelatedOptions)
 	config.RegisterOptionsProvider(MemoryContextPackOptions)
 	config.RegisterOptionsProvider(MemorySummarizeOptions)
+	config.RegisterOptionsProvider(MemoryLinksOptions)
+	config.RegisterOptionsProvider(MemoryNeighborsOptions)
+	config.RegisterOptionsProvider(MemoryPackOptions)
 }

--- a/internal/query/doctor.go
+++ b/internal/query/doctor.go
@@ -20,8 +20,14 @@ import (
 // (`doctor`) both surface them. They are populated by the cmd layer (which
 // holds the vault config + schema registry) via the shared status.go helpers —
 // the same place HookDrift is populated — so query.Doctor's signature stays
-// stable. Both are omitempty so existing JSON consumers and the query-layer
-// tests that call Doctor without a config see no extra noise.
+// stable.
+//
+// IssuesSummary is a POINTER with omitempty so the unmeasured state (a raw
+// query.Doctor call with no schema registry — e.g. the query-layer tests) omits
+// the field entirely. The earlier non-pointer struct always serialized a
+// false-zero {errors:0,warnings:0}, indistinguishable from a measured-healthy
+// vault. nil now means "validation not run"; a non-nil &{0,0} means "ran, found
+// nothing". Types likewise stays omitempty (empty map => omitted).
 type DoctorResult struct {
 	VaultPath         string                    `json:"vault_path"`
 	TotalFiles        int                       `json:"total_files"`
@@ -30,7 +36,7 @@ type DoctorResult struct {
 	IndexStatus       string                    `json:"index_status"`
 	Embeddings        *DoctorEmbeddings         `json:"embeddings,omitempty"`
 	Types             map[string]StatusTypeInfo `json:"types,omitempty"`
-	IssuesSummary     StatusIssuesSummary       `json:"issues_summary"`
+	IssuesSummary     *StatusIssuesSummary      `json:"issues_summary,omitempty"`
 	Issues            DoctorIssues              `json:"issues"`
 }
 

--- a/internal/query/doctor.go
+++ b/internal/query/doctor.go
@@ -13,14 +13,25 @@ import (
 )
 
 // DoctorResult is the JSON-serializable output of the doctor command.
+//
+// Types and IssuesSummary carry the per-type breakdown and errors/warnings
+// rollup that `vault status` used to produce. doctor is now the single health
+// hub, so the cold-start view (`doctor --summary`) and the read-only diagnosis
+// (`doctor`) both surface them. They are populated by the cmd layer (which
+// holds the vault config + schema registry) via the shared status.go helpers —
+// the same place HookDrift is populated — so query.Doctor's signature stays
+// stable. Both are omitempty so existing JSON consumers and the query-layer
+// tests that call Doctor without a config see no extra noise.
 type DoctorResult struct {
-	VaultPath         string            `json:"vault_path"`
-	TotalFiles        int               `json:"total_files"`
-	DomainNotes       int               `json:"domain_notes"`
-	UnstructuredNotes int               `json:"unstructured_notes"`
-	IndexStatus       string            `json:"index_status"`
-	Embeddings        *DoctorEmbeddings `json:"embeddings,omitempty"`
-	Issues            DoctorIssues      `json:"issues"`
+	VaultPath         string                    `json:"vault_path"`
+	TotalFiles        int                       `json:"total_files"`
+	DomainNotes       int                       `json:"domain_notes"`
+	UnstructuredNotes int                       `json:"unstructured_notes"`
+	IndexStatus       string                    `json:"index_status"`
+	Embeddings        *DoctorEmbeddings         `json:"embeddings,omitempty"`
+	Types             map[string]StatusTypeInfo `json:"types,omitempty"`
+	IssuesSummary     StatusIssuesSummary       `json:"issues_summary"`
+	Issues            DoctorIssues              `json:"issues"`
 }
 
 // DoctorEmbeddings reports the vault's semantic-retrieval readiness. Surfaces

--- a/internal/query/doctor_test.go
+++ b/internal/query/doctor_test.go
@@ -1,6 +1,7 @@
 package query_test
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -32,6 +33,25 @@ func TestDoctor_ReturnsVaultSummary(t *testing.T) {
 	assert.Greater(t, result.DomainNotes, 0)
 	assert.GreaterOrEqual(t, result.UnstructuredNotes, 0)
 	assert.Equal(t, result.TotalFiles, result.DomainNotes+result.UnstructuredNotes)
+}
+
+// A raw query.Doctor result (no cmd layer, so IssuesSummary stays nil) must
+// OMIT issues_summary from its JSON — not emit a false-zero
+// {errors:0,warnings:0} that's indistinguishable from a measured-healthy
+// vault. The cmd path (doctor --summary) populates it; the omission here is the
+// invariant H3 locks down.
+func TestDoctor_RawResultOmitsIssuesSummary(t *testing.T) {
+	db := buildIndexedDB(t)
+
+	result, err := query.Doctor(db, testVaultPath, nil)
+	require.NoError(t, err)
+	assert.Nil(t, result.IssuesSummary,
+		"raw query.Doctor must leave IssuesSummary unmeasured (nil)")
+
+	raw, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "issues_summary",
+		"unmeasured issues_summary must be omitted from the JSON, not false-zeroed")
 }
 
 func TestDoctor_ReportsUnresolvedLinks(t *testing.T) {

--- a/internal/query/links.go
+++ b/internal/query/links.go
@@ -13,56 +13,139 @@ import (
 // LinksConfig holds parameters for links out/in operations.
 type LinksConfig struct {
 	Input      string
-	Direction  string // "out" or "in"
+	Direction  string // "out", "in", or "both"
 	EdgeType   string
 	JSONOutput bool
 	VaultPath  string
 	IndexHash  string
 }
 
-// RunLinks executes the links out or links in logic.
-func RunLinks(db *index.DB, cfg LinksConfig, w io.Writer) error {
+// OutResult is the JSON-serializable payload for an outbound-links query.
+// SourceID is the queried note; Links are the edges leaving it.
+type OutResult struct {
+	SourceID string          `json:"source_id"`
+	Links    []graph.OutLink `json:"links"`
+}
+
+// InResult is the JSON-serializable payload for an inbound-links (backlinks)
+// query. TargetID is the queried note; Links are the edges pointing at it.
+type InResult struct {
+	TargetID string         `json:"target_id"`
+	Links    []graph.InLink `json:"links"`
+}
+
+// BothResult is the combined payload for a `--both` query: it carries the
+// outbound and inbound directions in ONE structure so the cmd layer can wrap
+// it in a single envelope (out before in) instead of emitting two concatenated
+// envelopes (invalid JSON). The `in_links` tag keeps the inbound links array
+// distinguishable from the outbound one when both are decoded together.
+type BothResult struct {
+	Out struct {
+		SourceID string          `json:"source_id"`
+		Links    []graph.OutLink `json:"links"`
+	} `json:"out"`
+	In struct {
+		TargetID string         `json:"target_id"`
+		Links    []graph.InLink `json:"in_links"`
+	} `json:"in"`
+}
+
+// resolveNoteID resolves cfg.Input to a single note ID. On a resolution
+// failure it returns a non-nil envelope error payload that the caller should
+// render (JSON) or surface as a Go error (human) — never both.
+func resolveNoteID(db *index.DB, cfg LinksConfig) (string, error) {
 	resolver := graph.NewResolver(db)
 	resolved, err := resolver.Resolve(cfg.Input)
 	if err != nil {
-		return fmt.Errorf("resolving: %w", err)
+		return "", fmt.Errorf("resolving: %w", err)
 	}
 	if !resolved.Resolved || resolved.Ambiguous {
+		return "", fmt.Errorf("could not resolve %q unambiguously", cfg.Input)
+	}
+	return resolved.Matches[0].ID, nil
+}
+
+// CollectOut returns the outbound-links payload for noteID WITHOUT rendering.
+// Split from rendering so the cmd layer can aggregate directions into one
+// envelope for the `--both` JSON path.
+func CollectOut(db *index.DB, noteID, edgeType string) (OutResult, error) {
+	links, err := graph.LinksOut(db, noteID, edgeType)
+	if err != nil {
+		return OutResult{}, fmt.Errorf("querying links: %w", err)
+	}
+	return OutResult{SourceID: noteID, Links: links}, nil
+}
+
+// CollectIn returns the inbound-links (backlinks) payload for noteID WITHOUT
+// rendering.
+func CollectIn(db *index.DB, noteID, edgeType string) (InResult, error) {
+	links, err := graph.LinksIn(db, noteID, edgeType)
+	if err != nil {
+		return InResult{}, fmt.Errorf("querying links: %w", err)
+	}
+	return InResult{TargetID: noteID, Links: links}, nil
+}
+
+// CollectBoth resolves cfg.Input and returns the combined out+in payload
+// WITHOUT rendering. Used by the cmd layer to build a single `--both` envelope.
+func CollectBoth(db *index.DB, cfg LinksConfig) (BothResult, string, error) {
+	var both BothResult
+	noteID, err := resolveNoteID(db, cfg)
+	if err != nil {
+		return both, "", err
+	}
+	out, err := CollectOut(db, noteID, cfg.EdgeType)
+	if err != nil {
+		return both, noteID, err
+	}
+	in, err := CollectIn(db, noteID, cfg.EdgeType)
+	if err != nil {
+		return both, noteID, err
+	}
+	both.Out.SourceID = out.SourceID
+	both.Out.Links = out.Links
+	both.In.TargetID = in.TargetID
+	both.In.Links = in.Links
+	return both, noteID, nil
+}
+
+// RunLinks executes a single-direction ("out" or "in") links query and renders
+// it to w. The `--both` path is handled by the cmd layer via CollectBoth so it
+// can emit ONE envelope rather than two concatenated ones.
+func RunLinks(db *index.DB, cfg LinksConfig, w io.Writer) error {
+	noteID, err := resolveNoteID(db, cfg)
+	if err != nil {
 		if cfg.JSONOutput {
 			return json.NewEncoder(w).Encode(
 				envelope.Error("links "+cfg.Direction, "resolution_failed",
 					fmt.Sprintf("could not resolve %q unambiguously", cfg.Input), ""))
 		}
-		return fmt.Errorf("could not resolve %q unambiguously", cfg.Input)
+		return err
 	}
 
-	noteID := resolved.Matches[0].ID
 	cmdName := "links " + cfg.Direction
-
 	if cfg.Direction == "out" {
-		return runLinksOut(db, noteID, cfg, cmdName, w)
+		out, err := CollectOut(db, noteID, cfg.EdgeType)
+		if err != nil {
+			return err
+		}
+		return renderOut(out, cfg, cmdName, w)
 	}
-	return runLinksIn(db, noteID, cfg, cmdName, w)
+	in, err := CollectIn(db, noteID, cfg.EdgeType)
+	if err != nil {
+		return err
+	}
+	return renderIn(in, cfg, cmdName, w)
 }
 
-func runLinksOut(db *index.DB, noteID string, cfg LinksConfig, cmdName string, w io.Writer) error {
-	links, err := graph.LinksOut(db, noteID, cfg.EdgeType)
-	if err != nil {
-		return fmt.Errorf("querying links: %w", err)
-	}
-
+func renderOut(out OutResult, cfg LinksConfig, cmdName string, w io.Writer) error {
 	if cfg.JSONOutput {
-		type outResult struct {
-			SourceID string          `json:"source_id"`
-			Links    []graph.OutLink `json:"links"`
-		}
-		env := envelope.OK(cmdName, outResult{SourceID: noteID, Links: links})
+		env := envelope.OK(cmdName, out)
 		env.Meta.VaultPath = cfg.VaultPath
 		env.Meta.IndexHash = cfg.IndexHash
 		return json.NewEncoder(w).Encode(env)
 	}
-
-	for _, l := range links {
+	for _, l := range out.Links {
 		id := l.TargetRaw
 		if l.TargetID != nil {
 			id = *l.TargetID
@@ -74,24 +157,14 @@ func runLinksOut(db *index.DB, noteID string, cfg LinksConfig, cmdName string, w
 	return nil
 }
 
-func runLinksIn(db *index.DB, noteID string, cfg LinksConfig, cmdName string, w io.Writer) error {
-	links, err := graph.LinksIn(db, noteID, cfg.EdgeType)
-	if err != nil {
-		return fmt.Errorf("querying links: %w", err)
-	}
-
+func renderIn(in InResult, cfg LinksConfig, cmdName string, w io.Writer) error {
 	if cfg.JSONOutput {
-		type inResult struct {
-			TargetID string         `json:"target_id"`
-			Links    []graph.InLink `json:"links"`
-		}
-		env := envelope.OK(cmdName, inResult{TargetID: noteID, Links: links})
+		env := envelope.OK(cmdName, in)
 		env.Meta.VaultPath = cfg.VaultPath
 		env.Meta.IndexHash = cfg.IndexHash
 		return json.NewEncoder(w).Encode(env)
 	}
-
-	for _, l := range links {
+	for _, l := range in.Links {
 		if _, err := fmt.Fprintf(w, "%-20s %-20s %s\n", l.SourceID, l.EdgeType, l.Confidence); err != nil {
 			return err
 		}

--- a/internal/query/links.go
+++ b/internal/query/links.go
@@ -37,8 +37,9 @@ type InResult struct {
 // BothResult is the combined payload for a `--both` query: it carries the
 // outbound and inbound directions in ONE structure so the cmd layer can wrap
 // it in a single envelope (out before in) instead of emitting two concatenated
-// envelopes (invalid JSON). The `in_links` tag keeps the inbound links array
-// distinguishable from the outbound one when both are decoded together.
+// envelopes (invalid JSON). Inbound links use the same "links" key as the
+// standalone --in payload; the object nesting (result.in vs result.out)
+// already disambiguates direction.
 type BothResult struct {
 	Out struct {
 		SourceID string          `json:"source_id"`
@@ -46,7 +47,7 @@ type BothResult struct {
 	} `json:"out"`
 	In struct {
 		TargetID string         `json:"target_id"`
-		Links    []graph.InLink `json:"in_links"`
+		Links    []graph.InLink `json:"links"`
 	} `json:"in"`
 }
 

--- a/internal/query/links_collect_test.go
+++ b/internal/query/links_collect_test.go
@@ -1,0 +1,220 @@
+package query_test
+
+// links_collect_test.go — behavior-focused tests for CollectOut, CollectIn,
+// CollectBoth, and the renderOut/renderIn human-output branches in links.go.
+//
+// These tests target the gap identified in the patch-coverage gate run (75.27%).
+// CollectBoth was at 0%; CollectOut/CollectIn error paths at 75%; renderOut/renderIn
+// JSON paths were already covered — these cover the complementary branches.
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CollectBoth combines outbound and inbound links for a single note into one
+// result without rendering. The cmd layer uses this to emit ONE valid JSON
+// envelope for --both instead of two concatenated envelopes (invalid JSON).
+// This test verifies structural correctness and that out comes before in in the
+// serialized form.
+func TestCollectBoth_ReturnsCombinedDirections(t *testing.T) {
+	db, dir := smallIndexedVault(t)
+	cfg := query.LinksConfig{
+		Input:     "concept-alpha",
+		VaultPath: dir,
+	}
+
+	both, noteID, err := query.CollectBoth(db, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "concept-alpha", noteID,
+		"CollectBoth must return the resolved noteID so callers can use it for logging")
+
+	// out side: source_id is the queried note; it must have a link to proj-beta
+	assert.Equal(t, "concept-alpha", both.Out.SourceID,
+		"combined result's out.source_id must be the queried note")
+	var foundOut bool
+	for _, l := range both.Out.Links {
+		if l.TargetID != nil && *l.TargetID == "proj-beta" {
+			foundOut = true
+		}
+	}
+	assert.True(t, foundOut, "out direction must include the alpha→beta outbound link")
+
+	// in side: target_id is the queried note; beta must reference it back
+	assert.Equal(t, "concept-alpha", both.In.TargetID,
+		"combined result's in.target_id must be the queried note")
+	var foundIn bool
+	for _, l := range both.In.Links {
+		if l.SourceID == "proj-beta" {
+			foundIn = true
+		}
+	}
+	assert.True(t, foundIn, "in direction must surface the beta→alpha inbound link")
+}
+
+// CollectBoth serialized to JSON must have "out" before "in" in the payload —
+// the ordering is pinned by the struct field order in BothResult.
+func TestCollectBoth_JSONKeyOrderIsOutBeforeIn(t *testing.T) {
+	db, dir := smallIndexedVault(t)
+	cfg := query.LinksConfig{Input: "concept-alpha", VaultPath: dir}
+
+	both, _, err := query.CollectBoth(db, cfg)
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(both)
+	require.NoError(t, err)
+	outIdx := bytes.Index(raw, []byte(`"out"`))
+	inIdx := bytes.Index(raw, []byte(`"in"`))
+	require.NotEqual(t, -1, outIdx, "serialized BothResult must contain \"out\" key")
+	require.NotEqual(t, -1, inIdx, "serialized BothResult must contain \"in\" key")
+	assert.Less(t, outIdx, inIdx, "\"out\" key must appear before \"in\" in the serialized payload")
+}
+
+// CollectBoth with an unresolvable input returns an error — callers must not
+// silently get empty data.
+func TestCollectBoth_UnresolvableInputErrors(t *testing.T) {
+	db, dir := smallIndexedVault(t)
+	cfg := query.LinksConfig{Input: "no-such-note", VaultPath: dir}
+
+	_, _, err := query.CollectBoth(db, cfg)
+	require.Error(t, err, "CollectBoth must propagate resolution errors")
+}
+
+// CollectOut returns the outbound-links payload without rendering. The caller
+// (cmd layer or the CollectBoth aggregator) can then wrap it in any envelope.
+func TestCollectOut_ReturnsOutboundLinks(t *testing.T) {
+	db, _ := smallIndexedVault(t)
+
+	out, err := query.CollectOut(db, "concept-alpha", "")
+	require.NoError(t, err)
+	assert.Equal(t, "concept-alpha", out.SourceID)
+
+	var found bool
+	for _, l := range out.Links {
+		if l.TargetID != nil && *l.TargetID == "proj-beta" {
+			found = true
+		}
+	}
+	assert.True(t, found, "CollectOut must include the alpha→beta outbound link")
+}
+
+// CollectIn returns the inbound-links payload without rendering. Alpha is
+// referenced by beta via both wikilink and related_ids.
+func TestCollectIn_ReturnsInboundLinks(t *testing.T) {
+	db, _ := smallIndexedVault(t)
+
+	in, err := query.CollectIn(db, "concept-alpha", "")
+	require.NoError(t, err)
+	assert.Equal(t, "concept-alpha", in.TargetID)
+
+	var found bool
+	for _, l := range in.Links {
+		if l.SourceID == "proj-beta" {
+			found = true
+		}
+	}
+	assert.True(t, found, "CollectIn must surface the beta→alpha inbound link")
+}
+
+// CollectOut/CollectIn with an edge-type filter: a non-matching filter must
+// return an empty links slice, not an error — empty results are valid.
+func TestCollectOut_EdgeTypeFilterDropsNonMatchingLinks(t *testing.T) {
+	db, _ := smallIndexedVault(t)
+
+	out, err := query.CollectOut(db, "concept-alpha", "no-such-edge-type")
+	require.NoError(t, err)
+	assert.Equal(t, "concept-alpha", out.SourceID)
+	// The filter is valid; it just returns nothing. The SourceID is always set.
+	var hasBeta bool
+	for _, l := range out.Links {
+		if l.TargetID != nil && *l.TargetID == "proj-beta" {
+			hasBeta = true
+		}
+	}
+	assert.False(t, hasBeta, "a non-matching edge-type filter must drop the alpha→beta link")
+}
+
+// RunLinks --out JSON path: the envelope must carry status "ok" and include
+// the source_id. Complements the existing human-mode test.
+func TestRunLinks_OutJSONEnvelopeShape(t *testing.T) {
+	db, dir := smallIndexedVault(t)
+	var buf bytes.Buffer
+	err := query.RunLinks(db, query.LinksConfig{
+		Input: "concept-alpha", Direction: "out", VaultPath: dir, JSONOutput: true,
+	}, &buf)
+	require.NoError(t, err)
+
+	var env struct {
+		Status string `json:"status"`
+		Result struct {
+			SourceID string `json:"source_id"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+	assert.Equal(t, "ok", env.Status)
+	assert.Equal(t, "concept-alpha", env.Result.SourceID)
+}
+
+// RunLinks --in JSON path: the envelope must carry status "ok" and include
+// the target_id.
+func TestRunLinks_InJSONEnvelopeShape(t *testing.T) {
+	db, dir := smallIndexedVault(t)
+	var buf bytes.Buffer
+	err := query.RunLinks(db, query.LinksConfig{
+		Input: "concept-alpha", Direction: "in", VaultPath: dir, JSONOutput: true,
+	}, &buf)
+	require.NoError(t, err)
+
+	var env struct {
+		Status string `json:"status"`
+		Result struct {
+			TargetID string `json:"target_id"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+	assert.Equal(t, "ok", env.Status)
+	assert.Equal(t, "concept-alpha", env.Result.TargetID)
+}
+
+// RunLinks with an unresolvable input in JSON mode emits an error envelope
+// rather than returning a Go error, so callers can parse the failure code.
+func TestRunLinks_UnresolvableInputJSONEmitsErrorEnvelope(t *testing.T) {
+	db, dir := smallIndexedVault(t)
+	var buf bytes.Buffer
+	err := query.RunLinks(db, query.LinksConfig{
+		Input: "no-such-note", Direction: "out", VaultPath: dir, JSONOutput: true,
+	}, &buf)
+	require.NoError(t, err, "JSON mode: error is encoded in the envelope, not returned as Go error")
+
+	var env struct {
+		Status string `json:"status"`
+		Errors []struct {
+			Code string `json:"code"`
+		} `json:"errors"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+	assert.Equal(t, "error", env.Status)
+	require.NotEmpty(t, env.Errors)
+	assert.Equal(t, "resolution_failed", env.Errors[0].Code)
+}
+
+// renderOut human mode (non-JSON): each link is formatted with a TargetID
+// pointer resolved. If TargetID is nil, TargetRaw is used. Both branches
+// are exercised transitively through CollectOut + RunLinks.
+func TestRunLinks_OutHumanOutputUsesTargetID(t *testing.T) {
+	db, dir := smallIndexedVault(t)
+	var buf bytes.Buffer
+	err := query.RunLinks(db, query.LinksConfig{
+		Input: "concept-alpha", Direction: "out", VaultPath: dir,
+	}, &buf)
+	require.NoError(t, err)
+	// The human line format is: %-20s %-20s %s (target, edge_type, confidence).
+	// proj-beta must appear because alpha links to it.
+	assert.Contains(t, buf.String(), "proj-beta",
+		"human renderOut must include the resolved target ID")
+}

--- a/internal/query/runners_test.go
+++ b/internal/query/runners_test.go
@@ -411,8 +411,8 @@ func TestDoctor_EmbeddingsStatusReflectsAbsence(t *testing.T) {
 }
 
 // RunLinks in human mode (non-JSON) prints rows with source/edge/confidence
-// columns — scripts awk these. Covers the human-output branch of runLinksIn
-// and runLinksOut.
+// columns — scripts awk these. Covers the human-output branch of RunLinks /
+// renderIn / renderOut.
 func TestRunLinks_InHumanOutputHasSourceAndEdgeColumns(t *testing.T) {
 	db, dir := smallIndexedVault(t)
 	var buf bytes.Buffer

--- a/internal/query/status.go
+++ b/internal/query/status.go
@@ -38,7 +38,6 @@ func VaultStatus(db *index.DB, vaultPath string, cfg *vault.Config, reg *schema.
 	result := &StatusResult{
 		VaultPath:   vaultPath,
 		IndexStatus: "current",
-		Types:       make(map[string]StatusTypeInfo),
 	}
 
 	// Note counts
@@ -50,7 +49,33 @@ func VaultStatus(db *index.DB, vaultPath string, cfg *vault.Config, reg *schema.
 	}
 	result.UnstructuredNotes = result.TotalFiles - result.DomainNotes
 
-	// Type info with counts
+	// Per-type breakdown and issues rollup come from the shared helpers so the
+	// cold-start view here and the doctor health hub stay in lockstep (SSOT).
+	types, err := CollectTypeBreakdown(db, cfg)
+	if err != nil {
+		return nil, err
+	}
+	result.Types = types
+
+	summary, err := SummarizeValidationIssues(db, reg)
+	if err != nil {
+		return nil, err
+	}
+	result.IssuesSummary = summary
+
+	return result, nil
+}
+
+// CollectTypeBreakdown returns the per-type note counts together with each
+// type's required fields and valid statuses, drawn from the vault config's
+// type registry. It is the single source of truth for the per-type breakdown
+// surfaced by both `vault status` (cold-start) and `doctor` (health hub).
+// A nil cfg yields an empty (non-nil) map so callers can range safely.
+func CollectTypeBreakdown(db *index.DB, cfg *vault.Config) (map[string]StatusTypeInfo, error) {
+	types := make(map[string]StatusTypeInfo)
+	if cfg == nil {
+		return types, nil
+	}
 	for name, td := range cfg.Types {
 		var count int
 		if err := db.QueryRow("SELECT COUNT(*) FROM notes WHERE type = ?", name).Scan(&count); err != nil {
@@ -60,25 +85,33 @@ func VaultStatus(db *index.DB, vaultPath string, cfg *vault.Config, reg *schema.
 		if statuses == nil {
 			statuses = []string{}
 		}
-		result.Types[name] = StatusTypeInfo{
+		types[name] = StatusTypeInfo{
 			Count:    count,
 			Required: td.Required,
 			Statuses: statuses,
 		}
 	}
+	return types, nil
+}
 
-	// Issues summary from validation
+// SummarizeValidationIssues runs the schema validator and rolls its issues up
+// into error/warning counts. Shared by `vault status` and `doctor` so both
+// report the same rollup (SSOT). A nil reg yields a zero-value summary.
+func SummarizeValidationIssues(db *index.DB, reg *schema.Registry) (StatusIssuesSummary, error) {
+	var summary StatusIssuesSummary
+	if reg == nil {
+		return summary, nil
+	}
 	valResult, err := Validate(db, reg)
 	if err != nil {
-		return nil, fmt.Errorf("running validation: %w", err)
+		return summary, fmt.Errorf("running validation: %w", err)
 	}
 	for _, issue := range valResult.Issues {
 		if issue.Severity == "error" {
-			result.IssuesSummary.Errors++
+			summary.Errors++
 		} else {
-			result.IssuesSummary.Warnings++
+			summary.Warnings++
 		}
 	}
-
-	return result, nil
+	return summary, nil
 }

--- a/internal/query/status_nilguard_test.go
+++ b/internal/query/status_nilguard_test.go
@@ -1,0 +1,99 @@
+package query_test
+
+// status_nilguard_test.go — behavior tests for the nil-cfg/nil-reg guard
+// branches in CollectTypeBreakdown and SummarizeValidationIssues.
+//
+// These guards are the single-source-of-truth shared helpers surfaced by both
+// `vault status` (cold-start) and `doctor` (health hub). The nil-guard
+// branches were uncovered at 64.5–75% (patch-coverage gap run 2026-06-07).
+// Covering them also verifies that callers can safely range over the result
+// without nil-dereference panics.
+
+import (
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/query"
+	"github.com/peiman/vaultmind/internal/schema"
+	"github.com/peiman/vaultmind/internal/vault"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CollectTypeBreakdown with a nil vault.Config must return an empty non-nil map.
+// Callers that range over the result must not panic even when no config is
+// available (e.g., vault with no .vaultmind/config.yaml).
+func TestCollectTypeBreakdown_NilConfigReturnsEmptyMap(t *testing.T) {
+	db := buildIndexedDB(t)
+
+	types, err := query.CollectTypeBreakdown(db, nil)
+	require.NoError(t, err, "nil cfg must not cause an error")
+	assert.NotNil(t, types, "result must be a non-nil map so callers can range safely")
+	assert.Empty(t, types, "no types are defined when cfg is nil")
+}
+
+// CollectTypeBreakdown with a valid config populates per-type counts and their
+// schema metadata (required fields + valid statuses). This is the happy path
+// exercised transitively by TestCollectTypeBreakdown_SharedHelper; we add an
+// explicit nil-statuses check here because the helper normalises nil → empty
+// slice to prevent callers from receiving a nil slice for an optional field.
+func TestCollectTypeBreakdown_NilStatusesNormalisedToEmpty(t *testing.T) {
+	db := buildIndexedDB(t)
+
+	// The test vault has a "concept" type with no statuses defined.
+	// CollectTypeBreakdown must return []string{} not nil for the Statuses field.
+	// (A nil slice serialises as JSON null; callers expect [].)
+	cfg, err := vault.LoadConfig(testVaultPath)
+	require.NoError(t, err)
+
+	types, err := query.CollectTypeBreakdown(db, cfg)
+	require.NoError(t, err)
+
+	for typeName, info := range types {
+		assert.NotNil(t, info.Statuses,
+			"Statuses for type %q must be a non-nil slice, never JSON null", typeName)
+	}
+}
+
+// SummarizeValidationIssues with a nil registry must return a zero-value
+// summary without error. The nil guard exists so both vault status and doctor
+// can call this helper before a registry has been loaded.
+func TestSummarizeValidationIssues_NilRegistryReturnsZeroSummary(t *testing.T) {
+	db := buildIndexedDB(t)
+
+	summary, err := query.SummarizeValidationIssues(db, nil)
+	require.NoError(t, err, "nil registry must not cause an error")
+	assert.Equal(t, 0, summary.Errors, "nil registry must yield 0 errors")
+	assert.Equal(t, 0, summary.Warnings, "nil registry must yield 0 warnings")
+}
+
+// SummarizeValidationIssues counts errors and warnings correctly on a clean
+// vault. A vault with no schema violations must report 0 errors and 0 warnings.
+// This is the SSOT contract: both the status path and the doctor path call the
+// same function and must agree.
+func TestSummarizeValidationIssues_CleanVaultHasZeroIssues(t *testing.T) {
+	db := buildIndexedDB(t)
+	cfg, err := vault.LoadConfig(testVaultPath)
+	require.NoError(t, err)
+	reg := schema.NewRegistry(cfg.Types)
+
+	summary, err := query.SummarizeValidationIssues(db, reg)
+	require.NoError(t, err)
+	assert.Equal(t, 0, summary.Errors,
+		"clean fixture vault must have no schema errors")
+}
+
+// VaultStatus with nil cfg still returns a valid result (no panic, no error):
+// the types map will be empty because there is no type registry to draw from.
+func TestVaultStatus_NilCfgReturnsValidResult(t *testing.T) {
+	db := buildIndexedDB(t)
+
+	result, err := query.VaultStatus(db, testVaultPath, nil, nil)
+	require.NoError(t, err, "nil cfg/reg must not cause VaultStatus to fail")
+	assert.Equal(t, testVaultPath, result.VaultPath)
+	assert.Greater(t, result.TotalFiles, 0,
+		"VaultStatus must still count notes even without cfg")
+	assert.NotNil(t, result.Types, "Types must be a non-nil map even when cfg is nil")
+	assert.Empty(t, result.Types, "no types can be listed when cfg is nil")
+	assert.Equal(t, 0, result.IssuesSummary.Errors,
+		"nil reg yields zero issues — not an error")
+}

--- a/internal/query/status_test.go
+++ b/internal/query/status_test.go
@@ -55,3 +55,45 @@ func TestVaultStatus_IncludesIssueSummary(t *testing.T) {
 	// Clean vault should have 0 errors
 	assert.Equal(t, 0, result.IssuesSummary.Errors)
 }
+
+// CollectTypeBreakdown is the SSOT helper now shared between vault status and
+// the doctor health hub: it must return per-type counts plus the required
+// fields and valid statuses straight from the registry, with the same shape
+// VaultStatus.Types carries.
+func TestCollectTypeBreakdown_SharedHelper(t *testing.T) {
+	db := buildIndexedDB(t)
+	cfg, err := vault.LoadConfig(testVaultPath)
+	require.NoError(t, err)
+
+	types, err := query.CollectTypeBreakdown(db, cfg)
+	require.NoError(t, err)
+	require.Contains(t, types, "concept")
+	require.Contains(t, types, "project")
+	assert.Greater(t, types["concept"].Count, 0)
+	assert.Contains(t, types["concept"].Required, "title")
+
+	// The doctor path and the status path must agree byte-for-byte: same DB,
+	// same cfg, identical breakdown. This is the SSOT contract.
+	reg := schema.NewRegistry(cfg.Types)
+	status, err := query.VaultStatus(db, testVaultPath, cfg, reg)
+	require.NoError(t, err)
+	assert.Equal(t, status.Types, types,
+		"the shared breakdown helper must produce exactly what VaultStatus reports")
+}
+
+// SummarizeValidationIssues is the SSOT helper for the errors/warnings rollup.
+// It must match the count VaultStatus reports for the same DB + registry.
+func TestSummarizeValidationIssues_SharedHelper(t *testing.T) {
+	db := buildIndexedDB(t)
+	cfg, err := vault.LoadConfig(testVaultPath)
+	require.NoError(t, err)
+	reg := schema.NewRegistry(cfg.Types)
+
+	summary, err := query.SummarizeValidationIssues(db, reg)
+	require.NoError(t, err)
+
+	status, err := query.VaultStatus(db, testVaultPath, cfg, reg)
+	require.NoError(t, err)
+	assert.Equal(t, status.IssuesSummary, summary,
+		"the shared rollup helper must produce exactly what VaultStatus reports")
+}


### PR DESCRIPTION
## Summary

Refactors the command surface to remove three overlapping seams (full rationale + alternatives in **docs/adr/101-command-taxonomy.md**):

- **Graph traversal unified under `memory`** — `memory links <id> --out|--in|--both` (absorbs `links out`/`links in`), `memory neighbors` (merges `links neighbors` + `memory recall`), `memory pack` (renames `memory context-pack`). Top-level `links` removed.
- **`doctor` is the single vault-health hub** — `doctor --summary` absorbs `vault status` (per-type breakdown + errors/warnings rollup); the `vault` parent dissolves.
- **`doctor heal` (alias `fix`)** — `doctor heal` applies all auto-fixable repairs; `doctor heal wikilinks` is the surgical form (logic moved from `lint fix-links`). Applies by default, `--dry-run` previews, one shared `internal/mutation` engine. Top-level `lint` removed. The diagnosis remedy now points at `doctor heal wikilinks` instead of the unshipped `scripts/fix_wikilinks.py`.

Every removed/renamed invocation stays as a **hidden deprecated alias** (one-line stderr notice -> delegates to the new path), kept ~2 releases.

## Backward compatibility

- Old invocations keep working via the hidden aliases (incl. `links neighbors` preserving its old low-confidence / 200-node defaults).
- :warning: `vault status --json` now emits the `doctor` envelope shape (noted in CHANGELOG).

## Quality

- `task check` green — **All 23 checks, project coverage 84.49%**; pre-push patch-coverage gate passes (80.72%).
- A multi-specialist review pass found and fixed **3 HIGH + 5 MEDIUM + 6 LOW**, notably:
  - `memory links --json` on the default `--both` previously emitted two concatenated JSON envelopes (**invalid JSON**) -> now one combined envelope.
  - `DoctorResult.issues_summary` no longer serializes a misleading false-zero (now pointer + omitempty).
  - Direction tests strengthened to actually distinguish `--out` vs `--in`.

## Known / out of scope

- `TestDataview*` fail under `go test -shuffle` — **pre-existing** (reproduces identically on the base commit; dataview is untouched here). To be filed separately.
- Coverage margin is intentionally minimal here; a follow-up command-catalog PR raises project coverage to >90%.