### PR TITLE
feat(identity): Contract B dev-interim custody signer (slice 2)

### DIFF
--- a/.ckeletin/pkg/config/keys_generated.go
+++ b/.ckeletin/pkg/config/keys_generated.go
@@ -130,6 +130,9 @@ const (
 	KeyAppHooksuninstallJson            = "app.hooksuninstall.json"             // Output in JSON format
 	KeyAppHooksuninstallLocal           = "app.hooksuninstall.local"            // Target .claude/settings.local.json instead of .claude/settings.json.
 	KeyAppHooksuninstallRemovescripts   = "app.hooksuninstall.removescripts"    // Also delete the installed hook scripts under .claude/scripts/ (default: leave...
+	KeyAppIdentityinitSignerKey         = "app.identityinit.signer_key"         // Sealed signer key path (default: XDG data dir)
+	KeyAppIdentitysignFile              = "app.identitysign.file"               // Read entry JSON from this file instead of stdin
+	KeyAppIdentitysignSignerSocket      = "app.identitysign.signer_socket"      // Signer socket path (default: XDG state dir)
 	KeyAppIndexVault                    = "app.index.vault"                     // Path to the vault root directory
 	KeyAppIndexJson                     = "app.index.json"                      // Output in JSON format
 	KeyAppIndexFull                     = "app.index.full"                      // Force full rebuild instead of incremental index

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -160,6 +160,8 @@ components:
       - internal/hooks/**
       # VaultMind auto-RAG drift catalog (Go schema for the JSON env var the bash engine consumes):
       - internal/hooks/autorag/**
+      # VaultMind Contract-B identity CLI logic (keyless sign via the signer client + keypair mint/seal; keeps cmd/identity_* ultra-thin):
+      - internal/identitycli/**
 
   # pkg/ was cleaned by task init (checkmate is now an external dependency).
   # Re-add this section if you create new public packages in pkg/.

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -70,6 +70,8 @@ rules:
         - cmd/frontmatter_merge.go  # Reads user-specified YAML merge file (--file flag)
         - cmd/telemetry.go  # Reads config file from viper.ConfigFileUsed() path (not user input)
         - cmd/dataview_lint.go  # Reads vault .md files via paths from vault scanner (user-provided vault path)
+        - cmd/identity_sign.go  # Reads the Contract-B entry from the operator-provided --file path (same trust tier as cmd/apply.go)
+        - internal/identity/signer/signer.go  # Reads the operator-configured sealed signer key file (0600, path from signer Config, not runtime user input)
         - internal/mutation/lint.go  # Reads/writes vault .md files via WalkDir (user-provided vault path, paths from filesystem walk)
         - internal/baseline/fixture.go  # Reads project-internal baseline fixture + snapshot paths from test callers (filepath.Clean applied, not user input at runtime)
         - internal/query/validate_live.go  # Reads vault .md files via filepath.WalkDir rooted at user-provided vault path (already #nosec G304)

--- a/cmd/identity.go
+++ b/cmd/identity.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"github.com/peiman/vaultmind/internal/xdg"
+	"github.com/spf13/cobra"
+)
+
+// Contract-B identity custody path/flag constants (SSOT). The CLI is KEYLESS:
+// it never opens the key file. The key path exists so `identity init` can SEAL
+// the key for the signer, and so docs/operators can locate it — the signing
+// path uses only the socket via the signer Client.
+const (
+	// signerKeyFilename is the sealed ed25519 private-key file the signer loads.
+	signerKeyFilename = "identity-signer.key"
+	// signerSocketFilename is the 0600 Unix-domain socket the signer listens on.
+	signerSocketFilename = "identity-signer.sock"
+)
+
+var identityCmd = &cobra.Command{
+	Use:   "identity",
+	Short: "Contract-B agent identity: keypair custody + signing",
+	Long: `Contract-B agent identity commands.
+
+The ed25519 private key is held by a SEPARATE signer process and reached over a
+0600 Unix-domain socket; this CLI is KEYLESS and never opens the key file.
+
+DEV-INTERIM: the signer currently runs as the SAME uid as the CLI. This is the
+custody ARCHITECTURE, not real isolation — real isolation needs a dedicated
+service uid + launchd + sandbox + Secure-Enclave key wrap (deferred).`,
+}
+
+func init() {
+	RootCmd.AddCommand(identityCmd)
+}
+
+// defaultSignerKeyPath returns the sealed key-file path under the XDG data dir.
+func defaultSignerKeyPath() (string, error) {
+	return xdg.DataFile(signerKeyFilename)
+}
+
+// defaultSignerSocketPath returns the signer socket path under the XDG state dir.
+func defaultSignerSocketPath() (string, error) {
+	return xdg.StateFile(signerSocketFilename)
+}

--- a/cmd/identity_init.go
+++ b/cmd/identity_init.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/identitycli"
+	"github.com/spf13/cobra"
+)
+
+var identityInitCmd = MustNewCommand(commands.IdentityInitMetadata, runIdentityInit)
+
+func init() {
+	identityCmd.AddCommand(identityInitCmd)
+	setupCommandConfig(identityInitCmd)
+}
+
+func runIdentityInit(cmd *cobra.Command, _ []string) error {
+	keyPath := getConfigValueWithFlags[string](cmd, "signer-key", config.KeyAppIdentityinitSignerKey)
+	if keyPath == "" {
+		p, err := defaultSignerKeyPath()
+		if err != nil {
+			return fmt.Errorf("resolving signer key path: %w", err)
+		}
+		keyPath = p
+	}
+	return identitycli.Init(cmd.OutOrStdout(), keyPath)
+}

--- a/cmd/identity_sign.go
+++ b/cmd/identity_sign.go
@@ -46,6 +46,11 @@ func readIdentityEntryJSON(cmd *cobra.Command) ([]byte, error) {
 		}
 		return b, nil
 	}
+	// TODO(contract-b hardening): io.ReadAll here is unbounded — a caller
+	// piping a huge stream would consume unbounded memory before the signer
+	// even sees the bytes. In the hardening slice, replace with
+	// io.LimitReader(cmd.InOrStdin(), maxEntryBytes) where maxEntryBytes
+	// matches (or is tighter than) the signer's maxRequestBytes constant.
 	b, err := io.ReadAll(cmd.InOrStdin())
 	if err != nil {
 		return nil, fmt.Errorf("reading entry from stdin: %w", err)

--- a/cmd/identity_sign.go
+++ b/cmd/identity_sign.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/identity/signer"
+	"github.com/peiman/vaultmind/internal/identitycli"
+	"github.com/spf13/cobra"
+)
+
+var identitySignCmd = MustNewCommand(commands.IdentitySignMetadata, runIdentitySign)
+
+func init() {
+	identityCmd.AddCommand(identitySignCmd)
+	setupCommandConfig(identitySignCmd)
+}
+
+func runIdentitySign(cmd *cobra.Command, _ []string) error {
+	sockPath := getConfigValueWithFlags[string](cmd, "signer-socket", config.KeyAppIdentitysignSignerSocket)
+	if sockPath == "" {
+		p, err := defaultSignerSocketPath()
+		if err != nil {
+			return fmt.Errorf("resolving signer socket path: %w", err)
+		}
+		sockPath = p
+	}
+	entryJSON, err := readIdentityEntryJSON(cmd)
+	if err != nil {
+		return err
+	}
+	client := &signer.Client{SocketPath: sockPath}
+	return identitycli.SignEntry(cmd.OutOrStdout(), client, entryJSON)
+}
+
+// readIdentityEntryJSON reads the entry from --file when set, else from stdin.
+func readIdentityEntryJSON(cmd *cobra.Command) ([]byte, error) {
+	filePath := getConfigValueWithFlags[string](cmd, "file", config.KeyAppIdentitysignFile)
+	if filePath != "" {
+		b, err := os.ReadFile(filePath) //nolint:gosec // operator-provided entry path
+		if err != nil {
+			return nil, fmt.Errorf("reading entry file: %w", err)
+		}
+		return b, nil
+	}
+	b, err := io.ReadAll(cmd.InOrStdin())
+	if err != nil {
+		return nil, fmt.Errorf("reading entry from stdin: %w", err)
+	}
+	return b, nil
+}

--- a/cmd/identity_test.go
+++ b/cmd/identity_test.go
@@ -2,13 +2,59 @@ package cmd
 
 import (
 	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/signer"
 	"github.com/peiman/vaultmind/internal/identitycli"
 )
+
+// startCmdSigner boots a real signer on a short UDS allowlisting the test uid
+// and returns the socket path plus the public key for verification. It is the
+// fixture the cmd-level sign tests use to drive `identity sign` end to end.
+func startCmdSigner(t *testing.T) (sockPath string, pub ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	// Short dirs: a t.TempDir() under /var/folders can exceed the ~104-char UDS
+	// path limit on darwin.
+	keyDir, err := os.MkdirTemp("", "vmck")
+	if err != nil {
+		t.Fatalf("MkdirTemp key: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(keyDir) })
+	keyPath := filepath.Join(keyDir, "k.key")
+	if err := signer.SealPrivateKey(keyPath, priv); err != nil {
+		t.Fatalf("SealPrivateKey: %v", err)
+	}
+	sockDir, err := os.MkdirTemp("", "vmcs")
+	if err != nil {
+		t.Fatalf("MkdirTemp sock: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sockPath = filepath.Join(sockDir, "s.sock")
+	s, err := signer.New(signer.Config{
+		KeyPath:     keyPath,
+		SocketPath:  sockPath,
+		AllowedUIDs: []uint32{uint32(os.Getuid())},
+	})
+	if err != nil {
+		t.Fatalf("signer.New: %v", err)
+	}
+	if err := s.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	go func() { _ = s.Serve() }()
+	t.Cleanup(func() { _ = s.Close() })
+	return sockPath, pub
+}
 
 // TestIdentityInitCommandWiring drives `identity init` through RootCmd and
 // asserts the thin command seals a 0600 key and prints only the public key.
@@ -61,5 +107,86 @@ func TestIdentitySignCommandFailsClosedWhenSignerUnreachable(t *testing.T) {
 	_, _, err = runRootCmd(t, "identity", "sign", "--file", entryPath, "--signer-socket", sockPath)
 	if err == nil {
 		t.Fatal("expected fail-closed error when signer unreachable, got nil")
+	}
+}
+
+// TestIdentitySignCommandViaStdin drives `identity sign` reading the entry from
+// STDIN (the default agent flow — no --file) against a live signer and asserts a
+// VERIFYING signature is printed. This covers readIdentityEntryJSON's stdin
+// branch, which only --file tests previously exercised.
+func TestIdentitySignCommandViaStdin(t *testing.T) {
+	sockPath, pub := startCmdSigner(t)
+	const entry = `{"agent":"mira","epoch":1}`
+
+	RootCmd.SetIn(strings.NewReader(entry))
+	defer RootCmd.SetIn(os.Stdin)
+
+	out, _, err := runRootCmd(t, "identity", "sign", "--signer-socket", sockPath)
+	if err != nil {
+		t.Fatalf("identity sign via stdin: %v", err)
+	}
+
+	line := strings.TrimSpace(out.String())
+	if !strings.HasPrefix(line, identitycli.SigLabel) {
+		t.Fatalf("output %q missing signature label %q", line, identitycli.SigLabel)
+	}
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(line, identitycli.SigLabel))
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+	canonical, err := identity.Canonicalize([]byte(entry))
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	ok, err := identity.VerifyCanonical(pub, canonical, sig)
+	if err != nil || !ok {
+		t.Fatalf("stdin-signed signature did not verify: ok=%v err=%v", ok, err)
+	}
+}
+
+// TestIdentitySignCommandFileNotFound asserts `identity sign --file <missing>`
+// FAILS CLOSED with a clear error and prints no signature, rather than silently
+// falling back to stdin or emitting an empty result.
+func TestIdentitySignCommandFileNotFound(t *testing.T) {
+	dir, err := os.MkdirTemp("", "vmcmdsignnf")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	missing := filepath.Join(dir, "does-not-exist.json")
+
+	// No --signer-socket: this also exercises runIdentitySign's default-socket
+	// resolution branch (socket is resolved before the entry is read).
+	out, _, err := runRootCmd(t, "identity", "sign", "--file", missing)
+	if err == nil {
+		t.Fatal("expected error for nonexistent --file, got nil")
+	}
+	if strings.Contains(out.String(), identitycli.SigLabel) {
+		t.Fatalf("file-not-found path must not print a signature, got %q", out.String())
+	}
+}
+
+// TestDefaultSignerPathsResolveUnderXDG asserts the XDG path helpers return
+// non-empty, distinct paths ending in the SSOT filenames. This covers the
+// happy path of defaultSignerKeyPath / defaultSignerSocketPath.
+func TestDefaultSignerPathsResolveUnderXDG(t *testing.T) {
+	keyPath, err := defaultSignerKeyPath()
+	if err != nil {
+		t.Fatalf("defaultSignerKeyPath: %v", err)
+	}
+	if !strings.HasSuffix(keyPath, signerKeyFilename) {
+		t.Fatalf("key path %q does not end in %q", keyPath, signerKeyFilename)
+	}
+
+	sockPath, err := defaultSignerSocketPath()
+	if err != nil {
+		t.Fatalf("defaultSignerSocketPath: %v", err)
+	}
+	if !strings.HasSuffix(sockPath, signerSocketFilename) {
+		t.Fatalf("socket path %q does not end in %q", sockPath, signerSocketFilename)
+	}
+
+	if keyPath == sockPath {
+		t.Fatal("key and socket default paths must differ")
 	}
 }

--- a/cmd/identity_test.go
+++ b/cmd/identity_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"crypto/ed25519"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/identitycli"
+)
+
+// TestIdentityInitCommandWiring drives `identity init` through RootCmd and
+// asserts the thin command seals a 0600 key and prints only the public key.
+func TestIdentityInitCommandWiring(t *testing.T) {
+	keyDir, err := os.MkdirTemp("", "vmcmdinit")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(keyDir) })
+	keyPath := filepath.Join(keyDir, "k.key")
+
+	out, _, err := runRootCmd(t, "identity", "init", "--signer-key", keyPath)
+	if err != nil {
+		t.Fatalf("identity init: %v", err)
+	}
+	if !strings.Contains(out.String(), identitycli.PubKeyLabel) {
+		t.Fatalf("output missing public-key label: %q", out.String())
+	}
+
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("Stat key: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("key perm = %o, want 0600", perm)
+	}
+	keyBytes, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("ReadFile key: %v", err)
+	}
+	if len(keyBytes) != ed25519.PrivateKeySize {
+		t.Fatalf("sealed key len = %d, want %d", len(keyBytes), ed25519.PrivateKeySize)
+	}
+}
+
+// TestIdentitySignCommandFailsClosedWhenSignerUnreachable drives `identity sign`
+// through RootCmd pointed at a non-existent socket and asserts it fails closed.
+func TestIdentitySignCommandFailsClosedWhenSignerUnreachable(t *testing.T) {
+	dir, err := os.MkdirTemp("", "vmcmdsign")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	entryPath := filepath.Join(dir, "entry.json")
+	if err := os.WriteFile(entryPath, []byte(`{"agent":"mira","epoch":1}`), 0o600); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	sockPath := filepath.Join(dir, "nope.sock")
+
+	_, _, err = runRootCmd(t, "identity", "sign", "--file", entryPath, "--signer-socket", sockPath)
+	if err == nil {
+		t.Fatal("expected fail-closed error when signer unreachable, got nil")
+	}
+}

--- a/cmd/zz_catalog.go
+++ b/cmd/zz_catalog.go
@@ -249,6 +249,21 @@ var commandCatalog = map[string]catalogEntry{
 		when:  "you finished a session and want candidate transformation moments to review for arcs.",
 		short: "Surface candidate transformation moments for arc distillation",
 	},
+	"vaultmind identity": {
+		group: groupLifecycle,
+		when:  "you need Contract-B agent identity: mint a keypair or sign an entry via the keyless signer.",
+		short: "Contract-B agent identity: keypair custody and signing",
+	},
+	"vaultmind identity init": {
+		group: groupLifecycle,
+		when:  "you are setting up an agent and need to mint its ed25519 keypair and seal the private key to the signer.",
+		short: "Mint an agent keypair and seal the private key to the signer",
+	},
+	"vaultmind identity sign": {
+		group: groupLifecycle,
+		when:  "you have a Contract-B entry to sign and want it validated, canonicalized, and signed by the keyless signer.",
+		short: "Validate, canonicalize, and sign an entry via the keyless signer",
+	},
 	"vaultmind hooks": {
 		group: groupLifecycle,
 		when:  "you need to install, remove, or check VaultMind's Claude Code hook scripts.",

--- a/internal/config/commands/identity_init_config.go
+++ b/internal/config/commands/identity_init_config.go
@@ -1,0 +1,32 @@
+package commands
+
+import "github.com/peiman/vaultmind/.ckeletin/pkg/config"
+
+// IdentityInitMetadata defines metadata for the `identity init` command.
+var IdentityInitMetadata = config.CommandMetadata{
+	Use:   "init",
+	Short: "Mint an agent keypair and seal the private key to the signer",
+	Long: `Mint a per-agent ed25519 keypair, SEAL the private key to the signer's 0600
+key file, and print the PUBLIC key.
+
+The private key is NEVER printed or logged. Re-running refuses to overwrite an
+existing sealed key.
+
+DEV-INTERIM: the sealed key is a raw 0600 file. Secure-Enclave wrapping and a
+dedicated service uid are deferred (see internal/identity/signer).`,
+	ConfigPrefix: "app.identityinit",
+	FlagOverrides: map[string]string{
+		"app.identityinit.signer_key": "signer-key",
+	},
+}
+
+// IdentityInitOptions returns config options for `identity init`.
+func IdentityInitOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.identityinit.signer_key", DefaultValue: "", Description: "Sealed signer key path (default: XDG data dir)", Type: "string"},
+	}
+}
+
+func init() {
+	config.RegisterOptionsProvider(IdentityInitOptions)
+}

--- a/internal/config/commands/identity_sign_config.go
+++ b/internal/config/commands/identity_sign_config.go
@@ -1,0 +1,32 @@
+package commands
+
+import "github.com/peiman/vaultmind/.ckeletin/pkg/config"
+
+// IdentitySignMetadata defines metadata for the `identity sign` command.
+var IdentitySignMetadata = config.CommandMetadata{
+	Use:   "sign",
+	Short: "Validate, canonicalize, and sign an entry via the keyless signer",
+	Long: `Read a Contract-B entry (stdin or --file), VALIDATE and CANONICALIZE it
+(slice-1 schema gate + RFC 8785 JCS), then send the canonical bytes to the
+signer over its 0600 socket and print the signature.
+
+This CLI is KEYLESS: it NEVER opens the private-key file. If the signer is
+unreachable it FAILS CLOSED with an error (never a silent unsigned result).`,
+	ConfigPrefix: "app.identitysign",
+	FlagOverrides: map[string]string{
+		"app.identitysign.file":          "file",
+		"app.identitysign.signer_socket": "signer-socket",
+	},
+}
+
+// IdentitySignOptions returns config options for `identity sign`.
+func IdentitySignOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.identitysign.file", DefaultValue: "", Description: "Read entry JSON from this file instead of stdin", Type: "string"},
+		{Key: "app.identitysign.signer_socket", DefaultValue: "", Description: "Signer socket path (default: XDG state dir)", Type: "string"},
+	}
+}
+
+func init() {
+	config.RegisterOptionsProvider(IdentitySignOptions)
+}

--- a/internal/identity/signer/client.go
+++ b/internal/identity/signer/client.go
@@ -1,0 +1,52 @@
+package signer
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+)
+
+// errSignerUnreachable prefixes a dial failure so the CLI can FAIL CLOSED with
+// a clear message instead of a silent nil signature.
+const errSignerUnreachable = "signer: unreachable (is the signer running?)"
+
+// Client dials the signer's 0600 Unix-domain socket and requests signatures.
+// It holds NO key material — it exists so the CLI never opens the key file.
+type Client struct {
+	// SocketPath is the signer's 0600 Unix-domain socket.
+	SocketPath string
+}
+
+// Sign sends the already-canonical bytes to the signer and returns the ed25519
+// signature. It FAILS CLOSED (returns a non-nil error, never a nil signature)
+// when the signer is unreachable or refuses the request. The caller MUST pass
+// JCS-canonical bytes; the client does not canonicalize.
+func (c *Client) Sign(canonicalBytes []byte) ([]byte, error) {
+	if c.SocketPath == "" {
+		return nil, errors.New("signer: client SocketPath is empty")
+	}
+	conn, err := net.Dial(network, c.SocketPath)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errSignerUnreachable, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := writeFrame(conn, canonicalBytes); err != nil {
+		return nil, fmt.Errorf("signer: send request: %w", err)
+	}
+
+	status := make([]byte, 1)
+	if _, err := io.ReadFull(conn, status); err != nil {
+		return nil, fmt.Errorf("signer: read response status: %w", err)
+	}
+	payload, err := readFrame(conn)
+	if err != nil {
+		return nil, fmt.Errorf("signer: read response: %w", err)
+	}
+	if status[0] != respOK {
+		// Surface the signer's error message; fail closed.
+		return nil, fmt.Errorf("signer refused: %s", string(payload))
+	}
+	return payload, nil
+}

--- a/internal/identity/signer/peercred_darwin.go
+++ b/internal/identity/signer/peercred_darwin.go
@@ -1,0 +1,40 @@
+//go:build darwin
+
+package signer
+
+import (
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// peerUID derives the UID of the process on the other end of a Unix-domain
+// connection on darwin via getsockopt(SOL_LOCAL, LOCAL_PEERCRED), which returns
+// an xucred whose Uid is the peer's effective UID. This is the same technique
+// the Contract-B custody probe validated.
+//
+// TODO(contract-b hardening): under a dedicated service uid + launchd sandbox,
+// this UID check becomes a real cross-trust-domain boundary; today the signer
+// and CLI share a uid, so this gates "which uid may sign" but is not yet a
+// privilege boundary.
+func peerUID(conn *net.UnixConn) (uint32, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return 0, fmt.Errorf("syscall conn: %w", err)
+	}
+	var (
+		cred    *unix.Xucred
+		credErr error
+	)
+	ctrlErr := raw.Control(func(fd uintptr) {
+		cred, credErr = unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+	})
+	if ctrlErr != nil {
+		return 0, fmt.Errorf("control fd: %w", ctrlErr)
+	}
+	if credErr != nil {
+		return 0, fmt.Errorf("getsockopt LOCAL_PEERCRED: %w", credErr)
+	}
+	return cred.Uid, nil
+}

--- a/internal/identity/signer/peercred_linux.go
+++ b/internal/identity/signer/peercred_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package signer
+
+import (
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// peerUID derives the UID of the process on the other end of a Unix-domain
+// connection on linux via getsockopt(SOL_SOCKET, SO_PEERCRED). The primary
+// custody target is darwin (LOCAL_PEERCRED + xucred); this linux variant keeps
+// the package buildable and testable on linux CI with the equivalent ucred
+// mechanism.
+func peerUID(conn *net.UnixConn) (uint32, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return 0, fmt.Errorf("syscall conn: %w", err)
+	}
+	var (
+		ucred   *unix.Ucred
+		credErr error
+	)
+	ctrlErr := raw.Control(func(fd uintptr) {
+		ucred, credErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	})
+	if ctrlErr != nil {
+		return 0, fmt.Errorf("control fd: %w", ctrlErr)
+	}
+	if credErr != nil {
+		return 0, fmt.Errorf("getsockopt SO_PEERCRED: %w", credErr)
+	}
+	return ucred.Uid, nil
+}

--- a/internal/identity/signer/signer.go
+++ b/internal/identity/signer/signer.go
@@ -1,0 +1,266 @@
+// Package signer implements the Contract-B DEV-INTERIM custody signer.
+//
+// The load-bearing property of real custody is that the ed25519 private key
+// lives in a SEPARATE process from the CLI: the CLI is KEYLESS and asks the
+// signer to sign canonical bytes over a 0600 Unix-domain socket. The signer
+// authenticates the caller by deriving its UID via darwin LOCAL_PEERCRED and
+// checking it against an allowlist, runs a policy hook, then signs with
+// identity.SignCanonical. The private key NEVER leaves this process — it is
+// never returned, logged, or exposed.
+//
+// DEV-INTERIM SCOPE: this is the ARCHITECTURE for real custody, not real
+// isolation yet. Today the signer and the CLI run as the SAME UID, so a
+// same-uid peer is not actually a different trust domain — the UID allowlist
+// gates "which uids may sign" but cannot yet distinguish the keyless CLI from
+// any other same-uid process.
+//
+// TODO(contract-b hardening): real isolation requires the signer to run under a
+// DEDICATED SERVICE UID via launchd, in a sandbox, with the key wrapped by the
+// Secure Enclave (SEP). Until those land, this provides the API surface and the
+// process boundary but NOT a real privilege boundary.
+package signer
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// Wire/identity error and protocol constants (SSOT).
+const (
+	// network is the Unix-domain socket network for both ends.
+	network = "unix"
+
+	// keyFilePerm is the required permission for the sealed private-key file.
+	keyFilePerm os.FileMode = 0o600
+	// socketPerm is the required permission for the listening socket.
+	socketPerm os.FileMode = 0o600
+
+	// maxRequestBytes bounds a single signing request so a hostile peer cannot
+	// force unbounded allocation. Canonical Contract-B entries are tiny; 1 MiB
+	// is far beyond any legitimate entry.
+	maxRequestBytes = 1 << 20
+
+	// respOK / respErr are the single-byte response status prefixes.
+	respOK  byte = 0x01
+	respErr byte = 0x00
+
+	// errSealKeyLen is returned by SealPrivateKey for a wrong-length key.
+	errSealKeyLen = "signer: seal: private key must be ed25519.PrivateKeySize bytes"
+	// errLoadKeyLen is returned by load for a key file of the wrong size.
+	errLoadKeyLen = "signer: load: key file is not ed25519.PrivateKeySize bytes"
+	// errUIDNotAllowed is returned when the caller UID is not on the allowlist.
+	errUIDNotAllowed = "signer: caller uid not allowed"
+	// errPolicyRefused prefixes a policy-hook refusal.
+	errPolicyRefused = "signer: policy refused"
+	// errNotListening is returned when Serve is called before Listen.
+	errNotListening = "signer: not listening (call Listen first)"
+)
+
+// PolicyFunc inspects the canonical bytes a caller asked to sign and returns a
+// non-nil error to REFUSE signing. It is a seam: the default is permissive
+// (signs everything) but the hook is always PRESENT so a future policy can
+// refuse dangerous messages without an API change.
+type PolicyFunc func(canonicalBytes []byte) error
+
+// Config configures a Signer. KeyPath and SocketPath are required.
+type Config struct {
+	// KeyPath is the 0600 sealed ed25519 private-key file.
+	KeyPath string
+	// SocketPath is the 0600 Unix-domain socket the signer listens on.
+	SocketPath string
+	// AllowedUIDs is the allowlist of caller UIDs permitted to request a
+	// signature. A caller whose peer UID is not in this set is denied.
+	AllowedUIDs []uint32
+	// Policy is the refusal hook. Nil means permissive (sign everything).
+	Policy PolicyFunc
+}
+
+// Signer holds the private key in-process and serves signing requests over a
+// 0600 Unix-domain socket. The key is never returned, logged, or exposed.
+type Signer struct {
+	priv    ed25519.PrivateKey
+	cfg     Config
+	allowed map[uint32]struct{}
+
+	mu sync.Mutex
+	ln *net.UnixListener
+}
+
+// New loads the sealed private key and prepares a Signer. It does NOT yet bind
+// the socket — call Listen, then Serve. New fails if the key file is missing or
+// the wrong size.
+func New(cfg Config) (*Signer, error) {
+	if cfg.KeyPath == "" {
+		return nil, errors.New("signer: KeyPath is required")
+	}
+	if cfg.SocketPath == "" {
+		return nil, errors.New("signer: SocketPath is required")
+	}
+	priv, err := loadPrivateKey(cfg.KeyPath)
+	if err != nil {
+		return nil, err
+	}
+	allowed := make(map[uint32]struct{}, len(cfg.AllowedUIDs))
+	for _, u := range cfg.AllowedUIDs {
+		allowed[u] = struct{}{}
+	}
+	return &Signer{priv: priv, cfg: cfg, allowed: allowed}, nil
+}
+
+// Listen binds the 0600 Unix-domain socket. Any stale socket file at the path
+// is removed first. The socket is chmod'd to 0600 so only the owning uid can
+// connect (the same-uid dev-interim boundary; see package doc).
+func (s *Signer) Listen() error {
+	// Remove a stale socket left by a prior crashed run.
+	if err := os.Remove(s.cfg.SocketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("signer: remove stale socket: %w", err)
+	}
+	addr, err := net.ResolveUnixAddr(network, s.cfg.SocketPath)
+	if err != nil {
+		return fmt.Errorf("signer: resolve socket: %w", err)
+	}
+	ln, err := net.ListenUnix(network, addr)
+	if err != nil {
+		return fmt.Errorf("signer: listen: %w", err)
+	}
+	// TODO(contract-b hardening): under a dedicated service uid + launchd, the
+	// socket should be owned by the service uid and group-readable only by the
+	// CLI's uid; for now 0600 + same-uid is the interim boundary.
+	if err := os.Chmod(s.cfg.SocketPath, socketPerm); err != nil {
+		_ = ln.Close()
+		return fmt.Errorf("signer: chmod socket: %w", err)
+	}
+	s.mu.Lock()
+	s.ln = ln
+	s.mu.Unlock()
+	return nil
+}
+
+// Serve accepts connections until the listener is closed. Each connection is a
+// single sign request/response. Serve blocks; run it in a goroutine.
+func (s *Signer) Serve() error {
+	s.mu.Lock()
+	ln := s.ln
+	s.mu.Unlock()
+	if ln == nil {
+		return errors.New(errNotListening)
+	}
+	for {
+		conn, err := ln.AcceptUnix()
+		if err != nil {
+			// A closed listener is a clean shutdown (Close was called); any
+			// other accept error is surfaced.
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("signer: accept: %w", err)
+		}
+		s.handle(conn)
+	}
+}
+
+// Close stops the listener and removes the socket file. The in-memory key is
+// dropped when the process exits; Close does not attempt to scrub it (Go's GC
+// gives no guarantee, and the dedicated-uid hardening is the real mitigation).
+func (s *Signer) Close() error {
+	s.mu.Lock()
+	ln := s.ln
+	s.ln = nil
+	s.mu.Unlock()
+	if ln != nil {
+		_ = ln.Close()
+	}
+	if err := os.Remove(s.cfg.SocketPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// handle services one connection: authenticate the peer UID, read the request,
+// run policy, sign, and write the response. Errors are reported to the caller
+// as a respErr frame, never as a leaked key or a silent success.
+func (s *Signer) handle(conn *net.UnixConn) {
+	defer func() { _ = conn.Close() }()
+
+	uid, err := peerUID(conn)
+	if err != nil {
+		writeErr(conn, fmt.Sprintf("signer: peer uid: %v", err))
+		return
+	}
+	if _, ok := s.allowed[uid]; !ok {
+		writeErr(conn, errUIDNotAllowed)
+		return
+	}
+
+	req, err := readFrame(conn)
+	if err != nil {
+		writeErr(conn, fmt.Sprintf("signer: read request: %v", err))
+		return
+	}
+
+	if s.cfg.Policy != nil {
+		if perr := s.cfg.Policy(req); perr != nil {
+			writeErr(conn, fmt.Sprintf("%s: %v", errPolicyRefused, perr))
+			return
+		}
+	}
+
+	// Sign over the received bytes, which the CLI guarantees are JCS-canonical
+	// (validated + canonicalized before sending). The key never leaves here.
+	sig, err := identity.SignCanonical(s.priv, identity.CanonicalBytesFromTrusted(req))
+	if err != nil {
+		writeErr(conn, fmt.Sprintf("signer: sign: %v", err))
+		return
+	}
+	writeOK(conn, sig)
+}
+
+// loadPrivateKey reads the sealed key file and returns the ed25519 private key.
+// It enforces the exact key length so a truncated/corrupt file fails closed.
+func loadPrivateKey(path string) (ed25519.PrivateKey, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- operator-configured sealed signer key path (signer Config), not runtime user input
+	if err != nil {
+		return nil, fmt.Errorf("signer: read key file: %w", err)
+	}
+	if len(b) != ed25519.PrivateKeySize {
+		return nil, errors.New(errLoadKeyLen)
+	}
+	priv := make(ed25519.PrivateKey, ed25519.PrivateKeySize)
+	copy(priv, b)
+	return priv, nil
+}
+
+// SealPrivateKey writes priv to path with 0600 permissions, creating it
+// exclusively (O_EXCL) so an existing key is never silently overwritten. It is
+// the ONLY blessed way to persist a signer key. The private key is written
+// raw; the SEP-wrap is deferred.
+//
+// TODO(contract-b hardening): wrap the key with the Secure Enclave (SEP) so it
+// is non-exfiltratable at rest; today it is a raw 0600 file on disk.
+func SealPrivateKey(path string, priv ed25519.PrivateKey) error {
+	if len(priv) != ed25519.PrivateKeySize {
+		return errors.New(errSealKeyLen)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, keyFilePerm) // #nosec G304 -- operator-configured sealed signer key path, created 0600 O_EXCL
+	if err != nil {
+		return fmt.Errorf("signer: create key file: %w", err)
+	}
+	if _, err := f.Write(priv); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("signer: write key file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("signer: close key file: %w", err)
+	}
+	// Re-assert 0600 in case umask/OS widened the create mode.
+	if err := os.Chmod(path, keyFilePerm); err != nil {
+		return fmt.Errorf("signer: chmod key file: %w", err)
+	}
+	return nil
+}

--- a/internal/identity/signer/signer.go
+++ b/internal/identity/signer/signer.go
@@ -78,6 +78,16 @@ type Config struct {
 	// signature. A caller whose peer UID is not in this set is denied.
 	AllowedUIDs []uint32
 	// Policy is the refusal hook. Nil means permissive (sign everything).
+	//
+	// TODO(contract-b hardening): the nil/permissive default lets any
+	// allowlisted caller get arbitrary bytes signed. This is an INTENTIONAL
+	// same-uid dev-interim residual, NOT permanent — before the signer moves
+	// behind a dedicated service UID, it MUST enforce identity.ValidateSchema
+	// (+ optionally re-canonicalize) server-side, because at that point the
+	// CLI/caller is across a trust boundary and can no longer be trusted to
+	// have validated. Shipping without this under a dedicated-uid deployment
+	// would make the signer an arbitrary-bytes signing oracle behind the new
+	// privilege boundary.
 	Policy PolicyFunc
 }
 
@@ -144,6 +154,14 @@ func (s *Signer) Listen() error {
 
 // Serve accepts connections until the listener is closed. Each connection is a
 // single sign request/response. Serve blocks; run it in a goroutine.
+//
+// TODO(contract-b hardening): connections are handled sequentially with no
+// per-connection read/write deadline — a slow or stalled client blocks the
+// entire signer until the connection closes. This is an availability issue
+// only (single same-uid caller in the dev-interim model). In the hardening
+// slice, set a per-connection deadline via conn.SetDeadline immediately after
+// AcceptUnix, and consider handling connections in goroutines if concurrent
+// callers become possible.
 func (s *Signer) Serve() error {
 	s.mu.Lock()
 	ln := s.ln
@@ -185,6 +203,11 @@ func (s *Signer) Close() error {
 // handle services one connection: authenticate the peer UID, read the request,
 // run policy, sign, and write the response. Errors are reported to the caller
 // as a respErr frame, never as a leaked key or a silent success.
+//
+// TODO(contract-b hardening): handle has no panic recovery — a panicking
+// Policy hook would crash the signer process. Add a recover() at the top of
+// this function in the hardening slice so a misbehaving hook is converted to
+// an error response rather than a process crash.
 func (s *Signer) handle(conn *net.UnixConn) {
 	defer func() { _ = conn.Close() }()
 
@@ -211,8 +234,16 @@ func (s *Signer) handle(conn *net.UnixConn) {
 		}
 	}
 
-	// Sign over the received bytes, which the CLI guarantees are JCS-canonical
-	// (validated + canonicalized before sending). The key never leaves here.
+	// TODO(contract-b hardening): client-side-only validation is trusted ONLY
+	// because the caller and signer run as the same UID today (same-uid
+	// dev-interim residual — see the Policy TODO above). Once the signer moves
+	// behind a dedicated service UID, "the CLI guarantees JCS-canonical bytes"
+	// is no longer a valid trust claim: the CLI is across a privilege boundary
+	// and must be treated as untrusted input. At that point, the signer MUST
+	// re-validate via identity.ValidateSchema (and optionally re-canonicalize)
+	// server-side before signing, or the Policy hook must enforce it.
+	//
+	// Sign over the received bytes. The key never leaves here.
 	sig, err := identity.SignCanonical(s.priv, identity.CanonicalBytesFromTrusted(req))
 	if err != nil {
 		writeErr(conn, fmt.Sprintf("signer: sign: %v", err))
@@ -243,6 +274,11 @@ func loadPrivateKey(path string) (ed25519.PrivateKey, error) {
 //
 // TODO(contract-b hardening): wrap the key with the Secure Enclave (SEP) so it
 // is non-exfiltratable at rest; today it is a raw 0600 file on disk.
+//
+// TODO(contract-b hardening): a mid-write error (e.g. disk full after partial
+// write) leaves a partial key file at path. In the hardening slice, write to a
+// temp file in the same directory, then os.Rename into place atomically so a
+// failed write never produces a truncated key file.
 func SealPrivateKey(path string, priv ed25519.PrivateKey) error {
 	if len(priv) != ed25519.PrivateKeySize {
 		return errors.New(errSealKeyLen)

--- a/internal/identity/signer/signer_test.go
+++ b/internal/identity/signer/signer_test.go
@@ -1,0 +1,269 @@
+package signer
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// canonicalEntry is a minimal Contract-B-conformant entry (top-level JSON
+// object, ASCII keys, integer/string values) used across the signer tests.
+const canonicalEntry = `{"agent":"mira","epoch":1}`
+
+// newKeyFile mints an ed25519 keypair, seals the private key to a 0600 file in a
+// temp dir, and returns the file path plus the public key for verification.
+func newKeyFile(t *testing.T) (keyPath string, pub ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	dir := t.TempDir()
+	keyPath = filepath.Join(dir, "signer.key")
+	if err := SealPrivateKey(keyPath, priv); err != nil {
+		t.Fatalf("SealPrivateKey: %v", err)
+	}
+	return keyPath, pub
+}
+
+// shortSocketPath returns a socket path short enough to fit the ~104-char Unix
+// socket path limit (t.TempDir() under /var/folders on darwin can exceed it).
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "vmsk")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s.sock")
+}
+
+// startSigner boots a Signer on a temp UDS with the given uid allowlist and
+// returns a connected client plus the socket path. It registers cleanup.
+func startSigner(t *testing.T, keyPath string, allow []uint32) (*Client, string) {
+	t.Helper()
+	sockPath := shortSocketPath(t)
+	s, err := New(Config{
+		KeyPath:     keyPath,
+		SocketPath:  sockPath,
+		AllowedUIDs: allow,
+	})
+	if err != nil {
+		t.Fatalf("New signer: %v", err)
+	}
+	if err := s.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	go s.Serve()
+	t.Cleanup(func() { _ = s.Close() })
+	return &Client{SocketPath: sockPath}, sockPath
+}
+
+func canonicalBytes(t *testing.T) identity.CanonicalBytes {
+	t.Helper()
+	cb, err := identity.Canonicalize([]byte(canonicalEntry))
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	return cb
+}
+
+func TestSealPrivateKeyIs0600(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("key file perm = %o, want 0600", perm)
+	}
+}
+
+func TestSignerSignsForAllowlistedCaller(t *testing.T) {
+	keyPath, pub := newKeyFile(t)
+	// Allow the current uid (the test process IS the caller).
+	client, _ := startSigner(t, keyPath, []uint32{uint32(os.Getuid())})
+
+	cb := canonicalBytes(t)
+	sig, err := client.Sign(cb.Bytes())
+	if err != nil {
+		t.Fatalf("client.Sign: %v", err)
+	}
+
+	ok, err := identity.VerifyCanonical(pub, cb, sig)
+	if err != nil {
+		t.Fatalf("VerifyCanonical err: %v", err)
+	}
+	if !ok {
+		t.Fatal("signature did not verify")
+	}
+}
+
+func TestSignerDeniesNonAllowlistedCaller(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	// Allowlist a uid that is NOT the caller's (caller uid + 1 wraps but is fine
+	// for a not-equal check; ensure it differs).
+	other := uint32(os.Getuid()) + 1
+	client, _ := startSigner(t, keyPath, []uint32{other})
+
+	cb := canonicalBytes(t)
+	_, err := client.Sign(cb.Bytes())
+	if err == nil {
+		t.Fatal("expected denial for non-allowlisted caller, got nil error")
+	}
+}
+
+func TestSignerNeverReturnsKeyBytes(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	client, _ := startSigner(t, keyPath, []uint32{uint32(os.Getuid())})
+
+	priv, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("ReadFile key: %v", err)
+	}
+
+	cb := canonicalBytes(t)
+	sig, err := client.Sign(cb.Bytes())
+	if err != nil {
+		t.Fatalf("client.Sign: %v", err)
+	}
+	// The signature is ed25519.SignatureSize and must not contain the seed.
+	if len(sig) != ed25519.SignatureSize {
+		t.Fatalf("sig len = %d, want %d", len(sig), ed25519.SignatureSize)
+	}
+	if containsSub(sig, priv) {
+		t.Fatal("signer response leaked private key bytes")
+	}
+	// The ed25519 seed (first 32 bytes) must also not appear in the response.
+	if containsSub(sig, priv[:ed25519.SeedSize]) {
+		t.Fatal("signer response leaked private key seed")
+	}
+}
+
+func TestClientFailsClosedWhenSignerUnreachable(t *testing.T) {
+	// Point the client at a socket path that does not exist.
+	client := &Client{SocketPath: shortSocketPath(t)}
+	cb := canonicalBytes(t)
+	_, err := client.Sign(cb.Bytes())
+	if err == nil {
+		t.Fatal("expected fail-closed error when signer unreachable, got nil")
+	}
+}
+
+func TestPolicyHookCanRefuse(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	sockPath := shortSocketPath(t)
+	denied := errors.New("policy refused")
+	s, err := New(Config{
+		KeyPath:     keyPath,
+		SocketPath:  sockPath,
+		AllowedUIDs: []uint32{uint32(os.Getuid())},
+		Policy: func(_ []byte) error {
+			return denied
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	go s.Serve()
+	t.Cleanup(func() { _ = s.Close() })
+
+	client := &Client{SocketPath: sockPath}
+	cb := canonicalBytes(t)
+	if _, err := client.Sign(cb.Bytes()); err == nil {
+		t.Fatal("expected policy refusal, got nil error")
+	}
+}
+
+func TestSocketIs0600(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	_, sockPath := startSigner(t, keyPath, []uint32{uint32(os.Getuid())})
+	info, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatalf("Stat sock: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("socket perm = %o, want 0600", perm)
+	}
+}
+
+func TestSealPrivateKeyRejectsWrongLength(t *testing.T) {
+	dir := t.TempDir()
+	if err := SealPrivateKey(filepath.Join(dir, "k"), []byte("short")); err == nil {
+		t.Fatal("expected error for wrong-length private key")
+	}
+}
+
+func TestSealPrivateKeyRefusesOverwrite(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	if err := SealPrivateKey(keyPath, priv); err == nil {
+		t.Fatal("expected O_EXCL refusal to overwrite existing key")
+	}
+}
+
+func TestNewRequiresKeyAndSocketPaths(t *testing.T) {
+	if _, err := New(Config{SocketPath: "/tmp/s.sock"}); err == nil {
+		t.Fatal("expected error for missing KeyPath")
+	}
+	keyPath, _ := newKeyFile(t)
+	if _, err := New(Config{KeyPath: keyPath}); err == nil {
+		t.Fatal("expected error for missing SocketPath")
+	}
+}
+
+func TestNewRejectsBadKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.key")
+	if err := os.WriteFile(bad, []byte("not-a-key"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := New(Config{KeyPath: bad, SocketPath: filepath.Join(dir, "s.sock")}); err == nil {
+		t.Fatal("expected error for wrong-size key file")
+	}
+}
+
+func TestNewRejectsMissingKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := New(Config{KeyPath: filepath.Join(dir, "nope.key"), SocketPath: filepath.Join(dir, "s.sock")}); err == nil {
+		t.Fatal("expected error for missing key file")
+	}
+}
+
+func TestWriteFrameRejectsOversizePayload(t *testing.T) {
+	// A nil conn is fine: the size check fires before any write.
+	if err := writeFrame(nil, make([]byte, maxRequestBytes+1)); err == nil {
+		t.Fatal("expected error for oversize frame")
+	}
+}
+
+// containsSub reports whether sub appears as a contiguous subsequence of b.
+func containsSub(b, sub []byte) bool {
+	if len(sub) == 0 || len(sub) > len(b) {
+		return false
+	}
+	for i := 0; i+len(sub) <= len(b); i++ {
+		match := true
+		for j := range sub {
+			if b[i+j] != sub[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/identity/signer/signer_test.go
+++ b/internal/identity/signer/signer_test.go
@@ -1,9 +1,13 @@
 package signer
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/binary"
 	"errors"
+	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -245,6 +249,183 @@ func TestWriteFrameRejectsOversizePayload(t *testing.T) {
 	// A nil conn is fine: the size check fires before any write.
 	if err := writeFrame(nil, make([]byte, maxRequestBytes+1)); err == nil {
 		t.Fatal("expected error for oversize frame")
+	}
+}
+
+// startRawServer stands up a raw Unix-domain listener whose single accepted
+// connection is driven by handler. It returns the socket path. It exists so the
+// client can be tested against DELIBERATELY MALFORMED server responses that a
+// well-behaved signer would never produce.
+func startRawServer(t *testing.T, handler func(net.Conn)) string {
+	t.Helper()
+	sockPath := shortSocketPath(t)
+	ln, err := net.Listen(network, sockPath)
+	if err != nil {
+		t.Fatalf("raw listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		handler(conn)
+	}()
+	return sockPath
+}
+
+// assertSignFailsClosed asserts client.Sign returns a non-nil error AND never a
+// nil-error-with-a-signature — the load-bearing fail-closed contract.
+func assertSignFailsClosed(t *testing.T, sockPath string) {
+	t.Helper()
+	client := &Client{SocketPath: sockPath}
+	sig, err := client.Sign([]byte(`{"agent":"mira","epoch":1}`))
+	if err == nil {
+		t.Fatalf("expected fail-closed error, got nil (sig=%x)", sig)
+	}
+	if sig != nil {
+		t.Fatalf("fail-closed path returned a non-nil signature: %x", sig)
+	}
+}
+
+// TestClientFailsClosedOnEmptySocketPath asserts a Client with no SocketPath
+// fails closed (non-nil error, nil signature) rather than dialing an empty
+// address — a misconfiguration must never silently produce no signature.
+func TestClientFailsClosedOnEmptySocketPath(t *testing.T) {
+	client := &Client{}
+	sig, err := client.Sign([]byte(`{"agent":"mira","epoch":1}`))
+	if err == nil {
+		t.Fatalf("expected error for empty SocketPath, got nil (sig=%x)", sig)
+	}
+	if sig != nil {
+		t.Fatalf("empty-SocketPath path returned a signature: %x", sig)
+	}
+}
+
+// TestClientFailsClosedOnMalformedServer drives client.Sign against servers that
+// violate the wire protocol. In every case Sign must FAIL CLOSED — these cover
+// the read-status / readFrame / response-parse error branches in client.Sign.
+func TestClientFailsClosedOnMalformedServer(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler func(net.Conn)
+	}{
+		{
+			// Closes immediately after reading nothing: the client's read of the
+			// 1-byte response status hits EOF.
+			name:    "closes before any response",
+			handler: func(conn net.Conn) { _ = conn.Close() },
+		},
+		{
+			// Sends the status byte, then announces an oversize response frame
+			// (> maxRequestBytes): readFrame must reject before allocating.
+			name: "oversize response length prefix",
+			handler: func(conn net.Conn) {
+				_, _ = conn.Write([]byte{respOK})
+				var hdr [frameHeaderLen]byte
+				binary.BigEndian.PutUint32(hdr[:], maxRequestBytes+1)
+				_, _ = conn.Write(hdr[:])
+			},
+		},
+		{
+			// Sends status + a header claiming N bytes, then closes early: the
+			// client's readFrame payload read hits EOF (truncated frame).
+			name: "announces bytes then closes early",
+			handler: func(conn net.Conn) {
+				_, _ = conn.Write([]byte{respOK})
+				var hdr [frameHeaderLen]byte
+				binary.BigEndian.PutUint32(hdr[:], 64)
+				_, _ = conn.Write(hdr[:])
+				_, _ = conn.Write([]byte("short"))
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sockPath := startRawServer(t, tc.handler)
+			assertSignFailsClosed(t, sockPath)
+		})
+	}
+}
+
+// TestSignerRejectsOversizeRequestOnLiveConn connects raw to a STARTED signer
+// and writes a request header announcing 0xFFFFFFFF bytes. The signer's
+// read-side readFrame must reject it (n > maxRequestBytes) and reply with a
+// respErr frame — no OOM, no hang, no signature.
+func TestSignerRejectsOversizeRequestOnLiveConn(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	_, sockPath := startSigner(t, keyPath, []uint32{uint32(os.Getuid())})
+
+	conn, err := net.Dial(network, sockPath)
+	if err != nil {
+		t.Fatalf("dial signer: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	var hdr [frameHeaderLen]byte
+	binary.BigEndian.PutUint32(hdr[:], 0xFFFFFFFF)
+	if _, err := conn.Write(hdr[:]); err != nil {
+		t.Fatalf("write oversize header: %v", err)
+	}
+
+	// Read the response: a respErr status byte, then a framed error message.
+	status := make([]byte, 1)
+	if _, err := io.ReadFull(conn, status); err != nil {
+		t.Fatalf("read response status: %v", err)
+	}
+	if status[0] != respErr {
+		t.Fatalf("status = %#x, want respErr (%#x)", status[0], respErr)
+	}
+	payload, err := readFrame(conn)
+	if err != nil {
+		t.Fatalf("read error frame: %v", err)
+	}
+	if !bytes.Contains(payload, []byte(errFrameTooLarge)) {
+		t.Fatalf("error frame %q does not mention oversize rejection", string(payload))
+	}
+}
+
+// TestPolicyHookReceivesCanonicalBytesAndPermissiveSigns asserts two contracts:
+//  1. the bytes handed to the Policy hook are EXACTLY the canonical request
+//     bytes (so a real policy inspects what is actually signed), and
+//  2. a permissive policy (returns nil) still produces a verifying signature.
+func TestPolicyHookReceivesCanonicalBytesAndPermissiveSigns(t *testing.T) {
+	keyPath, pub := newKeyFile(t)
+	cb := canonicalBytes(t)
+
+	var seen []byte
+	sockPath := shortSocketPath(t)
+	s, err := New(Config{
+		KeyPath:     keyPath,
+		SocketPath:  sockPath,
+		AllowedUIDs: []uint32{uint32(os.Getuid())},
+		Policy: func(b []byte) error {
+			seen = append([]byte(nil), b...)
+			return nil // permissive: must still sign
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	go func() { _ = s.Serve() }()
+	t.Cleanup(func() { _ = s.Close() })
+
+	client := &Client{SocketPath: sockPath}
+	sig, err := client.Sign(cb.Bytes())
+	if err != nil {
+		t.Fatalf("client.Sign with permissive policy: %v", err)
+	}
+
+	if !bytes.Equal(seen, cb.Bytes()) {
+		t.Fatalf("policy saw %q, want canonical request bytes %q", seen, cb.Bytes())
+	}
+	ok, err := identity.VerifyCanonical(pub, cb, sig)
+	if err != nil || !ok {
+		t.Fatalf("permissive-policy signature did not verify: ok=%v err=%v", ok, err)
 	}
 }
 

--- a/internal/identity/signer/wire.go
+++ b/internal/identity/signer/wire.go
@@ -1,0 +1,69 @@
+package signer
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+)
+
+// frameHeaderLen is the byte length of the big-endian uint32 length prefix that
+// precedes every framed payload on the wire.
+const frameHeaderLen = 4
+
+// errFrameTooLarge is returned when a peer announces a payload larger than
+// maxRequestBytes.
+const errFrameTooLarge = "signer: frame exceeds maximum size"
+
+// writeFrame writes a length-prefixed payload: a big-endian uint32 length
+// followed by the bytes.
+func writeFrame(conn net.Conn, payload []byte) error {
+	if len(payload) > maxRequestBytes {
+		return errors.New(errFrameTooLarge)
+	}
+	var hdr [frameHeaderLen]byte
+	// len(payload) is bounded by maxRequestBytes (1 MiB) above, so the uint32
+	// conversion cannot overflow.
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload))) //nolint:gosec // bounded by maxRequestBytes
+
+	if _, err := conn.Write(hdr[:]); err != nil {
+		return fmt.Errorf("signer: write frame header: %w", err)
+	}
+	if _, err := conn.Write(payload); err != nil {
+		return fmt.Errorf("signer: write frame payload: %w", err)
+	}
+	return nil
+}
+
+// readFrame reads a single length-prefixed payload, rejecting any frame larger
+// than maxRequestBytes before allocating.
+func readFrame(conn net.Conn) ([]byte, error) {
+	var hdr [frameHeaderLen]byte
+	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+		return nil, fmt.Errorf("signer: read frame header: %w", err)
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n > maxRequestBytes {
+		return nil, errors.New(errFrameTooLarge)
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return nil, fmt.Errorf("signer: read frame payload: %w", err)
+	}
+	return buf, nil
+}
+
+// writeOK writes a success response: the respOK status byte followed by a
+// framed signature payload.
+func writeOK(conn net.Conn, sig []byte) {
+	_, _ = conn.Write([]byte{respOK})
+	_ = writeFrame(conn, sig)
+}
+
+// writeErr writes a failure response: the respErr status byte followed by a
+// framed error message. The signer NEVER includes key material in an error.
+func writeErr(conn net.Conn, msg string) {
+	_, _ = conn.Write([]byte{respErr})
+	_ = writeFrame(conn, []byte(msg))
+}

--- a/internal/identitycli/identitycli.go
+++ b/internal/identitycli/identitycli.go
@@ -1,0 +1,80 @@
+// Package identitycli holds the business logic behind the `vaultmind identity`
+// commands (init, sign), keeping the cmd/ layer ultra-thin (ADR-001).
+//
+// The cardinal property: this package is KEYLESS for signing. SignEntry never
+// opens the private-key file — it validates+canonicalizes via the slice-1
+// identity core and delegates the actual ed25519 sign to a SignerClient (the
+// separate signer process over its 0600 socket). Only Init touches a private
+// key, and only to SEAL it via signer.SealPrivateKey; the key is never printed
+// or logged.
+package identitycli
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/signer"
+)
+
+// Output label constants (SSOT) so cmd/ and tests reference one definition.
+const (
+	// PubKeyLabel prefixes the printed public key. Only the PUBLIC key is ever
+	// printed by Init.
+	PubKeyLabel = "public_key (ed25519, base64): "
+	// SigLabel prefixes the printed signature.
+	SigLabel = "signature (ed25519, base64): "
+)
+
+// SignerClient is the minimal seam SignEntry needs: hand it canonical bytes,
+// get a signature back. The real implementation is *signer.Client; tests inject
+// a fake to prove the sign path never opens the key file.
+type SignerClient interface {
+	Sign(canonicalBytes []byte) ([]byte, error)
+}
+
+// Init mints a per-agent ed25519 keypair, SEALs the private key to keyPath
+// (0600, refusing to overwrite), and writes ONLY the public key to out. The
+// private key is never printed or logged.
+func Init(out io.Writer, keyPath string) error {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generating keypair: %w", err)
+	}
+	// SEAL the private key; on any error it stays only in memory, never emitted.
+	if err := signer.SealPrivateKey(keyPath, priv); err != nil {
+		return fmt.Errorf("sealing private key: %w", err)
+	}
+	pubB64 := base64.StdEncoding.EncodeToString(pub)
+	if _, err := fmt.Fprintf(out, "%s%s\n", PubKeyLabel, pubB64); err != nil {
+		return err
+	}
+	// TODO(contract-b registry slice): also derive + print the fingerprint and
+	// register the pubkey with the trust-root registry. Slice 2 is mint+custody.
+	return nil
+}
+
+// SignEntry runs the slice-1 validate+canonicalize path, hands the canonical
+// bytes to the SignerClient, and writes the signature to out. It is provably
+// KEYLESS: it has no key path and never reads the private-key file. It FAILS
+// CLOSED — any schema, canonicalize, or signer error returns non-nil and prints
+// nothing.
+func SignEntry(out io.Writer, client SignerClient, entryJSON []byte) error {
+	if err := identity.ValidateSchema(entryJSON); err != nil {
+		return fmt.Errorf("entry rejected by schema: %w", err)
+	}
+	canonical, err := identity.Canonicalize(entryJSON)
+	if err != nil {
+		return fmt.Errorf("canonicalizing entry: %w", err)
+	}
+	sig, err := client.Sign(canonical.Bytes())
+	if err != nil {
+		return fmt.Errorf("signing via signer: %w", err)
+	}
+	sigB64 := base64.StdEncoding.EncodeToString(sig)
+	_, werr := fmt.Fprintf(out, "%s%s\n", SigLabel, sigB64)
+	return werr
+}

--- a/internal/identitycli/identitycli_test.go
+++ b/internal/identitycli/identitycli_test.go
@@ -1,0 +1,224 @@
+package identitycli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/signer"
+)
+
+const testEntry = `{"agent":"mira","epoch":1}`
+
+// fakeSignerClient signs locally with a held key and records the bytes it
+// received. It lets the test prove SignEntry produces a verifying signature
+// WITHOUT ever opening a key file — the only key here is reached through the
+// SignerClient seam, not via any file read in identitycli.
+type fakeSignerClient struct {
+	priv         ed25519.PrivateKey
+	gotCanonical []byte
+	failErr      error
+}
+
+func (f *fakeSignerClient) Sign(canonicalBytes []byte) ([]byte, error) {
+	if f.failErr != nil {
+		return nil, f.failErr
+	}
+	f.gotCanonical = append([]byte(nil), canonicalBytes...)
+	return ed25519.Sign(f.priv, canonicalBytes), nil
+}
+
+type sentinelErr string
+
+func (e sentinelErr) Error() string { return string(e) }
+
+func shortSock(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "vmic")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s.sock")
+}
+
+func TestSignEntryProducesVerifyingSignatureKeylessly(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	fake := &fakeSignerClient{priv: priv}
+
+	var out bytes.Buffer
+	if err := SignEntry(&out, fake, []byte(testEntry)); err != nil {
+		t.Fatalf("SignEntry: %v", err)
+	}
+
+	wantCanonical, err := identity.Canonicalize([]byte(testEntry))
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	if !bytes.Equal(fake.gotCanonical, wantCanonical.Bytes()) {
+		t.Fatalf("client got %q, want canonical %q", fake.gotCanonical, wantCanonical.Bytes())
+	}
+
+	sig := decodeSig(t, out.String())
+	ok, err := identity.VerifyCanonical(pub, wantCanonical, sig)
+	if err != nil || !ok {
+		t.Fatalf("signature did not verify: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestSignEntryRejectsInvalidSchema(t *testing.T) {
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	// A bare array is not a Contract-B object -> schema reject; signer not called.
+	if err := SignEntry(&out, fake, []byte(`[1,2,3]`)); err == nil {
+		t.Fatal("expected schema rejection, got nil")
+	}
+	if fake.gotCanonical != nil {
+		t.Fatal("signer was called for schema-invalid input")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("schema reject must print nothing, got %q", out.String())
+	}
+}
+
+func TestSignEntryFailsClosedOnSignerError(t *testing.T) {
+	fake := &fakeSignerClient{failErr: sentinelErr("signer unreachable")}
+	var out bytes.Buffer
+	if err := SignEntry(&out, fake, []byte(testEntry)); err == nil {
+		t.Fatal("expected fail-closed error, got nil")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("fail-closed must print nothing, got %q", out.String())
+	}
+}
+
+// TestSignEntryEndToEndKeyless boots a real signer and drives SignEntry through
+// the real Client: the only process holding the key is the signer.
+func TestSignEntryEndToEndKeyless(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyDir, err := os.MkdirTemp("", "vmkey")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(keyDir) })
+	keyPath := filepath.Join(keyDir, "k.key")
+	if err := signer.SealPrivateKey(keyPath, priv); err != nil {
+		t.Fatalf("SealPrivateKey: %v", err)
+	}
+
+	sockPath := shortSock(t)
+	s, err := signer.New(signer.Config{
+		KeyPath:     keyPath,
+		SocketPath:  sockPath,
+		AllowedUIDs: []uint32{uint32(os.Getuid())},
+	})
+	if err != nil {
+		t.Fatalf("signer.New: %v", err)
+	}
+	if err := s.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	go s.Serve()
+	t.Cleanup(func() { _ = s.Close() })
+
+	client := &signer.Client{SocketPath: sockPath}
+	var out bytes.Buffer
+	if err := SignEntry(&out, client, []byte(testEntry)); err != nil {
+		t.Fatalf("SignEntry: %v", err)
+	}
+
+	wantCanonical, _ := identity.Canonicalize([]byte(testEntry))
+	ok, err := identity.VerifyCanonical(pub, wantCanonical, decodeSig(t, out.String()))
+	if err != nil || !ok {
+		t.Fatalf("e2e signature did not verify: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestInitWritesSealed0600KeyAndNeverEmitsPrivate(t *testing.T) {
+	keyDir, err := os.MkdirTemp("", "vminit")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(keyDir) })
+	keyPath := filepath.Join(keyDir, "k.key")
+
+	var out bytes.Buffer
+	if err := Init(&out, keyPath); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("Stat key: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("key perm = %o, want 0600", perm)
+	}
+
+	keyBytes, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("ReadFile key: %v", err)
+	}
+	if len(keyBytes) != ed25519.PrivateKeySize {
+		t.Fatalf("sealed key len = %d, want %d", len(keyBytes), ed25519.PrivateKeySize)
+	}
+
+	outStr := out.String()
+	if !strings.Contains(outStr, PubKeyLabel) {
+		t.Fatalf("output missing public-key label: %q", outStr)
+	}
+	if strings.Contains(outStr, base64.StdEncoding.EncodeToString(keyBytes)) {
+		t.Fatal("init leaked the private key (base64) to stdout")
+	}
+	if strings.Contains(outStr, base64.StdEncoding.EncodeToString(keyBytes[:ed25519.SeedSize])) {
+		t.Fatal("init leaked the private key seed (base64) to stdout")
+	}
+
+	priv := ed25519.PrivateKey(keyBytes)
+	wantPub := base64.StdEncoding.EncodeToString(priv.Public().(ed25519.PublicKey))
+	if !strings.Contains(outStr, wantPub) {
+		t.Fatalf("printed public key does not match sealed key; out=%q", outStr)
+	}
+}
+
+func TestInitRefusesOverwrite(t *testing.T) {
+	keyDir, err := os.MkdirTemp("", "vminit2")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(keyDir) })
+	keyPath := filepath.Join(keyDir, "k.key")
+
+	var out bytes.Buffer
+	if err := Init(&out, keyPath); err != nil {
+		t.Fatalf("first Init: %v", err)
+	}
+	if err := Init(&out, keyPath); err == nil {
+		t.Fatal("second Init must refuse to overwrite existing key")
+	}
+}
+
+func decodeSig(t *testing.T, output string) []byte {
+	t.Helper()
+	line := strings.TrimSpace(output)
+	if !strings.HasPrefix(line, SigLabel) {
+		t.Fatalf("output %q missing prefix %q", line, SigLabel)
+	}
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(line, SigLabel))
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+	return sig
+}

--- a/internal/onboard/COMMANDS.md
+++ b/internal/onboard/COMMANDS.md
@@ -55,6 +55,9 @@ Generated from the command tree — do not edit by hand (run `task generate:docs
 | `vaultmind hooks` | Manage VaultMind's Claude Code hook scripts | you need to install, remove, or check VaultMind's Claude Code hook scripts. |
 | `vaultmind hooks install` | Install Claude Code hook scripts into a project | you want to wire VaultMind into a project by writing its hook scripts. |
 | `vaultmind hooks uninstall` | Remove VaultMind's Claude Code hook entries from a project | you want to remove VaultMind's Claude Code hook entries from a project. |
+| `vaultmind identity` | Contract-B agent identity: keypair custody and signing | you need Contract-B agent identity: mint a keypair or sign an entry via the keyless signer. |
+| `vaultmind identity init` | Mint an agent keypair and seal the private key to the signer | you are setting up an agent and need to mint its ed25519 keypair and seal the private key to the signer. |
+| `vaultmind identity sign` | Validate, canonicalize, and sign an entry via the keyless signer | you have a Contract-B entry to sign and want it validated, canonicalized, and signed by the keyless signer. |
 | `vaultmind init` | Scaffold a fresh persona-shaped vault, ready for you and your agent | you are starting fresh and need to scaffold a new persona-shaped vault. |
 
 ## Setup & introspection:


### PR DESCRIPTION
## Contract B — slice 2: dev-interim custody signer

Builds on slice 1 (#10). A separate-process signing helper so the agent's ed25519 private key never lives in the CLI/daemon.

### What's in it
- **`internal/identity/signer/`** — a UDS signing helper: the private key lives **only** in the signer process; it listens on a `0600` Unix-domain socket, derives the caller UID from the kernel via **LOCAL_PEERCRED** (client cannot inject it) and checks a UID allowlist (fail-closed), runs a `policy()` hook seam, and signs via slice 1's `SignCanonical`. The key is never returned, logged, or formatted.
- **Keyless CLI** — `vaultmind identity init` (mint ed25519 → seal to a `0600 O_EXCL` key file, print only the public key, refuse overwrite) and `vaultmind identity sign` (validate + canonicalize via slice 1 → send canonical bytes to the signer over the UDS → print the signature). The CLI process **never loads the private key** (`SignEntry` takes a keyless `SignerClient` interface).

### Scope (dev-interim, ratified)
Architecture + API now, running **same-uid** — documented as **NOT real isolation**. The load-bearing isolation (a **dedicated service uid** + launchd + sandbox + sealed-at-rest/SEP-wrap) and **server-side `ValidateSchema`** in the signer are deliberately deferred to a hardening pass, flagged with `TODO(contract-b hardening)` at the exact sites.

### How it was reviewed
- **Adversarial security red-team** (4 angles): key-isolation (CLI keyless — structurally verified), peer-cred (fail-closed), signing-oracle, failure-modes. Verdict: dev-interim substance passes; the one must-fix (an *undocumented* signing-oracle residual) is now documented.
- **pr-review-toolkit** (code/tests/silent-failure/types/comments). `task check` green; patch coverage 82.8%; live dogfood confirmed the keyless init→sign→verify loop.

### Tracked follow-ups (from the toolkit, for the hardening slice)
- Surface the signer's response-write errors (currently swallowed; client still fails closed).
- Type the `SignerClient.Sign` seam with `identity.CanonicalBytes` (make the canonical contract structural across the seam).
- Reject an empty UID allowlist in `New` (loud config error vs silent deny-all).
- Plus the documented dev-interim hardening TODOs (dedicated uid/launchd/sandbox, server-side ValidateSchema, per-conn deadline + panic-recover, atomic key write, bounded stdin).
