### PR TITLE
feat(identity): Contract B registry — the trust root (slice 3)

### DIFF
--- a/internal/identity/registry/keys.go
+++ b/internal/identity/registry/keys.go
@@ -1,0 +1,129 @@
+package registry
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// Domain-type and namespace constants (SSOT — referenced, never inlined).
+const (
+	// ErrPubKeyBadLen is returned by NewPublicKey for a key that is not
+	// ed25519.PublicKeySize bytes.
+	ErrPubKeyBadLen = "registry: public key must be ed25519.PublicKeySize bytes"
+	// ErrPubKeySmallOrder is returned by NewPublicKey for a small-order
+	// (universal-forgery) or undecodable public key.
+	ErrPubKeySmallOrder = "registry: public key is small-order or undecodable"
+
+	// GlobalPrefix is the reserved global-prefix slot for a network id (Door 5).
+	// v1 ids carry this prefix so they can be made hierarchical later WITHOUT a
+	// re-key. The id itself is derived from the keypair, never from a public git
+	// remote (which is public + precomputable and enables traffic analysis).
+	GlobalPrefix = "vmnet1:"
+
+	// networkIDHashBytes is how many leading bytes of the pubkey hash form the
+	// network id body. 16 bytes (128 bits) is collision-safe for the id space.
+	networkIDHashBytes = 16
+)
+
+// PublicKey is a VALIDATED ed25519 public key: it is wrong-length-rejected and
+// small-order-rejected AT CONSTRUCTION (NewPublicKey), so an invalid key is
+// unrepresentable in the binding/verify path. Code that holds a PublicKey can
+// rely on it being decodable and not a universal-forgery vector.
+type PublicKey struct {
+	key ed25519.PublicKey
+}
+
+// NewPublicKey validates b and returns a PublicKey. It rejects a wrong-length
+// key and a small-order/undecodable key (the universal-forgery vector that
+// stdlib ed25519.Verify leaves open) by routing through the slice-1 guard, so a
+// hostile key cannot enter a binding. It never panics.
+func NewPublicKey(b []byte) (PublicKey, error) {
+	if len(b) != ed25519.PublicKeySize {
+		return PublicKey{}, fmt.Errorf("%s", ErrPubKeyBadLen)
+	}
+	// Route a no-op verify through the slice-1 primitive purely to reuse its
+	// small-order/undecodable guard: a wrong-length sig short-circuits before
+	// the (cheap) signature check, so the ONLY way to reach (false, non-nil) for
+	// a correct-length key is the small-order reject.
+	_, err := identity.VerifyCanonical(b, identity.CanonicalBytesFromTrusted(nil), make([]byte, ed25519.SignatureSize))
+	if err != nil && err.Error() == identity.ErrVerifySmallOrderPubKey {
+		return PublicKey{}, fmt.Errorf("%s", ErrPubKeySmallOrder)
+	}
+	pk := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	copy(pk, b)
+	return PublicKey{key: pk}, nil
+}
+
+// Bytes returns the raw 32-byte public key. The slice aliases internal storage;
+// callers must not mutate it.
+func (p PublicKey) Bytes() ed25519.PublicKey { return p.key }
+
+// SignedEntry is PROOF that a raw entry passed the Contract-B schema gate, was
+// canonicalized, and verified under a validated PublicKey. The ONLY constructor
+// is NewSignedEntry, which runs the full gate; a SignedEntry value therefore
+// cannot exist for an invalid/forged entry — the invalid state is
+// unrepresentable.
+type SignedEntry struct {
+	pub       PublicKey
+	canonical identity.CanonicalBytes
+	sig       []byte
+}
+
+// NewSignedEntry runs the gate: it verifies sig over the SCHEMA-VALIDATED,
+// canonicalized form of rawJSON under pub (via identity.VerifyEntry, which runs
+// ValidateSchema + Canonicalize + ZIP-215 strict verify). It returns an error
+// when the entry violates the schema, cannot be canonicalized, is structurally
+// rejected, or simply does not verify. On success the returned SignedEntry is
+// proof the entry is conformant and authentic.
+func NewSignedEntry(pub PublicKey, rawJSON []byte, sig []byte) (SignedEntry, error) {
+	ok, err := identity.VerifyEntry(pub.key, rawJSON, sig)
+	if err != nil {
+		return SignedEntry{}, err
+	}
+	if !ok {
+		return SignedEntry{}, fmt.Errorf("%s", errEntrySigMismatch)
+	}
+	canonical, err := identity.Canonicalize(rawJSON)
+	if err != nil {
+		return SignedEntry{}, err
+	}
+	return SignedEntry{pub: pub, canonical: canonical, sig: sig}, nil
+}
+
+// Canonical returns the canonical bytes that were signed.
+func (s SignedEntry) Canonical() identity.CanonicalBytes { return s.canonical }
+
+// Slug returns the empty string: a SignedEntry is a transport-level proof, not
+// a slug-bound binding. The accessor exists so callers can treat any signed
+// payload uniformly; binding-level identity lives on AgentBinding.
+func (s SignedEntry) Slug() string { return "" }
+
+// errEntrySigMismatch is returned by NewSignedEntry when a well-formed,
+// conformant entry's signature simply does not match the public key.
+const errEntrySigMismatch = "registry: signed entry signature does not match public key"
+
+// NetworkID derives a stable, keypair-bound network id from a public key. The
+// id is SHA-256(pubkey) truncated and hex-encoded behind the reserved
+// GlobalPrefix. It is derived from the AUTHENTICATOR (the keypair), never from a
+// public git-remote fingerprint, so it rotates with a re-key and does not leak a
+// precomputable fingerprint→slug mapping (Door 5).
+func NetworkID(pub ed25519.PublicKey) string {
+	sum := sha256.Sum256(pub)
+	return GlobalPrefix + hex.EncodeToString(sum[:networkIDHashBytes])
+}
+
+// decodePubKey decodes a base64 (std, padded) ed25519 public key into a
+// validated PublicKey. It is the bridge from the wire/JSON form (base64 string)
+// to the validated domain type used in the verify path.
+func decodePubKey(b64 string) (PublicKey, error) {
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return PublicKey{}, fmt.Errorf("registry: decode pubkey base64: %w", err)
+	}
+	return NewPublicKey(raw)
+}

--- a/internal/identity/registry/keys.go
+++ b/internal/identity/registry/keys.go
@@ -59,9 +59,15 @@ func NewPublicKey(b []byte) (PublicKey, error) {
 	return PublicKey{key: pk}, nil
 }
 
-// Bytes returns the raw 32-byte public key. The slice aliases internal storage;
-// callers must not mutate it.
-func (p PublicKey) Bytes() ed25519.PublicKey { return p.key }
+// Bytes returns a defensive COPY of the raw 32-byte public key. A copy (not an
+// alias to internal storage) preserves the validated-key invariant: a caller
+// that mutates the returned slice cannot corrupt the PublicKey held in a
+// binding.
+func (p PublicKey) Bytes() ed25519.PublicKey {
+	out := make(ed25519.PublicKey, len(p.key))
+	copy(out, p.key)
+	return out
+}
 
 // SignedEntry is PROOF that a raw entry passed the Contract-B schema gate, was
 // canonicalized, and verified under a validated PublicKey. The ONLY constructor

--- a/internal/identity/registry/reattack_freeze_test.go
+++ b/internal/identity/registry/reattack_freeze_test.go
@@ -1,0 +1,565 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RE-ATTACK: FREEZE/ECLIPSE — adversarial re-verification of the fix in
+// 5086a9bfc40d9eb3185cc3414c376fc8d79e828c.
+//
+// Goal: confirm the ENTIRE class of future-valid_from / stale-registry attacks
+// is closed, not just the specific cases that were reported. Test both the
+// registry level (VerifyAndLoad) and the binding level (Resolve, VerifyMessage).
+// Also confirm that honest, currently-valid registries still load (no
+// over-rejection).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ---------------------------------------------------------------------------
+// A. REGISTRY-LEVEL: VerifyAndLoad rejects future valid_from
+// ---------------------------------------------------------------------------
+
+// TestReattack_RegistryValidFrom_NowPlus1Second — smallest possible future offset.
+// If the fix only checks for "large" offsets, this catches it.
+func TestReattack_RegistryValidFrom_NowPlus1Second(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() + 1, // just 1 second in the future
+		ValidUntil: fixedNow.Unix() + 86400,
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	_, _, err = VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted a registry with valid_from = now+1s — " +
+			"the 1-second-future case must be rejected (freeze/eclipse)")
+	}
+	if !strings.Contains(err.Error(), ErrStale) {
+		t.Fatalf("expected ErrStale, got: %v", err)
+	}
+}
+
+// TestReattack_RegistryValidFrom_NowPlus1Year — large future offset.
+func TestReattack_RegistryValidFrom_NowPlus1Year(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() + 86400*365,
+		ValidUntil: fixedNow.Unix() + 86400*365*2,
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	_, _, err = VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted a registry with valid_from = now+1yr")
+	}
+}
+
+// TestReattack_RegistryValidFrom_NanosecondBeforeBoundary — now has 999999999ns
+// but now.Unix() truncates to the same second as valid_from. This tests
+// the inclusive boundary: valid_from == now.Unix() should PASS.
+func TestReattack_RegistryValidFrom_NanosecondBeforeBoundary(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// Registry valid_from == fixedNow.Unix() exactly
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// now at 0.999999999s past the valid_from second — still in the same unix second
+	nowWithNanos := time.Unix(reg.ValidFrom, 999_999_999)
+	_, _, err = VerifyAndLoad(rootPub, env, 4, nowWithNanos, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("valid_from is inclusive: registry must load when now.Unix() == valid_from, "+
+			"even with sub-second offset. Got: %v", err)
+	}
+}
+
+// TestReattack_RegistryValidFrom_ExactlyAtNow — now.Unix() == reg.ValidFrom.
+// This is the honest case and MUST be accepted (no over-rejection).
+func TestReattack_RegistryValidFrom_ExactlyAtNow(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	atStart := time.Unix(reg.ValidFrom, 0)
+	loaded, _, err := VerifyAndLoad(rootPub, env, 4, atStart, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: VerifyAndLoad rejected a registry at exactly valid_from: %v", err)
+	}
+	if len(loaded.Agents) != 1 {
+		t.Fatal("loaded registry has wrong agent count")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B. BINDING-LEVEL: Resolve rejects not-yet-active binding valid_from
+// ---------------------------------------------------------------------------
+
+// TestReattack_BindingValidFrom_NowPlus1Second_Resolve — binding valid_from
+// is 1 second in the future. Resolve must skip it.
+func TestReattack_BindingValidFrom_NowPlus1Second_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.ValidFrom = fixedNow.Unix() + 1
+	b.ValidUntil = fixedNow.Unix() + 86400
+
+	reg := freshRegistry(5, b)
+	_, err := Resolve(reg, "mira", fixedNow)
+	if err == nil {
+		t.Fatal("SECURITY: Resolve accepted a binding with valid_from = now+1s — " +
+			"the not-yet-active binding must not resolve")
+	}
+}
+
+// TestReattack_BindingValidFrom_NowPlus1Year_Resolve
+func TestReattack_BindingValidFrom_NowPlus1Year_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.ValidFrom = fixedNow.Unix() + 86400*365
+	b.ValidUntil = fixedNow.Unix() + 86400*365*2
+
+	reg := freshRegistry(5, b)
+	_, err := Resolve(reg, "mira", fixedNow)
+	if err == nil {
+		t.Fatal("SECURITY: Resolve accepted a binding with valid_from = now+1yr")
+	}
+}
+
+// TestReattack_BindingValidFrom_ExactlyAtNow_Resolve — boundary inclusiveness.
+// A binding that starts exactly now MUST resolve (no over-rejection).
+func TestReattack_BindingValidFrom_ExactlyAtNow_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	// b.ValidFrom default is 1_770_000_000; fixedNow is 1_770_000_500.
+	// Set ValidFrom to exactly now.
+	b.ValidFrom = fixedNow.Unix()
+	b.ValidUntil = fixedNow.Unix() + 86400
+
+	reg := freshRegistry(5, b)
+	resolved, err := Resolve(reg, "mira", fixedNow)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: Resolve rejected a binding at exactly valid_from == now: %v", err)
+	}
+	if resolved.Slug != "mira" {
+		t.Fatalf("resolved wrong slug: %q", resolved.Slug)
+	}
+}
+
+// TestReattack_BindingValidFrom_NanosecondPrecision_Resolve — now has nanoseconds
+// but now.Unix() truncates to the same second as valid_from. Still accepted.
+func TestReattack_BindingValidFrom_NanosecondPrecision_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	startSecond := fixedNow.Unix()
+	b.ValidFrom = startSecond
+	b.ValidUntil = startSecond + 86400
+
+	reg := freshRegistry(5, b)
+	// now is in the same second but with high nanoseconds
+	nowNanos := time.Unix(startSecond, 999_999_999)
+	_, err := Resolve(reg, "mira", nowNanos)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: Resolve rejected when now.Unix() == valid_from (sub-second): %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C. BINDING-LEVEL: VerifyMessage / resolveTuple rejects not-yet-active binding
+// ---------------------------------------------------------------------------
+
+// TestReattack_BindingValidFrom_NowPlus1Second_VerifyMessage — E2E through
+// the verify path.
+func TestReattack_BindingValidFrom_NowPlus1Second_VerifyMessage(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.ValidFrom = fixedNow.Unix() + 1
+	b.ValidUntil = fixedNow.Unix() + 86400
+
+	reg := freshRegistry(5, b)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"premature"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+
+	_, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow)
+	if err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted a message under a binding with valid_from = now+1s")
+	}
+	if !strings.Contains(err.Error(), ErrNotYetValid) {
+		t.Fatalf("expected ErrNotYetValid, got: %v", err)
+	}
+}
+
+// TestReattack_BindingValidFrom_ExactlyAtNow_VerifyMessage — honest case.
+// A binding that starts exactly now MUST verify (no over-rejection).
+func TestReattack_BindingValidFrom_ExactlyAtNow_VerifyMessage(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.ValidFrom = fixedNow.Unix()
+	b.ValidUntil = fixedNow.Unix() + 86400
+
+	reg := freshRegistry(5, b)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"on time"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+
+	ok, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: VerifyMessage rejected at exactly valid_from == now: %v", err)
+	}
+	if !ok {
+		t.Fatal("OVER-REJECTION: VerifyMessage returned false for a valid message at exact boundary")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D. FULL E2E: sign → load → resolve → verify with future binding in an
+//    otherwise-valid registry. The registry itself is in-window, but the
+//    binding's valid_from is in the future. Resolve and VerifyMessage must
+//    both reject the premature binding.
+// ---------------------------------------------------------------------------
+
+func TestReattack_FullE2E_FutureBinding_InWindowRegistry(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, agentPriv := genKey(t)
+
+	// Registry is valid NOW, but the binding starts 1 hour from now.
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.ValidFrom = fixedNow.Unix() + 3600
+	b.ValidUntil = fixedNow.Unix() + 86400
+
+	reg := freshRegistry(5, b)
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// Registry loads (it is in-window).
+	loaded, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad should accept an in-window registry: %v", err)
+	}
+
+	// Resolve must reject the future binding.
+	if _, err := Resolve(loaded, "mira", fixedNow); err == nil {
+		t.Fatal("SECURITY: Resolve accepted a future-valid_from binding inside a loaded registry")
+	}
+
+	// VerifyMessage must also reject it.
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"early"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(loaded, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted a message under a future-valid_from binding")
+	}
+
+	// SAME binding at its valid_from MUST work (no over-rejection).
+	futureNow := time.Unix(b.ValidFrom, 0)
+	resolved, err := Resolve(loaded, "mira", futureNow)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: Resolve rejected binding at its valid_from: %v", err)
+	}
+	if resolved.Slug != "mira" {
+		t.Fatalf("resolved wrong slug: %q", resolved.Slug)
+	}
+	ok, err := VerifyMessage(loaded, "mira", 1, canonical, sig, futureNow)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: VerifyMessage rejected at binding valid_from: %v", err)
+	}
+	if !ok {
+		t.Fatal("OVER-REJECTION: VerifyMessage returned false at binding valid_from")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// E. WITHHELD/STALE REGISTRY — an attacker serves a legitimately-signed
+//    registry that is past its freshness window. Must still fail closed.
+// ---------------------------------------------------------------------------
+
+func TestReattack_WithheldRegistry_StillFailsClosed(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// Consumer's clock is 1 second past valid_until — the registry is stale.
+	staleNow := time.Unix(reg.ValidUntil+1, 0)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, staleNow, time.Hour*24*365); err == nil {
+		t.Fatal("SECURITY: withheld registry (past valid_until) was accepted")
+	}
+
+	// Consumer's clock is within valid_until but staleness exceeds maxStaleness.
+	// reg.ValidFrom = 1_770_000_000; set now to valid_from + 25 hours, within
+	// valid_until (1_780_000_000), but with maxStaleness = 24h.
+	staleByMax := time.Unix(reg.ValidFrom+int64((time.Hour*25).Seconds()), 0)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, staleByMax, time.Hour*24); err == nil {
+		t.Fatal("SECURITY: withheld registry (past maxStaleness) was accepted")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// F. HONEST REGISTRY — confirm no over-rejection after the fix.
+// ---------------------------------------------------------------------------
+
+func TestReattack_HonestRegistry_StillLoadsAndVerifies(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, agentPriv := genKey(t)
+
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	loaded, newHighest, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: honest registry rejected after fix: %v", err)
+	}
+	if newHighest != 5 {
+		t.Fatalf("newHighest = %d, want 5", newHighest)
+	}
+	if len(loaded.Agents) != 1 {
+		t.Fatal("wrong agent count")
+	}
+
+	resolved, err := Resolve(loaded, "mira", fixedNow)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: Resolve rejected honest binding: %v", err)
+	}
+	if resolved.Slug != "mira" {
+		t.Fatalf("resolved wrong slug: %q", resolved.Slug)
+	}
+
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"honest"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	ok, err := VerifyMessage(loaded, "mira", 1, canonical, sig, fixedNow)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: VerifyMessage rejected honest message: %v", err)
+	}
+	if !ok {
+		t.Fatal("OVER-REJECTION: VerifyMessage returned false for honest message")
+	}
+}
+
+// TestReattack_HonestRegistry_MultipleAgents — rotation scenario. One revoked
+// binding and one live binding for the same slug. The fix must not break this.
+func TestReattack_HonestRegistry_MultipleAgents(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	oldPub, _ := genKey(t)
+	newPub, newPriv := genKey(t)
+	revokedAt := int(1_770_000_100)
+
+	oldPk, _ := NewPublicKey(oldPub)
+	newPk, _ := NewPublicKey(newPub)
+
+	old := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: oldPk, KeyEpoch: 1,
+		ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		AuthorizedOriginDaemons: []string{"d"}, RevokedAt: &revokedAt,
+	}
+	fresh := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: newPk, KeyEpoch: 2,
+		ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		AuthorizedOriginDaemons: []string{"d"}, RevokedAt: nil,
+	}
+	reg := freshRegistry(6, old, fresh)
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	loaded, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: rotation registry rejected: %v", err)
+	}
+
+	// Live binding (epoch 2) resolves.
+	resolved, err := Resolve(loaded, "mira", fixedNow)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: live binding in rotation rejected: %v", err)
+	}
+	if resolved.KeyEpoch != 2 {
+		t.Fatalf("resolved wrong epoch: %d", resolved.KeyEpoch)
+	}
+
+	// Verify message under the new key.
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"rotated"}`))
+	sig, _ := identity.SignCanonical(newPriv, canonical)
+	ok, err := VerifyMessage(loaded, "mira", 2, canonical, sig, fixedNow)
+	if err != nil {
+		t.Fatalf("OVER-REJECTION: VerifyMessage rejected rotated binding: %v", err)
+	}
+	if !ok {
+		t.Fatal("OVER-REJECTION: VerifyMessage returned false for rotated binding")
+	}
+
+	// Old revoked epoch must still be rejected.
+	if _, err := VerifyMessage(loaded, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: revoked old binding still verifies after fix")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// G. COMBINED ATTACK: future valid_from + negative staleness bypass attempt.
+//    The fix adds `now.Unix() < reg.ValidFrom` BEFORE the staleness check.
+//    Verify that this ordering holds even with an extremely generous staleness.
+// ---------------------------------------------------------------------------
+
+func TestReattack_FutureValidFrom_WithMaxDurationStaleness(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() + 1, // 1 second in the future
+		ValidUntil: fixedNow.Unix() + 86400*365*100,
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// maxStaleness = maximum possible Duration value.
+	// Without the now < valid_from guard, this would pass because:
+	//   now - future = negative < maxStaleness = always true
+	maxDur := time.Duration(1<<63 - 1) // math.MaxInt64 nanoseconds
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, maxDur); err == nil {
+		t.Fatal("SECURITY: future valid_from bypassed with max duration staleness — " +
+			"the now < valid_from guard must fire first")
+	}
+}
+
+// TestReattack_FutureValidFrom_ExactlyNowPlus1Nanosecond — the time.Time has
+// nanosecond precision but valid_from is in seconds. A now that is 1ns past the
+// second boundary of valid_from-1 means now.Unix() is still valid_from-1 < valid_from,
+// so the registry IS valid. But if now is at the valid_from second + 0ns,
+// now.Unix() == valid_from, which should be accepted.
+func TestReattack_RegistryValidFrom_SubSecondEdge(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	target := fixedNow.Unix() + 10
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  target,
+		ValidUntil: target + 86400,
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// 1ns before the valid_from second: now.Unix() = target-1 < target => REJECT
+	justBefore := time.Unix(target-1, 999_999_999)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, justBefore, time.Hour*24*365); err == nil {
+		t.Fatal("SECURITY: 1ns before valid_from second accepted (now.Unix() < valid_from)")
+	}
+
+	// At exactly the valid_from second: now.Unix() = target == target => ACCEPT
+	atExact := time.Unix(target, 0)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, atExact, time.Hour*24*365); err != nil {
+		t.Fatalf("OVER-REJECTION: exactly at valid_from second rejected: %v", err)
+	}
+
+	// 1ns past the valid_from second (still same second): now.Unix() = target => ACCEPT
+	justAfterSameSecond := time.Unix(target, 1)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, justAfterSameSecond, time.Hour*24*365); err != nil {
+		t.Fatalf("OVER-REJECTION: 1ns past valid_from (same second) rejected: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// H. STALE REGISTRY CANNOT HIDE REVOCATION — the original motivation for the
+//    freeze/eclipse check. Verify that an attacker who withholds a newer
+//    registry (containing a revocation) and serves a stale one cannot succeed.
+// ---------------------------------------------------------------------------
+
+func TestReattack_StaleRegistryCannotHideRevocation(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, agentPriv := genKey(t)
+
+	// "Old" registry: agent is live, signed at epoch 5, valid for 1 hour.
+	oldReg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() - 7200, // 2 hours ago
+		ValidUntil: fixedNow.Unix() - 3600, // expired 1 hour ago
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	oldEnv, err := SignRegistry(rootPriv, oldReg)
+	if err != nil {
+		t.Fatalf("SignRegistry old: %v", err)
+	}
+
+	// An attacker serves the old (expired) registry to hide the revocation.
+	_, _, err = VerifyAndLoad(rootPub, oldEnv, 4, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("SECURITY: stale/expired registry was accepted — " +
+			"attacker can hide revocations by serving old registries")
+	}
+
+	// Even if the attacker's registry is not past valid_until but exceeds
+	// maxStaleness, it must still fail.
+	looseReg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() - 86400*2, // 2 days ago
+		ValidUntil: fixedNow.Unix() + 86400,   // still within valid_until
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	looseEnv, err := SignRegistry(rootPriv, looseReg)
+	if err != nil {
+		t.Fatalf("SignRegistry loose: %v", err)
+	}
+	_, _, err = VerifyAndLoad(rootPub, looseEnv, 4, fixedNow, time.Hour*24)
+	if err == nil {
+		t.Fatal("SECURITY: registry past maxStaleness was accepted despite being within valid_until")
+	}
+
+	// Meanwhile, the CURRENT registry (with revocation) must be accepted AND
+	// the revoked binding must not resolve.
+	revokedAt := int(int(fixedNow.Unix()) - 100)
+	revokedBinding := liveBinding(t, "mira", agentPub, 1)
+	revokedBinding.RevokedAt = &revokedAt
+	currentReg := freshRegistry(6, revokedBinding)
+	currentEnv, err := SignRegistry(rootPriv, currentReg)
+	if err != nil {
+		t.Fatalf("SignRegistry current: %v", err)
+	}
+	loaded, _, err := VerifyAndLoad(rootPub, currentEnv, 4, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("current registry should load: %v", err)
+	}
+	// The revoked binding must not verify messages.
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"try me"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(loaded, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: revoked binding still verifies after loading the current registry")
+	}
+}

--- a/internal/identity/registry/redteam_epoch_range_test.go
+++ b/internal/identity/registry/redteam_epoch_range_test.go
@@ -1,0 +1,571 @@
+package registry
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// =============================================================================
+// ADVERSARIAL RE-ATTACK: EPOCH RANGE VALIDATION
+//
+// Target: commit 5086a9bfc40d9eb3185cc3414c376fc8d79e828c
+// Claim under test: epochs outside [1, 2^53] are REJECTED by BOTH SignRegistry
+// AND VerifyAndLoad. No JCS precision-loss path remains where a signed epoch
+// differs from the loaded epoch. In-range epochs (1, 2^53) still work.
+// =============================================================================
+
+// --- SECTION 1: SignRegistry rejects every out-of-range epoch ---
+
+func TestReattack_SignRegistry_RejectsOutOfRange(t *testing.T) {
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	outOfRange := []struct {
+		name  string
+		epoch int
+	}{
+		{"zero", 0},
+		{"negative_minus1", -1},
+		{"negative_minus42", -42},
+		{"negative_MinInt64", math.MinInt64},
+		{"2^53+1", (1 << 53) + 1},
+		{"2^53+3", (1 << 53) + 3},
+		{"2^54", 1 << 54},
+		{"2^62", 1 << 62},
+		{"MaxInt64", math.MaxInt64},
+		{"MaxInt64/2", math.MaxInt64 >> 1},
+	}
+
+	for _, tc := range outOfRange {
+		t.Run("registry_epoch/"+tc.name, func(t *testing.T) {
+			reg := freshRegistry(tc.epoch, liveBinding(t, "mira", agentPub, 1))
+			_, err := SignRegistry(rootPriv, reg)
+			if err == nil {
+				t.Fatalf("SECURITY: SignRegistry minted registry epoch %d (%s) — must be rejected (outside [1,2^53])",
+					tc.epoch, tc.name)
+			}
+			if !strings.Contains(err.Error(), ErrEpochRange) {
+				t.Fatalf("wrong error for epoch %d: got %v, want substring %q", tc.epoch, err, ErrEpochRange)
+			}
+		})
+
+		t.Run("binding_key_epoch/"+tc.name, func(t *testing.T) {
+			b := liveBinding(t, "mira", agentPub, tc.epoch)
+			reg := freshRegistry(5, b)
+			_, err := SignRegistry(rootPriv, reg)
+			if err == nil {
+				t.Fatalf("SECURITY: SignRegistry minted binding key_epoch %d (%s) — must be rejected (outside [1,2^53])",
+					tc.epoch, tc.name)
+			}
+			if !strings.Contains(err.Error(), ErrEpochRange) {
+				t.Fatalf("wrong error for key_epoch %d: got %v, want substring %q", tc.epoch, err, ErrEpochRange)
+			}
+		})
+	}
+}
+
+// --- SECTION 2: VerifyAndLoad rejects hand-crafted bodies with out-of-range epochs ---
+//
+// THREAT MODEL: An attacker who controls the offline root key (or compromises
+// it) can produce arbitrary SignedRegistry envelopes. VerifyAndLoad is the
+// defense-in-depth layer that must reject out-of-range epochs in the
+// AUTHENTICATED body, even when the root signature is valid.
+//
+// JCS canonicalization normalizes numbers through float64, so:
+// - epoch 2^53+1 in raw JSON => canonical bytes contain 2^53 (precision loss)
+// - epoch 0, -1 in raw JSON => canonical bytes contain 0, -1 (preserved)
+//
+// For epochs that JCS normalizes to an in-range value (like 2^53+1 => 2^53),
+// the attack is actually CLOSED by the JCS normalization itself: the consumer
+// loads epoch 2^53, which is valid. There is no epoch confusion because the
+// signed bytes and decoded bytes agree. The real security property is:
+// SignRegistry REFUSES to sign such epochs, preventing them from entering the
+// system in the first place.
+//
+// For epochs that remain out-of-range after JCS (0, -1, very large), the
+// defense-in-depth in VerifyAndLoad must catch them.
+
+func TestReattack_VerifyAndLoad_RejectsHandCraftedOutOfRange(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	agentB64 := base64Std(agentPub)
+
+	// Epochs that remain out-of-range after JCS normalization.
+	outOfRange := []struct {
+		name  string
+		epoch string // JSON literal
+	}{
+		{"zero", "0"},
+		{"negative", "-1"},
+		// 2^54 is a power of two, so float64 represents it exactly => JCS preserves it.
+		// It is above MaxSafeEpoch, so VerifyAndLoad must reject it.
+		{"2^54", "18014398509481984"},
+	}
+
+	for _, tc := range outOfRange {
+		t.Run("registry_epoch/"+tc.name, func(t *testing.T) {
+			body := fmt.Sprintf(
+				`{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X","key_epoch":1,"pubkey":"%s","slug":"mira","valid_from":1770000000,"valid_until":1780000000}],"epoch":%s,"valid_from":1770000000,"valid_until":1780000000}`,
+				agentB64, tc.epoch,
+			)
+			env := handSign(t, rootPriv, body)
+			_, _, err := VerifyAndLoad(rootPub, env, 0, fixedNow, time.Hour*24*365)
+			if err == nil {
+				t.Fatalf("SECURITY: VerifyAndLoad accepted hand-signed registry epoch %s — must be rejected", tc.name)
+			}
+		})
+	}
+
+	// Out-of-range binding key_epoch in a hand-signed body (values preserved by JCS).
+	outOfRangeKeyEpoch := []struct {
+		name     string
+		keyEpoch string
+	}{
+		{"zero", "0"},
+		{"negative", "-1"},
+		// 2^54 exact in float64 => JCS preserves it, still above MaxSafeEpoch.
+		{"2^54", "18014398509481984"},
+	}
+
+	for _, tc := range outOfRangeKeyEpoch {
+		t.Run("binding_key_epoch/"+tc.name, func(t *testing.T) {
+			body := fmt.Sprintf(
+				`{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X","key_epoch":%s,"pubkey":"%s","slug":"mira","valid_from":1770000000,"valid_until":1780000000}],"epoch":5,"valid_from":1770000000,"valid_until":1780000000}`,
+				tc.keyEpoch, agentB64,
+			)
+			env := handSign(t, rootPriv, body)
+			_, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+			if err == nil {
+				t.Fatalf("SECURITY: VerifyAndLoad accepted hand-signed binding key_epoch %s — must be rejected", tc.name)
+			}
+		})
+	}
+}
+
+// --- SECTION 3: JCS precision-loss normalization closes the confusion path ---
+// Confirm that an epoch above 2^53 (specifically 2^53+1) gets silently rounded
+// by JCS to 2^53, so the canonical bytes + decoded body agree. The attacker
+// cannot create a signed body where the canonical bytes say one epoch but the
+// decoded body says another.
+
+func TestReattack_JCS_PrecisionLoss_NormalizesTo2Pow53(t *testing.T) {
+	// 2^53+1 = 9007199254740993 — cannot be represented exactly as float64.
+	// float64(9007199254740993) rounds to 9007199254740992.0
+	input := `{"epoch":9007199254740993}`
+	canonical, err := identity.Canonicalize([]byte(input))
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	output := string(canonical.Bytes())
+
+	// JCS must round 2^53+1 to 2^53 (confirmed by gowebpki/jcs v1.0.1 behavior).
+	if !strings.Contains(output, "9007199254740992") {
+		t.Fatalf("JCS did not normalize 2^53+1 to 2^53 — unexpected output: %s", output)
+	}
+	if strings.Contains(output, "9007199254740993") {
+		t.Fatal("JCS preserved 2^53+1 exactly — the epoch-range check on canonical bytes would see the original value")
+	}
+
+	// The decoded epoch from canonical bytes is 2^53, not 2^53+1.
+	var decoded struct {
+		Epoch int `json:"epoch"`
+	}
+	if err := json.Unmarshal(canonical.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Epoch != 1<<53 {
+		t.Fatalf("decoded epoch = %d, want %d (2^53)", decoded.Epoch, 1<<53)
+	}
+	t.Logf("CONFIRMED: JCS normalized 2^53+1 => 2^53. No epoch confusion in canonical bytes.")
+}
+
+// TestReattack_JCS_2pow53plus1_CannotBypass demonstrates the full attack path:
+// an attacker crafts a body with epoch 2^53+1, hand-signs it, and presents it
+// to VerifyAndLoad. The JCS normalization rounds the epoch to 2^53 in the
+// canonical bytes, so VerifyAndLoad sees epoch 2^53 (in-range) and LOADS it.
+// This is NOT a bypass — the consumer genuinely gets epoch 2^53, and the
+// anti-rollback monotonic counter works correctly on that value. The confusion
+// (attacker intended 2^53+1 but consumer got 2^53) is prevented by
+// SignRegistry refusing to sign 2^53+1.
+func TestReattack_JCS_2pow53plus1_NoEpochConfusion(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	agentB64 := base64Std(agentPub)
+
+	// Step 1: SignRegistry REFUSES to mint 2^53+1.
+	reg := freshRegistry((1<<53)+1, liveBinding(t, "mira", agentPub, 1))
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry accepted epoch 2^53+1 — the primary defense is broken")
+	}
+
+	// Step 2: An attacker who hand-signs a body with epoch 2^53+1 gets JCS
+	// normalization to 2^53. Verify that the loaded registry epoch is 2^53.
+	body := fmt.Sprintf(
+		`{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X","key_epoch":1,"pubkey":"%s","slug":"mira","valid_from":1770000000,"valid_until":1780000000}],"epoch":9007199254740993,"valid_from":1770000000,"valid_until":1780000000}`,
+		agentB64,
+	)
+	env := handSign(t, rootPriv, body)
+	loaded, newH, err := VerifyAndLoad(rootPub, env, (1<<53)-1, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad: %v (this is expected to LOAD because canonical epoch is 2^53)", err)
+	}
+
+	// The loaded epoch MUST be 2^53, not 2^53+1.
+	if loaded.Epoch != 1<<53 {
+		t.Fatalf("loaded epoch = %d, want %d (2^53) — epoch confusion!", loaded.Epoch, 1<<53)
+	}
+	if newH != 1<<53 {
+		t.Fatalf("newHighest = %d, want %d", newH, 1<<53)
+	}
+	t.Logf("CONFIRMED: hand-signed 2^53+1 body loads as epoch 2^53 — no confusion, anti-rollback works on the actual value")
+}
+
+// --- SECTION 4: In-range epochs work end-to-end (no over-rejection) ---
+
+func TestReattack_InRange_Epoch1_E2E(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, agentPriv := genKey(t)
+
+	reg := freshRegistry(1, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry at epoch 1: %v", err)
+	}
+	loaded, newH, err := VerifyAndLoad(rootPub, env, 0, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad at epoch 1: %v", err)
+	}
+	if newH != 1 {
+		t.Fatalf("newHighest = %d, want 1", newH)
+	}
+	if loaded.Epoch != 1 {
+		t.Fatalf("loaded epoch = %d, want 1", loaded.Epoch)
+	}
+
+	_, err = Resolve(loaded, "mira", fixedNow)
+	if err != nil {
+		t.Fatalf("Resolve at epoch 1: %v", err)
+	}
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"epoch-1"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	ok, err := VerifyMessage(loaded, "mira", 1, canonical, sig, fixedNow)
+	if err != nil {
+		t.Fatalf("VerifyMessage at epoch 1: %v", err)
+	}
+	if !ok {
+		t.Fatal("VerifyMessage at epoch 1 = false, want true")
+	}
+}
+
+func TestReattack_InRange_MaxSafeEpoch_E2E(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, agentPriv := genKey(t)
+
+	epoch := MaxSafeEpoch
+	keyEpoch := MaxSafeEpoch
+
+	reg := freshRegistry(epoch, liveBinding(t, "mira", agentPub, keyEpoch))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry at MaxSafeEpoch: %v", err)
+	}
+	loaded, newH, err := VerifyAndLoad(rootPub, env, epoch-1, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad at MaxSafeEpoch: %v", err)
+	}
+	if newH != epoch {
+		t.Fatalf("newHighest = %d, want %d", newH, epoch)
+	}
+	if loaded.Epoch != epoch {
+		t.Fatalf("loaded epoch = %d, want %d", loaded.Epoch, epoch)
+	}
+
+	_, err = Resolve(loaded, "mira", fixedNow)
+	if err != nil {
+		t.Fatalf("Resolve at MaxSafeEpoch: %v", err)
+	}
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"max-safe"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	ok, err := VerifyMessage(loaded, "mira", keyEpoch, canonical, sig, fixedNow)
+	if err != nil {
+		t.Fatalf("VerifyMessage at MaxSafeEpoch: %v", err)
+	}
+	if !ok {
+		t.Fatal("VerifyMessage at MaxSafeEpoch = false, want true")
+	}
+}
+
+// --- SECTION 5: Boundary fence-post tests (SignRegistry) ---
+
+func TestReattack_BoundaryFencePosts(t *testing.T) {
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	tests := []struct {
+		name      string
+		epoch     int
+		wantAllow bool
+	}{
+		{"epoch_0_reject", 0, false},
+		{"epoch_1_accept", 1, true},
+		{"epoch_2_accept", 2, true},
+		{"epoch_2^53-1_accept", (1 << 53) - 1, true},
+		{"epoch_2^53_accept", 1 << 53, true},
+		{"epoch_2^53+1_reject", (1 << 53) + 1, false},
+		{"epoch_2^53+2_reject", (1 << 53) + 2, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := freshRegistry(tc.epoch, liveBinding(t, "mira", agentPub, 1))
+			_, err := SignRegistry(rootPriv, reg)
+			if tc.wantAllow && err != nil {
+				t.Fatalf("over-rejection: epoch %d must be allowed, got: %v", tc.epoch, err)
+			}
+			if !tc.wantAllow && err == nil {
+				t.Fatalf("SECURITY: epoch %d must be rejected (outside [1,2^53])", tc.epoch)
+			}
+		})
+	}
+}
+
+// --- SECTION 6: epochInRange unit tests ---
+
+func TestReattack_EpochInRange_Unit(t *testing.T) {
+	tests := []struct {
+		epoch int
+		want  bool
+	}{
+		{math.MinInt64, false},
+		{-1, false},
+		{0, false},
+		{1, true},
+		{2, true},
+		{(1 << 53) - 1, true},
+		{1 << 53, true},
+		{(1 << 53) + 1, false},
+		{(1 << 53) + 3, false},
+		{math.MaxInt64 >> 1, false},
+		{math.MaxInt64, false},
+	}
+
+	for _, tc := range tests {
+		name := fmt.Sprintf("epoch_%d", tc.epoch)
+		t.Run(name, func(t *testing.T) {
+			got := epochInRange(tc.epoch)
+			if got != tc.want {
+				t.Fatalf("epochInRange(%d) = %v, want %v", tc.epoch, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- SECTION 7: VerifyAndLoad defense-in-depth for JCS-preserved out-of-range epochs ---
+// Epochs that are exact in float64 but above 2^53 (powers of 2: 2^54, 2^62)
+// pass through JCS unchanged, so the VerifyAndLoad epoch-range check on the
+// decoded body is the ONLY defense.
+
+func TestReattack_VerifyAndLoad_JCSPreserved_LargeEpoch(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	agentB64 := base64Std(agentPub)
+
+	// 2^54 = 18014398509481984 is exact in float64, so JCS preserves it.
+	// It is above MaxSafeEpoch (2^53), so VerifyAndLoad MUST reject it.
+	body := fmt.Sprintf(
+		`{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X","key_epoch":1,"pubkey":"%s","slug":"mira","valid_from":1770000000,"valid_until":1780000000}],"epoch":18014398509481984,"valid_from":1770000000,"valid_until":1780000000}`,
+		agentB64,
+	)
+	env := handSign(t, rootPriv, body)
+	_, _, err := VerifyAndLoad(rootPub, env, 0, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted epoch 2^54 — JCS preserves it exactly but it is above MaxSafeEpoch")
+	}
+	if !strings.Contains(err.Error(), ErrEpochRange) {
+		t.Fatalf("wrong error: got %v, want substring %q", err, ErrEpochRange)
+	}
+}
+
+func TestReattack_VerifyAndLoad_JCSPreserved_LargeKeyEpoch(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	agentB64 := base64Std(agentPub)
+
+	// Same but for binding key_epoch at 2^54.
+	body := fmt.Sprintf(
+		`{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X","key_epoch":18014398509481984,"pubkey":"%s","slug":"mira","valid_from":1770000000,"valid_until":1780000000}],"epoch":5,"valid_from":1770000000,"valid_until":1780000000}`,
+		agentB64,
+	)
+	env := handSign(t, rootPriv, body)
+	_, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted binding key_epoch 2^54")
+	}
+	if !strings.Contains(err.Error(), ErrEpochRange) {
+		t.Fatalf("wrong error: got %v, want substring %q", err, ErrEpochRange)
+	}
+}
+
+// --- SECTION 8: MaxInt64 DoS path ---
+// MaxInt64 through JCS gets scientific notation (float64 overflow territory).
+// Either canonicalize fails, unmarshal fails, or the epoch-range check catches it.
+
+func TestReattack_VerifyAndLoad_RejectsMaxInt64InBody(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	agentB64 := base64Std(agentPub)
+
+	body := fmt.Sprintf(
+		`{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X","key_epoch":1,"pubkey":"%s","slug":"mira","valid_from":1770000000,"valid_until":1780000000}],"epoch":9223372036854775807,"valid_from":1770000000,"valid_until":1780000000}`,
+		agentB64,
+	)
+
+	canonical, err := identity.Canonicalize([]byte(body))
+	if err != nil {
+		t.Logf("CORRECT: Canonicalize rejected MaxInt64 epoch: %v", err)
+		return
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+	_, _, err = VerifyAndLoad(rootPub, env, 0, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted MaxInt64 epoch from an authenticated body")
+	}
+	t.Logf("CORRECT: VerifyAndLoad rejected MaxInt64 epoch: %v", err)
+}
+
+// --- SECTION 9: Multiple bindings with mixed epoch validity ---
+
+func TestReattack_SignRegistry_OneValidOneInvalidKeyEpoch(t *testing.T) {
+	_, rootPriv := genKey(t)
+	pub1, _ := genKey(t)
+	pub2, _ := genKey(t)
+
+	revokedAt := int(1_770_000_100)
+	b1 := liveBinding(t, "ada", pub1, 1)
+	b2 := liveBinding(t, "mira", pub2, (1<<53)+1)
+	b2.RevokedAt = &revokedAt
+
+	reg := freshRegistry(5, b1, b2)
+	_, err := SignRegistry(rootPriv, reg)
+	if err == nil {
+		t.Fatal("SECURITY: SignRegistry minted a registry with one invalid binding key_epoch")
+	}
+	if !strings.Contains(err.Error(), ErrEpochRange) {
+		t.Fatalf("wrong error: got %v, want substring %q", err, ErrEpochRange)
+	}
+}
+
+// --- SECTION 10: JCS round-trip fidelity for in-range epochs ---
+
+func TestReattack_JCS_NoConfusionInRange(t *testing.T) {
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	safeEpochs := []struct {
+		name  string
+		epoch int
+	}{
+		{"1", 1},
+		{"42", 42},
+		{"1000000", 1_000_000},
+		{"2^52", 1 << 52},
+		{"2^53-1", (1 << 53) - 1},
+		{"2^53", 1 << 53},
+	}
+
+	for _, tc := range safeEpochs {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := freshRegistry(tc.epoch, liveBinding(t, "mira", agentPub, 1))
+			cb, err := canonicalBytes(reg)
+			if err != nil {
+				t.Fatalf("canonicalBytes: %v", err)
+			}
+			epochStr := fmt.Sprintf(`"epoch":%d`, tc.epoch)
+			if !strings.Contains(string(cb.Bytes()), epochStr) {
+				t.Fatalf("JCS CONFUSION: canonical bytes do not contain %q — got: %s",
+					epochStr, string(cb.Bytes()))
+			}
+
+			env, err := SignRegistry(rootPriv, reg)
+			if err != nil {
+				t.Fatalf("SignRegistry: %v", err)
+			}
+			rootPub := rootPriv.Public().(ed25519.PublicKey)
+			loaded, newH, err := VerifyAndLoad(rootPub, env, tc.epoch-1, fixedNow, time.Hour*24*365)
+			if err != nil {
+				t.Fatalf("VerifyAndLoad: %v", err)
+			}
+			if loaded.Epoch != tc.epoch {
+				t.Fatalf("loaded epoch = %d, want %d", loaded.Epoch, tc.epoch)
+			}
+			if newH != tc.epoch {
+				t.Fatalf("newHighest = %d, want %d", newH, tc.epoch)
+			}
+		})
+	}
+}
+
+// --- SECTION 11: MaxSafeEpoch constant value ---
+
+func TestReattack_MaxSafeEpoch_Is2Pow53(t *testing.T) {
+	if MaxSafeEpoch != 1<<53 {
+		t.Fatalf("MaxSafeEpoch = %d, want %d (2^53)", MaxSafeEpoch, 1<<53)
+	}
+	if MaxSafeEpoch != 9007199254740992 {
+		t.Fatalf("MaxSafeEpoch = %d, want 9007199254740992", MaxSafeEpoch)
+	}
+}
+
+// --- SECTION 12: Cross-language parity concern ---
+// The reason SignRegistry rejects > 2^53 even though JCS normalizes it: a Rust
+// or JavaScript verifier parsing the ORIGINAL pre-canonical JSON would see
+// 2^53+1, while Go after JCS sees 2^53. The fix prevents this parity break by
+// refusing to mint such values at the source.
+
+func TestReattack_CrossLanguageParity_SignRegistryPrevents(t *testing.T) {
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// 2^53+1: Go's json.Unmarshal into int handles it correctly (9007199254740993),
+	// but JCS normalizes it to 9007199254740992. SignRegistry must refuse to create
+	// this discrepancy.
+	reg := freshRegistry((1<<53)+1, liveBinding(t, "mira", agentPub, 1))
+	_, err := SignRegistry(rootPriv, reg)
+	if err == nil {
+		t.Fatal("SECURITY: SignRegistry minted 2^53+1 — cross-language parity break")
+	}
+
+	// Also 2^53+3: same issue, different odd number.
+	reg = freshRegistry((1<<53)+3, liveBinding(t, "mira", agentPub, 1))
+	_, err = SignRegistry(rootPriv, reg)
+	if err == nil {
+		t.Fatal("SECURITY: SignRegistry minted 2^53+3 — cross-language parity break")
+	}
+}
+
+// --- helpers ---
+
+// handSign canonicalizes body, signs with rootPriv, and returns a SignedRegistry.
+func handSign(t *testing.T, rootPriv ed25519.PrivateKey, body string) SignedRegistry {
+	t.Helper()
+	canonical, err := identity.Canonicalize([]byte(body))
+	if err != nil {
+		t.Fatalf("handSign: canonicalize: %v", err)
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("handSign: sign: %v", err)
+	}
+	return SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+}

--- a/internal/identity/registry/redteam_jcs_precision_test.go
+++ b/internal/identity/registry/redteam_jcs_precision_test.go
@@ -1,0 +1,133 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// TestRedteam_JCS_EpochPrecisionLoss asserts the epoch RANGE invariant that
+// closes the JCS precision-loss hole: SignRegistry accepts epochs in
+// [1, 2^53] (JCS renders them losslessly) and REJECTS any epoch above 2^53
+// (which would silently round under IEEE-754 double formatting → epoch
+// confusion / cross-language parity break).
+func TestRedteam_JCS_EpochPrecisionLoss(t *testing.T) {
+	testCases := []struct {
+		name      string
+		epoch     int
+		wantAllow bool
+	}{
+		{"2^52", 1 << 52, true},
+		{"2^53 - 1", (1 << 53) - 1, true},
+		{"2^53", 1 << 53, true},            // MaxSafeEpoch boundary — allowed
+		{"2^53 + 1", (1 << 53) + 1, false}, // first unsafe value
+		{"2^53 + 2", (1 << 53) + 2, false},
+		{"2^53 + 3", (1 << 53) + 3, false},
+		{"2^62", 1 << 62, false},
+		{"MaxInt64/2", int(1<<63-1) >> 1, false},
+	}
+
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := freshRegistry(tc.epoch, liveBinding(t, "mira", agentPub, 1))
+			_, err := SignRegistry(rootPriv, reg)
+			if tc.wantAllow && err != nil {
+				t.Fatalf("epoch %d (%s) is JCS-safe and must be signable, got: %v", tc.epoch, tc.name, err)
+			}
+			if !tc.wantAllow && err == nil {
+				t.Fatalf("SECURITY: epoch %d (%s) is JCS-UNSAFE (> 2^53) and must be rejected", tc.epoch, tc.name)
+			}
+		})
+	}
+}
+
+// TestRedteam_JCS_EpochPrecisionLoss_FullPath asserts the full path is closed at
+// epoch 2^53+1: SignRegistry refuses to mint it, and even a hand-signed body
+// carrying it is rejected by VerifyAndLoad — no epoch confusion or DoS reaches
+// the consumer.
+func TestRedteam_JCS_EpochPrecisionLoss_FullPath(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// 2^53 + 1 = 9007199254740993
+	epoch := (1 << 53) + 1
+	reg := freshRegistry(epoch, liveBinding(t, "mira", agentPub, 1))
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry minted epoch 2^53+1 — JCS precision-loss vector")
+	}
+
+	// Hand-sign a body at a registry-level epoch ABOVE 2^53 that JCS renders
+	// exactly (2^54 = 18014398509481984, a power of two) and confirm the load
+	// gate rejects it via the epoch-range check on the authenticated body.
+	const aboveSafe = 1 << 54 // 18014398509481984, > MaxSafeEpoch, JCS-exact
+	body := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X",` +
+		`"key_epoch":1,"pubkey":"` + base64Std(agentPub) + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":18014398509481984,"valid_from":1770000000,"valid_until":1780000000}`
+	canonical, err := identity.Canonicalize([]byte(body))
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+	if _, _, err := VerifyAndLoad(rootPub, env, aboveSafe-2, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted a hand-signed epoch above 2^53")
+	}
+}
+
+// TestRedteam_JCS_SafeEpochRange_2pow53 demonstrates that epochs within the
+// JSON-safe integer range (up to 2^53) work correctly end to end.
+func TestRedteam_JCS_SafeEpochRange_2pow53(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	epoch := 1 << 53 // Exactly 2^53, the maximum safe integer
+	reg := freshRegistry(epoch, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	_, newHighest, err := VerifyAndLoad(rootPub, env, epoch-1, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad at 2^53 should succeed: %v", err)
+	}
+	if newHighest != epoch {
+		t.Fatalf("newHighest = %d, want %d", newHighest, epoch)
+	}
+	t.Logf("CORRECT: epoch 2^53 (%d) works correctly end to end", epoch)
+}
+
+// TestRedteam_Freshness_FutureValidFromBypassesStaleness is a focused
+// demonstration that a future valid_from completely defeats maxStaleness.
+func TestRedteam_Freshness_FutureValidFromBypassesStaleness(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// Even with a 1-SECOND maxStaleness (extremely tight), a future valid_from
+	// bypasses it because now - future = negative < 1 second.
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() + 86400*365, // 1 year in the future
+		ValidUntil: fixedNow.Unix() + 86400*730, // 2 years in the future
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// 1-second maxStaleness: a future valid_from must be rejected by the
+	// now < valid_from guard, not slip through on a negative staleness duration.
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Second); err == nil {
+		t.Fatal("SECURITY: future valid_from (1 year ahead) accepted with 1-second maxStaleness — " +
+			"staleness-bound bypass")
+	}
+}

--- a/internal/identity/registry/redteam_overflow_test.go
+++ b/internal/identity/registry/redteam_overflow_test.go
@@ -1,0 +1,102 @@
+package registry
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+)
+
+// TestRedteam_Overflow_LargeEpochJSONRoundtrip tests what happens when a large
+// epoch value round-trips through JSON. Go's encoding/json uses float64 for
+// numbers, which loses precision above 2^53. An attacker could craft a JSON
+// with epoch just above 2^53 that silently truncates/rounds.
+func TestRedteam_Overflow_LargeEpochJSONRoundtrip(t *testing.T) {
+	// 2^53 + 1 = 9007199254740993 — this cannot be represented exactly as float64.
+	// Go json.Unmarshal into int uses a different path than float64 on modern Go,
+	// but let's verify.
+	type testReg struct {
+		Epoch int `json:"epoch"`
+	}
+	raw := `{"epoch":9007199254740993}`
+	var tr testReg
+	if err := json.Unmarshal([]byte(raw), &tr); err != nil {
+		t.Logf("INFO: Go rejects epoch 2^53+1 via json.Unmarshal into int: %v", err)
+		return
+	}
+	if tr.Epoch != 9007199254740993 {
+		t.Fatalf("VULNERABILITY: epoch 2^53+1 round-tripped as %d — precision loss in JSON", tr.Epoch)
+	}
+	t.Logf("CORRECT: Go's json.Unmarshal into int handles 2^53+1 correctly: %d", tr.Epoch)
+}
+
+// TestRedteam_Overflow_MaxIntEpochSignAndVerify asserts that a JCS-UNSAFE large
+// epoch (above 2^53, here ~MaxInt64/2) is REJECTED at sign time. Such epochs
+// round under IEEE-754 double formatting (epoch confusion across languages), so
+// they must never be minted.
+func TestRedteam_Overflow_MaxIntEpochSignAndVerify(t *testing.T) {
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	largeEpoch := int(math.MaxInt64 >> 1) // ~4.6e18, far above MaxSafeEpoch (2^53)
+	reg := freshRegistry(largeEpoch, liveBinding(t, "mira", agentPub, 1))
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry minted a JCS-unsafe epoch above 2^53 — epoch-confusion vector")
+	}
+}
+
+// TestRedteam_Overflow_MaxIntViaJSONMarshal asserts that a MaxInt64 epoch — which
+// JCS renders in scientific notation and json.Unmarshal then cannot parse back
+// into an int (a DoS on the load path) — is REJECTED at sign time, so it never
+// reaches the consumer.
+func TestRedteam_Overflow_MaxIntViaJSONMarshal(t *testing.T) {
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := freshRegistry(math.MaxInt, liveBinding(t, "mira", agentPub, 1))
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry minted a MaxInt epoch — JCS scientific-notation DoS vector")
+	}
+}
+
+// TestRedteam_FutureValidFrom_PerpetualFreshness demonstrates the future
+// valid_from attack more concretely: a registry issued with valid_from set
+// 10 years in the future, with valid_until 20 years in the future, passes
+// ALL freshness checks for a consumer running at any time in the next 10 years.
+func TestRedteam_FutureValidFrom_PerpetualFreshness(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	tenYears := int64(86400 * 365 * 10)
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() + tenYears,   // 10 years in the future
+		ValidUntil: fixedNow.Unix() + tenYears*2, // 20 years in the future
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// Consumer with a 24-hour maxStaleness
+	maxStale := time.Hour * 24
+
+	// At every point in the next 10 years (all BEFORE valid_from), the registry
+	// MUST be rejected — the now < valid_from guard denies perpetual freshness.
+	checkTimes := []struct {
+		name string
+		t    time.Time
+	}{
+		{"now", fixedNow},
+		{"1 year from now", fixedNow.Add(time.Hour * 24 * 365)},
+		{"5 years from now", fixedNow.Add(time.Hour * 24 * 365 * 5)},
+		{"9 years from now", fixedNow.Add(time.Hour * 24 * 365 * 9)},
+	}
+
+	for _, tc := range checkTimes {
+		if _, _, err := VerifyAndLoad(rootPub, env, 4, tc.t, maxStale); err == nil {
+			t.Fatalf("SECURITY: future valid_from registry accepted at %s — perpetual-freshness bypass", tc.name)
+		}
+	}
+}

--- a/internal/identity/registry/redteam_rollback_freeze_test.go
+++ b/internal/identity/registry/redteam_rollback_freeze_test.go
@@ -1,0 +1,540 @@
+package registry
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ATTACK VECTOR: ROLLBACK — Can a consumer be made to accept an OLD registry?
+// ═══════════════════════════════════════════════════════════════════════════
+
+// TestRedteam_Rollback_EpochEqualPersistedMustReject verifies that
+// epoch == persistedHighestEpoch is REJECTED (strictly greater required).
+func TestRedteam_Rollback_EpochEqualPersistedMustReject(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// persistedHighestEpoch == 5, registry epoch == 5 => MUST reject
+	_, newHighest, err := VerifyAndLoad(rootPub, env, 5, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("VULNERABILITY: epoch == persistedHighestEpoch was ACCEPTED — allows replaying the same registry")
+	}
+	// newHighest must not advance
+	if newHighest != 5 {
+		t.Fatalf("newHighest advanced to %d despite rejection", newHighest)
+	}
+}
+
+// TestRedteam_Rollback_EpochBelowPersistedMustReject verifies that
+// epoch < persistedHighestEpoch is REJECTED.
+func TestRedteam_Rollback_EpochBelowPersistedMustReject(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(3, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// persistedHighestEpoch == 10, registry epoch == 3 => MUST reject
+	_, _, err = VerifyAndLoad(rootPub, env, 10, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("VULNERABILITY: epoch < persistedHighestEpoch was ACCEPTED — allows rollback to old registry")
+	}
+}
+
+// TestRedteam_Rollback_EpochZeroMustReject asserts epoch 0 is rejected. The
+// epoch FLOOR of 1 makes SignRegistry refuse to mint epoch 0 outright (the
+// very first load must have epoch >= 1); a hand-signed epoch-0 body is likewise
+// rejected by VerifyAndLoad.
+func TestRedteam_Rollback_EpochZeroMustReject(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(0, liveBinding(t, "mira", agentPub, 1))
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry minted epoch 0 — epoch floor bypass")
+	}
+
+	// Hand-sign an epoch-0 body and confirm the load gate rejects it too.
+	body := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X",` +
+		`"key_epoch":1,"pubkey":"` + base64Std(agentPub) + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":0,"valid_from":1770000000,"valid_until":1780000000}`
+	canonical, err := identity.Canonicalize([]byte(body))
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+	if _, _, err := VerifyAndLoad(rootPub, env, 0, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("VULNERABILITY: epoch 0 with persistedHighest 0 was ACCEPTED — the very first load must have epoch > 0")
+	}
+}
+
+// TestRedteam_Rollback_EpochOneMustAcceptWhenPersistedZero tests that epoch 1
+// with persisted 0 is the legitimate first-use case.
+func TestRedteam_Rollback_EpochOneMustAcceptWhenPersistedZero(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(1, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	_, newHighest, err := VerifyAndLoad(rootPub, env, 0, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("epoch=1 with persisted=0 should be accepted: %v", err)
+	}
+	if newHighest != 1 {
+		t.Fatalf("newHighest = %d, want 1", newHighest)
+	}
+}
+
+// TestRedteam_Rollback_NegativeEpochMustReject asserts negative epochs cannot
+// reset the monotonic counter: the epoch floor of 1 makes SignRegistry refuse
+// to mint a negative epoch, and a hand-signed negative-epoch body is rejected
+// by VerifyAndLoad.
+func TestRedteam_Rollback_NegativeEpochMustReject(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(-1, liveBinding(t, "mira", agentPub, 1))
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry minted a negative epoch — epoch floor bypass")
+	}
+
+	// Hand-sign a negative-epoch body and confirm the load gate rejects it.
+	body := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X",` +
+		`"key_epoch":1,"pubkey":"` + base64Std(agentPub) + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":-1,"valid_from":1770000000,"valid_until":1780000000}`
+	canonical, err := identity.Canonicalize([]byte(body))
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+	if _, _, err := VerifyAndLoad(rootPub, env, 0, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("VULNERABILITY: negative epoch was ACCEPTED with persisted=0")
+	}
+}
+
+// TestRedteam_Rollback_NegativeEpochPersistedNegative asserts the epoch FLOOR:
+// a negative epoch must be rejected even when it is strictly greater than a more
+// negative persisted value (-1 > -2). The [1, MaxSafeEpoch] range closes the
+// "reset the monotonic counter with a negative epoch" angle. SignRegistry must
+// refuse to mint it too.
+func TestRedteam_Rollback_NegativeEpochPersistedNegative(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(-1, liveBinding(t, "mira", agentPub, 1))
+
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry minted a negative epoch — epoch floor bypass")
+	}
+
+	// Hand-sign a body with epoch -1 and confirm the load gate rejects it on the
+	// epoch-range floor regardless of the (more-negative) persisted value.
+	body := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X",` +
+		`"key_epoch":1,"pubkey":"` + base64Std(agentPub) + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":-1,"valid_from":1770000000,"valid_until":1780000000}`
+	canonical, err := identity.Canonicalize([]byte(body))
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+	if _, _, err := VerifyAndLoad(rootPub, env, -2, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted a negative epoch (no floor check)")
+	}
+}
+
+// TestRedteam_Rollback_IntOverflowMaxIntEpoch asserts the epoch CEILING closes
+// the int-overflow angle: a MaxInt epoch (which JCS would render in scientific
+// notation, overflowing the int unmarshal and/or rounding) is REJECTED at sign
+// time, so the monotonic counter can never be driven to MaxInt where MaxInt+1
+// would wrap.
+func TestRedteam_Rollback_IntOverflowMaxIntEpoch(t *testing.T) {
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := freshRegistry(math.MaxInt, liveBinding(t, "mira", agentPub, 1))
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry minted a MaxInt epoch — int-overflow / JCS-rounding vector")
+	}
+}
+
+// TestRedteam_Rollback_EpochOverflowViaJSON asserts that a hand-signed body whose
+// epoch is MaxInt64 is rejected on the load path. JCS renders MaxInt64 in
+// scientific notation (9223372036854776000), which exceeds int64 and fails the
+// JSON unmarshal — a DoS the epoch-range gate turns into a clean reject.
+func TestRedteam_Rollback_EpochOverflowViaJSON(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// SignRegistry must refuse MaxInt outright.
+	reg := freshRegistry(math.MaxInt, liveBinding(t, "mira", agentPub, 1))
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry minted a MaxInt epoch")
+	}
+
+	// A hand-signed MaxInt64 body must also be rejected by VerifyAndLoad.
+	body := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X",` +
+		`"key_epoch":1,"pubkey":"` + base64Std(agentPub) + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":9223372036854775807,"valid_from":1770000000,"valid_until":1780000000}`
+	canonical, err := identity.Canonicalize([]byte(body))
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted a hand-signed MaxInt64 epoch body")
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ATTACK VECTOR: FREEZE / ECLIPSE — Can a stale registry be honored?
+// ═══════════════════════════════════════════════════════════════════════════
+
+// TestRedteam_Freeze_ExactlyAtValidUntilBoundary tests the off-by-one at
+// valid_until. The check is `now.Unix() > reg.ValidUntil`. This means
+// now.Unix() == ValidUntil is ACCEPTED. Is this correct?
+func TestRedteam_Freeze_ExactlyAtValidUntilBoundary(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// Boundary convention (documented on VerifyAndLoad): valid_until is INCLUSIVE
+	// — the registry is honored AT exactly now == valid_until and rejected one
+	// second past it. Pin that intended, consistent behavior.
+	exactlyAt := time.Unix(reg.ValidUntil, 0)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, exactlyAt, time.Hour*24*365); err != nil {
+		t.Fatalf("valid_until is inclusive: registry must load AT exactly valid_until, got: %v", err)
+	}
+}
+
+// TestRedteam_Freeze_OneSecondPastValidUntilMustReject confirms the registry
+// is rejected 1 second after valid_until.
+func TestRedteam_Freeze_OneSecondPastValidUntilMustReject(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	oneAfter := time.Unix(reg.ValidUntil+1, 0)
+	_, _, err = VerifyAndLoad(rootPub, env, 4, oneAfter, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("VULNERABILITY: registry accepted 1 second past valid_until")
+	}
+}
+
+// TestRedteam_Freeze_ExactlyAtMaxStalenessBoundary tests the off-by-one at
+// maxStaleness. The check is `now.Sub(time.Unix(reg.ValidFrom, 0)) > maxStaleness`.
+// This means exactly AT maxStaleness it PASSES. Is this the intended behavior?
+func TestRedteam_Freeze_ExactlyAtMaxStalenessBoundary(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	maxStale := time.Hour * 24 // 24 hours
+	// Boundary convention (documented on VerifyAndLoad): maxStaleness is
+	// INCLUSIVE — staleness == exactly maxStaleness is honored, one tick past is
+	// rejected. Pin that intended, consistent behavior.
+	exactlyStale := time.Unix(reg.ValidFrom, 0).Add(maxStale)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, exactlyStale, maxStale); err != nil {
+		t.Fatalf("maxStaleness is inclusive: registry must load AT exactly maxStaleness, got: %v", err)
+	}
+}
+
+// TestRedteam_Freeze_OneNanosecondPastMaxStalenessMustReject tests that
+// exceeding maxStaleness by even a nanosecond triggers rejection.
+func TestRedteam_Freeze_OneNanosecondPastMaxStalenessMustReject(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	maxStale := time.Hour * 24
+	// One nanosecond past: now.Sub(valid_from) = maxStale + 1ns > maxStale => reject
+	pastStale := time.Unix(reg.ValidFrom, 0).Add(maxStale + time.Nanosecond)
+	_, _, err = VerifyAndLoad(rootPub, env, 4, pastStale, maxStale)
+	if err == nil {
+		t.Fatal("VULNERABILITY: registry accepted past maxStaleness")
+	}
+}
+
+// TestRedteam_Freeze_ValidUntilZeroDefaultsToNeverExpires tests whether a
+// valid_until of 0 creates a "never expires" hole. If valid_until == 0, then
+// now.Unix() > 0 is almost always true (since Unix epoch 0 is 1970), so it
+// SHOULD fail. But let's verify.
+func TestRedteam_Freeze_ValidUntilZeroDefaultsToNeverExpires(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() - 100, // 100 seconds ago
+		ValidUntil: 0,                     // ZERO — does this mean "never" or "already expired"?
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	_, _, err = VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("VULNERABILITY: valid_until=0 was ACCEPTED — this means zero defaults to 'never expires', creating a freeze hole")
+	}
+	t.Logf("CORRECT: valid_until=0 correctly treated as already-expired (now > 0)")
+}
+
+// TestRedteam_Freeze_ValidFromZeroMaxStalenessHuge tests whether valid_from=0
+// with a large maxStaleness allows an infinitely old registry.
+func TestRedteam_Freeze_ValidFromZeroMaxStalenessHuge(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// valid_from=0 means the registry was "created" at Unix epoch
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  0,
+		ValidUntil: fixedNow.Unix() + 86400, // 1 day in future
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// Freshness is bounded by the caller's maxStaleness, which is correct: with a
+	// 100-year maxStaleness a valid_from=0 (now - 0 < 100y) is, by definition,
+	// within the caller's freshness tolerance and is accepted. The defense
+	// against an absurdly old valid_from is a sane maxStaleness (caller policy),
+	// not a hardcoded floor. Pin this documented behavior.
+	hugeMax := time.Hour * 24 * 365 * 100
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, hugeMax); err != nil {
+		t.Fatalf("valid_from=0 within a 100-year maxStaleness must load (caller-bounded freshness), got: %v", err)
+	}
+	// And a TIGHT maxStaleness must reject the same registry, proving the bound
+	// is what gates it.
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour); err == nil {
+		t.Fatal("valid_from=0 must be rejected under a 1-hour maxStaleness")
+	}
+}
+
+// TestRedteam_Freeze_MissngValidUntilInWire tests whether a missing valid_until
+// field in the JSON (which defaults to Go zero value 0) creates a freeze hole.
+// This is tested indirectly: the wire format has valid_until as int64, so a
+// missing field defaults to 0, which fails the freshness check.
+func TestRedteam_Freeze_MissingValidUntilInWire(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	// Hand-craft a registry JSON WITHOUT valid_until at the registry level
+	agentPub, _ := genKey(t)
+	_ = agentPub
+	// The wireRegistry has valid_until; if the field is missing from JSON,
+	// Go's json.Unmarshal defaults it to 0. Let's verify that 0 fails.
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() - 100,
+		ValidUntil: 0, // simulates missing/defaulted field
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	_, _, err = VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err == nil {
+		t.Fatal("VULNERABILITY: missing/zero valid_until accepted — creates a 'never expires' freeze hole")
+	}
+}
+
+// TestRedteam_Freeze_NanosecondPrecisionLoss tests whether the Unix() truncation
+// to seconds creates a window where sub-second timing matters. valid_until is in
+// unix seconds (int64), but now is a time.Time with nanosecond precision.
+// The comparison is now.Unix() > reg.ValidUntil — now.Unix() truncates.
+func TestRedteam_Freeze_NanosecondPrecisionLoss(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// now is valid_until + 0.999999999 seconds. now.Unix() truncates to
+	// valid_until, so the comparison is at the inclusive boundary and the
+	// registry loads. This sub-second window is inherent to unix-second
+	// precision (valid_until is int64 seconds) and is documented, not a bug.
+	almostPast := time.Unix(reg.ValidUntil, 999_999_999)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, almostPast, time.Hour*24*365); err != nil {
+		t.Fatalf("unix-second truncation: registry must load within the same second as valid_until, got: %v", err)
+	}
+}
+
+// TestRedteam_Freeze_ClockSkew_FutureValidFrom tests whether a consumer whose
+// clock is behind can be tricked by a valid_from set in the future (from the
+// consumer's perspective). The staleness check is now - valid_from > maxStaleness.
+// If valid_from is in the FUTURE, now - valid_from is NEGATIVE, which is < maxStaleness,
+// so the check PASSES. Combined with a far-future valid_until, this creates a registry
+// that appears perpetually fresh.
+func TestRedteam_Freeze_ClockSkew_FutureValidFrom(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// valid_from is 1 hour in the future from the consumer's perspective
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() + 3600,             // 1 hour in future
+		ValidUntil: fixedNow.Unix() + 3600 + 86400*365, // 1 year in future
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// now - valid_from is NEGATIVE (about -1 hour). The now < valid_from guard
+	// must reject this BEFORE the negative duration can satisfy maxStaleness.
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24); err == nil {
+		t.Fatal("SECURITY: registry with a future valid_from accepted — " +
+			"the now < valid_from gate must reject it (perpetual-freshness bypass)")
+	}
+}
+
+// TestRedteam_Freeze_BindingValidUntilZero tests whether a binding with
+// valid_until=0 creates a "never expires" hole at the Resolve level.
+func TestRedteam_Freeze_BindingValidUntilZero(t *testing.T) {
+	agentPub, _ := genKey(t)
+	pk, err := NewPublicKey(agentPub)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	b := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: pk, KeyEpoch: 1,
+		ValidFrom:               1_770_000_000,
+		ValidUntil:              0, // ZERO valid_until on the binding
+		AuthorizedOriginDaemons: []string{"d"},
+	}
+	reg := freshRegistry(5, b)
+
+	_, err = Resolve(reg, "mira", fixedNow)
+	if err == nil {
+		t.Fatal("VULNERABILITY: binding with valid_until=0 resolved successfully — " +
+			"a zero valid_until should mean 'already expired', not 'never expires'")
+	}
+	t.Logf("CORRECT: binding with valid_until=0 rejected by Resolve: %v", err)
+}
+
+// TestRedteam_Freeze_MaxStalenessZero tests whether maxStaleness=0 creates
+// an impossible-to-satisfy condition or a bypass.
+func TestRedteam_Freeze_MaxStalenessZero(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// maxStaleness=0 means: now - valid_from must be <= 0. Since now is always
+	// after valid_from (in normal use), this should always reject.
+	_, _, err = VerifyAndLoad(rootPub, env, 4, fixedNow, 0)
+	if err == nil {
+		t.Fatal("VULNERABILITY: maxStaleness=0 did not reject — all registries should be 'too stale'")
+	}
+}
+
+// TestRedteam_Freeze_NegativeMaxStaleness tests whether negative maxStaleness
+// creates a bypass. A negative duration means now - valid_from > negative is
+// almost always true (unless now is before valid_from).
+func TestRedteam_Freeze_NegativeMaxStaleness(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// Negative maxStaleness: now - valid_from (positive) > negative => ALWAYS true => ALWAYS reject.
+	// This is actually SAFE (always rejects), but a caller mistake.
+	_, _, err = VerifyAndLoad(rootPub, env, 4, fixedNow, -time.Hour)
+	if err == nil {
+		t.Fatal("VULNERABILITY: negative maxStaleness allowed registry through")
+	}
+}
+
+// TestRedteam_Freeze_ConsumerBypassesCheckOrder tests that the check order
+// matters: root sig BEFORE anti-rollback BEFORE freshness. If a consumer
+// could somehow skip the freshness check (e.g., by failing on signature
+// verification first), the registry is still rejected. This tests that
+// ALL checks run in order.
+func TestRedteam_Freeze_ConsumerBypassesCheckOrder(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// Create a valid but STALE registry
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// Use a time well past valid_until
+	farFuture := time.Unix(reg.ValidUntil+86400*365, 0) // 1 year past valid_until
+
+	// Even though the sig is valid and epoch is fine, freshness must fail
+	_, _, err = VerifyAndLoad(rootPub, env, 4, farFuture, time.Hour)
+	if err == nil {
+		t.Fatal("VULNERABILITY: stale registry accepted despite being past valid_until")
+	}
+
+	// Now test: bad sig AND stale — should still reject (sig check first)
+	_, otherPriv := genKey(t)
+	badEnv, _ := SignRegistry(otherPriv, reg)
+	_, _, err = VerifyAndLoad(rootPub, badEnv, 4, farFuture, time.Hour)
+	if err == nil {
+		t.Fatal("VULNERABILITY: bad-sig + stale registry was accepted")
+	}
+}

--- a/internal/identity/registry/registry.go
+++ b/internal/identity/registry/registry.go
@@ -85,6 +85,15 @@ const (
 	// [1, MaxSafeEpoch] round-trip identically across languages and never DoS the
 	// JSON unmarshal path. The floor of 1 gives the monotonic counter a positive
 	// base (negative/zero rejected).
+	//
+	// TODO(contract-b hardening): defense-in-depth — consider MaxSafeEpoch = (1<<53)-1.
+	// A compromised root could hand-craft a body with epoch 2^53+1, which JCS rounds
+	// to 2^53 (in-range at this ceiling). Unreachable via the legitimate SignRegistry
+	// mint gate (it rejects >2^53 pre-canonicalization), so this is belt-and-suspenders
+	// against an already-compromised root, not a real attacker capability. With the
+	// ceiling at 2^53-1, a 2^53+1 body rounds to 2^53 which is then above-ceiling and
+	// rejected at load too. Alternative: a round-trip re-canonicalization equality
+	// check in VerifyAndLoad (closes the whole JCS-normalized-field-smuggling class).
 	MaxSafeEpoch = 1 << 53
 )
 

--- a/internal/identity/registry/registry.go
+++ b/internal/identity/registry/registry.go
@@ -1,0 +1,355 @@
+// Package registry implements Contract-B SLICE 3: the trust-root REGISTRY
+// itself — a root-signed, epoched, freshness-bounded slug→pubkey binding set
+// plus the consumer resolve/verify surface.
+//
+// It builds STRICTLY on the slice-1 primitives (identity.Canonicalize for JCS,
+// identity.VerifyCanonical for the small-order-rejecting ZIP-215 verify, and
+// identity.ValidateSchema via the SignedEntry gate) and does not reimplement
+// canonicalization or verification.
+//
+// The trust model (ratified in docs/mesh/contractb-decisions.md):
+//
+//   - The registry is signed by an OFFLINE root key (dev: an in-process
+//     keypair). SignRegistry is the offline-root operation; VerifyAndLoad is the
+//     load-bearing consumer trust gate.
+//   - ANTI-ROLLBACK: a monotonic epoch; the consumer persists the highest epoch
+//     seen and refuses any registry at-or-below it.
+//   - FRESHNESS / anti-freeze-eclipse: a registry past valid_until OR older than
+//     maxStaleness FAILS CLOSED (a stale registry may hide a revocation, so it
+//     must not be trusted).
+//   - REVOCATION + ROTATION: a binding carries revoked_at; rotation is a new
+//     {pubkey,key_epoch} tuple with the old tuple revoked. The ed25519 pubkey is
+//     identity; resolve/verify default-deny anything revoked, expired, or
+//     epoch-mismatched.
+//
+// SLICE-3 scope is the registry MECHANISM only. The agent-chat --registry
+// distribution wiring and the WireGuard daemon keys are deferred to slice 4.
+package registry
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// Trust-gate reject messages (SSOT — referenced from the verify path, asserted
+// by callers/tests, never inlined).
+const (
+	// ErrRootSig is returned by VerifyAndLoad when root_sig does not verify over
+	// the canonical registry bytes (forgery / tamper / wrong root key).
+	ErrRootSig = "registry: root signature does not verify"
+	// ErrRollback is returned by VerifyAndLoad when reg.epoch <= the persisted
+	// highest-seen epoch (anti-rollback).
+	ErrRollback = "registry: epoch is at or below the highest seen (anti-rollback)"
+	// ErrStale is returned by VerifyAndLoad when the registry is past valid_until
+	// or older than maxStaleness (freshness fails CLOSED).
+	ErrStale = "registry: registry is stale or expired (fail closed)"
+	// ErrUnknownSlug is returned by Resolve/VerifyMessage when no live binding
+	// matches the slug.
+	ErrUnknownSlug = "registry: no live binding for slug"
+	// ErrRevoked is returned when a binding has revoked_at set.
+	ErrRevoked = "registry: binding is revoked"
+	// ErrExpiredBinding is returned when now is past a binding's valid_until.
+	ErrExpiredBinding = "registry: binding is expired"
+	// ErrKeyEpochMismatch is returned by VerifyMessage when the caller's
+	// key_epoch does not match the resolved binding (default-deny).
+	ErrKeyEpochMismatch = "registry: key_epoch does not match the live binding"
+	// ErrBadRootKey is returned by SignRegistry for a nil/wrong-length root key.
+	ErrBadRootKey = "registry: root private key must be ed25519.PrivateKeySize bytes"
+	// errMarshalRegistry wraps a registry JSON-marshal failure.
+	errMarshalRegistry = "registry: marshal registry"
+	// errUnmarshalRegistry wraps a canonical-registry JSON-unmarshal failure.
+	errUnmarshalRegistry = "registry: unmarshal registry"
+)
+
+// AgentBinding binds a slug to a validated ed25519 public key for one key epoch,
+// with a freshness window and an optional revocation timestamp. The ed25519
+// pubkey is the identity; the slug is a label.
+type AgentBinding struct {
+	// Slug is the addressable agent label.
+	Slug string
+	// DisplayName is the human-facing name (may contain non-ASCII, e.g. "Mira ⭐").
+	DisplayName string
+	// PubKey is the validated ed25519 public key (small-order-rejected).
+	PubKey PublicKey
+	// KeyEpoch is the rotation generation of {pubkey,key_epoch}.
+	KeyEpoch int
+	// ValidFrom / ValidUntil bound the binding's validity (unix seconds).
+	ValidFrom  int64
+	ValidUntil int64
+	// AuthorizedOriginDaemons lists the daemon ids permitted to originate for
+	// this slug.
+	AuthorizedOriginDaemons []string
+	// RevokedAt is the unix-seconds revocation time, or nil if the binding is
+	// live. A revoked binding never resolves or verifies.
+	RevokedAt *int
+}
+
+// Registry is the root-signed binding set with a monotonic epoch and a freshness
+// window.
+type Registry struct {
+	// Epoch is the monotonic anti-rollback counter.
+	Epoch int
+	// ValidFrom / ValidUntil bound registry freshness (unix seconds).
+	ValidFrom  int64
+	ValidUntil int64
+	// Agents are the bindings.
+	Agents []AgentBinding
+}
+
+// SignedRegistry is the distribution envelope: the JCS-canonical registry bytes,
+// the ed25519 root signature over exactly those bytes, and the root key epoch.
+type SignedRegistry struct {
+	// Registry is the JCS-canonical encoding of the Registry — the EXACT bytes
+	// that root_sig covers.
+	Registry []byte
+	// RootSig is the ed25519 signature by the offline root key over Registry.
+	RootSig []byte
+	// RootKeyEpoch identifies which root key signed (for root rotation).
+	RootKeyEpoch int
+}
+
+// wireBinding is the JSON/JCS shape of a binding. Field names + ordering are the
+// SSOT canonical form ratified in docs/mesh/contractb-decisions.md (snake_case,
+// pubkey as base64). omitempty on revoked_at means a live binding emits no key
+// (nil pointer == "live"), matching the decisions-doc canonical example.
+type wireBinding struct {
+	AuthorizedOriginDaemons []string `json:"authorized_origin_daemons"`
+	DisplayName             string   `json:"display_name"`
+	KeyEpoch                int      `json:"key_epoch"`
+	PubKey                  string   `json:"pubkey"`
+	RevokedAt               *int     `json:"revoked_at,omitempty"`
+	Slug                    string   `json:"slug"`
+	ValidFrom               int64    `json:"valid_from"`
+	ValidUntil              int64    `json:"valid_until"`
+}
+
+// wireRegistry is the JSON/JCS shape of the registry. JCS sorts keys, so the Go
+// field order here is for readability only; the canonical bytes are
+// Canonicalize's output.
+type wireRegistry struct {
+	Agents     []wireBinding `json:"agents"`
+	Epoch      int           `json:"epoch"`
+	ValidFrom  int64         `json:"valid_from"`
+	ValidUntil int64         `json:"valid_until"`
+}
+
+// toWire converts a Registry to its wire shape (base64 pubkeys).
+func toWire(reg Registry) wireRegistry {
+	agents := make([]wireBinding, len(reg.Agents))
+	for i, a := range reg.Agents {
+		agents[i] = wireBinding{
+			AuthorizedOriginDaemons: a.AuthorizedOriginDaemons,
+			DisplayName:             a.DisplayName,
+			KeyEpoch:                a.KeyEpoch,
+			PubKey:                  base64.StdEncoding.EncodeToString(a.PubKey.Bytes()),
+			RevokedAt:               a.RevokedAt,
+			Slug:                    a.Slug,
+			ValidFrom:               a.ValidFrom,
+			ValidUntil:              a.ValidUntil,
+		}
+	}
+	return wireRegistry{
+		Agents:     agents,
+		Epoch:      reg.Epoch,
+		ValidFrom:  reg.ValidFrom,
+		ValidUntil: reg.ValidUntil,
+	}
+}
+
+// fromWire converts a decoded wire registry back to a Registry, re-validating
+// every pubkey through NewPublicKey so a small-order/garbage key in the bytes
+// cannot enter a binding (an invalid binding is unrepresentable).
+func fromWire(w wireRegistry) (Registry, error) {
+	agents := make([]AgentBinding, len(w.Agents))
+	for i, a := range w.Agents {
+		pk, err := decodePubKey(a.PubKey)
+		if err != nil {
+			return Registry{}, err
+		}
+		agents[i] = AgentBinding{
+			Slug:                    a.Slug,
+			DisplayName:             a.DisplayName,
+			PubKey:                  pk,
+			KeyEpoch:                a.KeyEpoch,
+			ValidFrom:               a.ValidFrom,
+			ValidUntil:              a.ValidUntil,
+			AuthorizedOriginDaemons: a.AuthorizedOriginDaemons,
+			RevokedAt:               a.RevokedAt,
+		}
+	}
+	return Registry{
+		Epoch:      w.Epoch,
+		ValidFrom:  w.ValidFrom,
+		ValidUntil: w.ValidUntil,
+		Agents:     agents,
+	}, nil
+}
+
+// canonicalBytes marshals a Registry to its JCS-canonical bytes via the slice-1
+// Canonicalize primitive — the EXACT bytes the root signs and the consumer
+// verifies.
+func canonicalBytes(reg Registry) (identity.CanonicalBytes, error) {
+	raw, err := json.Marshal(toWire(reg))
+	if err != nil {
+		return identity.CanonicalBytes{}, fmt.Errorf("%s: %w", errMarshalRegistry, err)
+	}
+	return identity.Canonicalize(raw)
+}
+
+// SignRegistry is the OFFLINE-ROOT operation: it JCS-canonicalizes reg and
+// ed25519-signs the canonical bytes with the root private key, returning the
+// distribution envelope. It reuses the slice-1 SignCanonical primitive and
+// returns an error (never panics) on a nil/wrong-length root key.
+func SignRegistry(rootPriv ed25519.PrivateKey, reg Registry) (SignedRegistry, error) {
+	if len(rootPriv) != ed25519.PrivateKeySize {
+		return SignedRegistry{}, fmt.Errorf("%s", ErrBadRootKey)
+	}
+	canonical, err := canonicalBytes(reg)
+	if err != nil {
+		return SignedRegistry{}, err
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		return SignedRegistry{}, err
+	}
+	return SignedRegistry{
+		Registry:     canonical.Bytes(),
+		RootSig:      sig,
+		RootKeyEpoch: 0,
+	}, nil
+}
+
+// VerifyAndLoad is the load-bearing consumer trust gate. It FAILS CLOSED on
+// every check, in order:
+//
+//  1. ROOT SIG: verify root_sig over the canonical registry bytes via
+//     identity.VerifyCanonical (which rejects a small-order/non-canonical root
+//     key and a non-canonical signature). A bad sig is rejected.
+//  2. ANTI-ROLLBACK: reject if reg.epoch <= persistedHighestEpoch.
+//  3. FRESHNESS: reject (fail closed) if now is past reg.valid_until OR
+//     (now - reg.valid_from) > maxStaleness.
+//
+// On success it returns the verified Registry and newHighestEpoch =
+// max(persistedHighestEpoch, reg.epoch) for the caller to persist.
+func VerifyAndLoad(
+	pinnedRootPub ed25519.PublicKey,
+	env SignedRegistry,
+	persistedHighestEpoch int,
+	now time.Time,
+	maxStaleness time.Duration,
+) (Registry, int, error) {
+	// 1. Root signature over the canonical bytes (small-order root key rejected
+	// inside VerifyCanonical). Any structural error or a non-match is a reject.
+	ok, err := identity.VerifyCanonical(
+		pinnedRootPub,
+		identity.CanonicalBytesFromTrusted(env.Registry),
+		env.RootSig,
+	)
+	if err != nil {
+		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s: %w", ErrRootSig, err)
+	}
+	if !ok {
+		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s", ErrRootSig)
+	}
+
+	// Decode the now-authenticated bytes. Pubkeys are re-validated in fromWire.
+	var w wireRegistry
+	if err := json.Unmarshal(env.Registry, &w); err != nil {
+		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s: %w", errUnmarshalRegistry, err)
+	}
+	reg, err := fromWire(w)
+	if err != nil {
+		return Registry{}, persistedHighestEpoch, err
+	}
+
+	// 2. Anti-rollback.
+	if reg.Epoch <= persistedHighestEpoch {
+		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s", ErrRollback)
+	}
+
+	// 3. Freshness — fail closed. A stale registry may hide a revocation.
+	if now.Unix() > reg.ValidUntil {
+		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s", ErrStale)
+	}
+	if now.Sub(time.Unix(reg.ValidFrom, 0)) > maxStaleness {
+		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s", ErrStale)
+	}
+
+	newHighest := persistedHighestEpoch
+	if reg.Epoch > newHighest {
+		newHighest = reg.Epoch
+	}
+	return reg, newHighest, nil
+}
+
+// Resolve returns the LIVE binding for slug at now. It default-denies: a binding
+// with revoked_at set, or one whose valid_until has passed, is rejected; an
+// unknown slug is rejected. When multiple bindings share a slug (rotation), the
+// first live, unexpired one is returned.
+func Resolve(reg Registry, slug string, now time.Time) (AgentBinding, error) {
+	for _, b := range reg.Agents {
+		if b.Slug != slug {
+			continue
+		}
+		if b.RevokedAt != nil {
+			continue
+		}
+		if now.Unix() > b.ValidUntil {
+			continue
+		}
+		return b, nil
+	}
+	return AgentBinding{}, fmt.Errorf("%s: %q", ErrUnknownSlug, slug)
+}
+
+// VerifyMessage resolves the live binding for slug, requires keyEpoch to match
+// the binding's key_epoch (default-deny on mismatch), then verifies sig over the
+// canonical bytes under the binding's validated pubkey via the slice-1
+// VerifyCanonical. A keyed slug with a revoked/expired/epoch-mismatched binding
+// is rejected. An honest non-match returns (false, nil); a structural problem
+// returns (false, error).
+func VerifyMessage(
+	reg Registry,
+	slug string,
+	keyEpoch int,
+	canonical identity.CanonicalBytes,
+	sig []byte,
+	now time.Time,
+) (bool, error) {
+	b, err := resolveTuple(reg, slug, keyEpoch, now)
+	if err != nil {
+		return false, err
+	}
+	return identity.VerifyCanonical(b.PubKey.Bytes(), canonical, sig)
+}
+
+// resolveTuple resolves the live binding for the EXACT {slug,key_epoch} tuple at
+// now, default-denying a revoked, expired, or epoch-mismatched binding. It is
+// the shared default-deny path behind VerifyMessage.
+func resolveTuple(reg Registry, slug string, keyEpoch int, now time.Time) (AgentBinding, error) {
+	for _, b := range reg.Agents {
+		if b.Slug != slug || b.KeyEpoch != keyEpoch {
+			continue
+		}
+		if b.RevokedAt != nil {
+			return AgentBinding{}, fmt.Errorf("%s: %q", ErrRevoked, slug)
+		}
+		if now.Unix() > b.ValidUntil {
+			return AgentBinding{}, fmt.Errorf("%s: %q", ErrExpiredBinding, slug)
+		}
+		return b, nil
+	}
+	// No tuple matched. Distinguish "slug exists but epoch differs" (mismatch)
+	// from "no such slug" for a clearer default-deny signal.
+	for _, b := range reg.Agents {
+		if b.Slug == slug {
+			return AgentBinding{}, fmt.Errorf("%s: %q", ErrKeyEpochMismatch, slug)
+		}
+	}
+	return AgentBinding{}, fmt.Errorf("%s: %q", ErrUnknownSlug, slug)
+}

--- a/internal/identity/registry/registry.go
+++ b/internal/identity/registry/registry.go
@@ -60,11 +60,37 @@ const (
 	ErrKeyEpochMismatch = "registry: key_epoch does not match the live binding"
 	// ErrBadRootKey is returned by SignRegistry for a nil/wrong-length root key.
 	ErrBadRootKey = "registry: root private key must be ed25519.PrivateKeySize bytes"
+	// ErrEpochRange is returned by SignRegistry/VerifyAndLoad when an epoch
+	// (registry epoch or a binding key_epoch) is outside [1, MaxSafeEpoch]. JCS
+	// (RFC 8785) renders numbers as IEEE-754 doubles, so an epoch above 2^53
+	// silently rounds (cross-language parity break + epoch confusion) and an
+	// epoch near MaxInt64 fails JSON unmarshal (DoS); a zero/negative epoch also
+	// breaks the monotonic anti-rollback floor.
+	ErrEpochRange = "registry: epoch out of range [1, 2^53]"
+	// ErrNotYetValid is returned by Resolve/VerifyMessage when now is before a
+	// binding's valid_from (a not-yet-active binding must not resolve or verify).
+	ErrNotYetValid = "registry: binding is not yet valid"
+	// ErrDuplicateBinding is returned by VerifyAndLoad when the registry contains
+	// duplicate {slug,key_epoch} tuples, or more than one live (non-revoked)
+	// binding for the same slug (shadowing / ambiguous-resolution defense).
+	ErrDuplicateBinding = "registry: duplicate binding (slug/key_epoch or multiple live bindings per slug)"
 	// errMarshalRegistry wraps a registry JSON-marshal failure.
 	errMarshalRegistry = "registry: marshal registry"
 	// errUnmarshalRegistry wraps a canonical-registry JSON-unmarshal failure.
 	errUnmarshalRegistry = "registry: unmarshal registry"
+
+	// MaxSafeEpoch is the inclusive upper bound for any epoch (registry epoch and
+	// binding key_epoch). It is 2^53 — the largest integer JCS (which formats
+	// numbers as IEEE-754 doubles) can render without precision loss, so epochs in
+	// [1, MaxSafeEpoch] round-trip identically across languages and never DoS the
+	// JSON unmarshal path. The floor of 1 gives the monotonic counter a positive
+	// base (negative/zero rejected).
+	MaxSafeEpoch = 1 << 53
 )
+
+// epochInRange reports whether e is within the JCS-safe, anti-rollback-floored
+// range [1, MaxSafeEpoch].
+func epochInRange(e int) bool { return e >= 1 && e <= MaxSafeEpoch }
 
 // AgentBinding binds a slug to a validated ed25519 public key for one key epoch,
 // with a freshness window and an optional revocation timestamp. The ed25519
@@ -209,6 +235,17 @@ func SignRegistry(rootPriv ed25519.PrivateKey, reg Registry) (SignedRegistry, er
 	if len(rootPriv) != ed25519.PrivateKeySize {
 		return SignedRegistry{}, fmt.Errorf("%s", ErrBadRootKey)
 	}
+	// Refuse to sign an out-of-range epoch (registry or any binding key_epoch):
+	// these are JCS-unsafe / break the anti-rollback floor, so they must never be
+	// minted in the first place.
+	if !epochInRange(reg.Epoch) {
+		return SignedRegistry{}, fmt.Errorf("%s", ErrEpochRange)
+	}
+	for _, a := range reg.Agents {
+		if !epochInRange(a.KeyEpoch) {
+			return SignedRegistry{}, fmt.Errorf("%s", ErrEpochRange)
+		}
+	}
 	canonical, err := canonicalBytes(reg)
 	if err != nil {
 		return SignedRegistry{}, err
@@ -230,9 +267,18 @@ func SignRegistry(rootPriv ed25519.PrivateKey, reg Registry) (SignedRegistry, er
 //  1. ROOT SIG: verify root_sig over the canonical registry bytes via
 //     identity.VerifyCanonical (which rejects a small-order/non-canonical root
 //     key and a non-canonical signature). A bad sig is rejected.
-//  2. ANTI-ROLLBACK: reject if reg.epoch <= persistedHighestEpoch.
-//  3. FRESHNESS: reject (fail closed) if now is past reg.valid_until OR
-//     (now - reg.valid_from) > maxStaleness.
+//  2. EPOCH RANGE: reject if reg.epoch or any binding key_epoch is outside
+//     [1, MaxSafeEpoch] (JCS-safe + anti-rollback floor).
+//  3. UNIQUENESS: reject duplicate {slug,key_epoch} tuples or more than one live
+//     binding per slug.
+//  4. ANTI-ROLLBACK: reject if reg.epoch <= persistedHighestEpoch.
+//  5. FRESHNESS: reject (fail closed) if now is before reg.valid_from, past
+//     reg.valid_until, OR (now - reg.valid_from) > maxStaleness.
+//
+// Boundary convention: valid_until and maxStaleness are INCLUSIVE — a registry
+// is honored AT exactly now == valid_until and AT exactly staleness ==
+// maxStaleness, and rejected one tick past either. valid_from is inclusive too
+// (honored AT now == valid_from, rejected before it).
 //
 // On success it returns the verified Registry and newHighestEpoch =
 // max(persistedHighestEpoch, reg.epoch) for the caller to persist.
@@ -267,12 +313,38 @@ func VerifyAndLoad(
 		return Registry{}, persistedHighestEpoch, err
 	}
 
-	// 2. Anti-rollback.
+	// 2. Epoch range — reject a JCS-unsafe / non-positive epoch (registry epoch
+	// and every binding key_epoch). An out-of-range epoch in the authenticated
+	// body means epoch confusion or a broken monotonic floor; fail closed.
+	if !epochInRange(reg.Epoch) {
+		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s", ErrEpochRange)
+	}
+	for _, b := range reg.Agents {
+		if !epochInRange(b.KeyEpoch) {
+			return Registry{}, persistedHighestEpoch, fmt.Errorf("%s", ErrEpochRange)
+		}
+	}
+
+	// 3. Uniqueness — reject duplicate {slug,key_epoch} tuples and more than one
+	// live (non-revoked) binding per slug, so a shadow binding cannot mask the
+	// intended one.
+	if err := checkBindingUniqueness(reg.Agents); err != nil {
+		return Registry{}, persistedHighestEpoch, err
+	}
+
+	// 4. Anti-rollback.
 	if reg.Epoch <= persistedHighestEpoch {
 		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s", ErrRollback)
 	}
 
-	// 3. Freshness — fail closed. A stale registry may hide a revocation.
+	// 5. Freshness — fail closed. A stale registry may hide a revocation. A
+	// registry whose valid_from is in the FUTURE is NOT fresh, it is suspicious:
+	// without this guard a future valid_from yields a negative staleness that
+	// always satisfies maxStaleness (perpetual freshness; defeats
+	// revocation-withholding limits).
+	if now.Unix() < reg.ValidFrom {
+		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s", ErrStale)
+	}
 	if now.Unix() > reg.ValidUntil {
 		return Registry{}, persistedHighestEpoch, fmt.Errorf("%s", ErrStale)
 	}
@@ -288,15 +360,23 @@ func VerifyAndLoad(
 }
 
 // Resolve returns the LIVE binding for slug at now. It default-denies: a binding
-// with revoked_at set, or one whose valid_until has passed, is rejected; an
-// unknown slug is rejected. When multiple bindings share a slug (rotation), the
-// first live, unexpired one is returned.
+// with revoked_at set, one whose valid_until has passed, or one whose valid_from
+// is still in the future (not yet active), is skipped. When the slug exists only
+// in a revoked form, ErrRevoked is returned so the reason is distinguishable
+// from ErrUnknownSlug; otherwise an unknown/no-live-binding slug is rejected.
+// When multiple bindings share a slug (rotation), the first live, in-window one
+// is returned.
 func Resolve(reg Registry, slug string, now time.Time) (AgentBinding, error) {
+	sawRevoked := false
 	for _, b := range reg.Agents {
 		if b.Slug != slug {
 			continue
 		}
 		if b.RevokedAt != nil {
+			sawRevoked = true
+			continue
+		}
+		if now.Unix() < b.ValidFrom {
 			continue
 		}
 		if now.Unix() > b.ValidUntil {
@@ -304,7 +384,39 @@ func Resolve(reg Registry, slug string, now time.Time) (AgentBinding, error) {
 		}
 		return b, nil
 	}
+	// Distinguish "the slug exists but every binding for it is revoked" from
+	// "no such slug" so callers can alert specifically on revocation probing.
+	if sawRevoked {
+		return AgentBinding{}, fmt.Errorf("%s: %q", ErrRevoked, slug)
+	}
 	return AgentBinding{}, fmt.Errorf("%s: %q", ErrUnknownSlug, slug)
+}
+
+// checkBindingUniqueness rejects a binding set that contains duplicate
+// {slug,key_epoch} tuples or more than one live (non-revoked) binding for the
+// same slug. Either condition lets a shadow binding mask the intended one, so a
+// conforming registry must not ship them.
+func checkBindingUniqueness(agents []AgentBinding) error {
+	type tuple struct {
+		slug  string
+		epoch int
+	}
+	seenTuple := make(map[tuple]struct{}, len(agents))
+	liveSlug := make(map[string]struct{}, len(agents))
+	for _, b := range agents {
+		tk := tuple{slug: b.Slug, epoch: b.KeyEpoch}
+		if _, dup := seenTuple[tk]; dup {
+			return fmt.Errorf("%s", ErrDuplicateBinding)
+		}
+		seenTuple[tk] = struct{}{}
+		if b.RevokedAt == nil {
+			if _, dup := liveSlug[b.Slug]; dup {
+				return fmt.Errorf("%s", ErrDuplicateBinding)
+			}
+			liveSlug[b.Slug] = struct{}{}
+		}
+	}
+	return nil
 }
 
 // VerifyMessage resolves the live binding for slug, requires keyEpoch to match
@@ -338,6 +450,9 @@ func resolveTuple(reg Registry, slug string, keyEpoch int, now time.Time) (Agent
 		}
 		if b.RevokedAt != nil {
 			return AgentBinding{}, fmt.Errorf("%s: %q", ErrRevoked, slug)
+		}
+		if now.Unix() < b.ValidFrom {
+			return AgentBinding{}, fmt.Errorf("%s: %q", ErrNotYetValid, slug)
 		}
 		if now.Unix() > b.ValidUntil {
 			return AgentBinding{}, fmt.Errorf("%s: %q", ErrExpiredBinding, slug)

--- a/internal/identity/registry/registry_test.go
+++ b/internal/identity/registry/registry_test.go
@@ -349,6 +349,85 @@ func TestNewPublicKey_Bytes(t *testing.T) {
 	}
 }
 
+func TestNewPublicKey_BytesReturnsDefensiveCopy(t *testing.T) {
+	pub, _ := genKey(t)
+	pk, err := NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	// Mutating the returned slice must NOT corrupt the PublicKey's validated
+	// internal storage (Bytes returns a copy, not an alias).
+	got := pk.Bytes()
+	got[0] ^= 0xFF
+	if string(pk.Bytes()) != string(pub) {
+		t.Fatal("Bytes() returned an alias to internal storage — a caller mutated the validated key")
+	}
+}
+
+func TestVerifyAndLoad_RejectsDuplicateSlugEpoch(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	pub1, _ := genKey(t)
+	pub2, _ := genKey(t)
+	// Two bindings with the SAME {slug,key_epoch} tuple must be rejected.
+	b1 := liveBinding(t, "mira", pub1, 1)
+	b2 := liveBinding(t, "mira", pub2, 1)
+	reg := freshRegistry(5, b1, b2)
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("expected reject for duplicate {slug,key_epoch} tuple")
+	}
+}
+
+func TestVerifyAndLoad_RejectsMultipleLiveBindingsPerSlug(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	pub1, _ := genKey(t)
+	pub2, _ := genKey(t)
+	// Two DISTINCT-epoch but both-LIVE bindings for one slug must be rejected
+	// (rotation requires the old tuple be revoked, so only one is ever live).
+	b1 := liveBinding(t, "mira", pub1, 1)
+	b2 := liveBinding(t, "mira", pub2, 2)
+	reg := freshRegistry(5, b1, b2)
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("expected reject for more than one live binding per slug")
+	}
+}
+
+func TestVerifyAndLoad_AllowsRotationOneLivePlusRevoked(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	oldPub, _ := genKey(t)
+	newPub, _ := genKey(t)
+	revokedAt := int(1_770_000_100)
+	oldPk, _ := NewPublicKey(oldPub)
+	newPk, _ := NewPublicKey(newPub)
+	// A legitimate rotation (old tuple revoked, new tuple live) MUST still load —
+	// the uniqueness invariant does not over-reject valid rotations.
+	old := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: oldPk, KeyEpoch: 1,
+		ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		AuthorizedOriginDaemons: []string{"d"}, RevokedAt: &revokedAt,
+	}
+	fresh := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: newPk, KeyEpoch: 2,
+		ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		AuthorizedOriginDaemons: []string{"d"}, RevokedAt: nil,
+	}
+	reg := freshRegistry(6, old, fresh)
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365); err != nil {
+		t.Fatalf("legitimate rotation must still load: %v", err)
+	}
+}
+
 func TestNetworkID_DerivedFromPubkey(t *testing.T) {
 	pub, _ := genKey(t)
 	other, _ := genKey(t)
@@ -407,6 +486,28 @@ func TestSignedEntry_RejectsBadSignature(t *testing.T) {
 	sig, _ := identity.SignEntry(otherPriv, raw)
 	if _, err := NewSignedEntry(pk, raw, sig); err == nil {
 		t.Fatal("expected NewSignedEntry reject for non-matching signature")
+	}
+}
+
+func TestSignRegistry_RejectsOutOfRangeKeyEpoch(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	// A binding key_epoch above MaxSafeEpoch is JCS-unsafe and must be refused.
+	b := liveBinding(t, "mira", agentPub, MaxSafeEpoch+1)
+	reg := freshRegistry(5, b)
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("expected SignRegistry reject for out-of-range binding key_epoch")
+	}
+	_ = rootPub
+}
+
+func TestResolve_HonorsValidFromBoundaryInclusive(t *testing.T) {
+	// Over-rejection guard: a binding is active AT exactly now == valid_from.
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	atStart := time.Unix(b.ValidFrom, 0)
+	if _, err := Resolve(freshRegistry(5, b), "mira", atStart); err != nil {
+		t.Fatalf("valid_from is inclusive: binding must resolve AT exactly valid_from, got: %v", err)
 	}
 }
 

--- a/internal/identity/registry/registry_test.go
+++ b/internal/identity/registry/registry_test.go
@@ -1,0 +1,514 @@
+package registry
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// genKey returns a fresh ed25519 keypair for tests.
+func genKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return pub, priv
+}
+
+// fixedNow is a stable reference instant used across the freshness/expiry tests.
+var fixedNow = time.Unix(1_770_000_500, 0)
+
+// liveBinding builds a binding that is live at fixedNow with the given pubkey.
+func liveBinding(t *testing.T, slug string, pub ed25519.PublicKey, epoch int) AgentBinding {
+	t.Helper()
+	pk, err := NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	return AgentBinding{
+		Slug:                    slug,
+		DisplayName:             "Display " + slug,
+		PubKey:                  pk,
+		KeyEpoch:                epoch,
+		ValidFrom:               1_770_000_000,
+		ValidUntil:              1_780_000_000,
+		AuthorizedOriginDaemons: []string{"daemon-eu-1"},
+		RevokedAt:               nil,
+	}
+}
+
+// freshRegistry builds a registry whose freshness window contains fixedNow.
+func freshRegistry(epoch int, agents ...AgentBinding) Registry {
+	return Registry{
+		Epoch:      epoch,
+		ValidFrom:  1_770_000_000,
+		ValidUntil: 1_780_000_000,
+		Agents:     agents,
+	}
+}
+
+func TestSignAndVerifyAndLoad_Valid(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, agentPriv := genKey(t)
+
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	loaded, newHighest, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad: %v", err)
+	}
+	if newHighest != 5 {
+		t.Fatalf("newHighestEpoch = %d, want 5", newHighest)
+	}
+	if len(loaded.Agents) != 1 {
+		t.Fatalf("loaded agents = %d, want 1", len(loaded.Agents))
+	}
+
+	b, err := Resolve(loaded, "mira", fixedNow)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if b.Slug != "mira" {
+		t.Fatalf("resolved slug = %q, want mira", b.Slug)
+	}
+
+	// A real signature by the agent over canonical bytes verifies through the registry.
+	canonical, err := identity.Canonicalize([]byte(`{"msg":"hello"}`))
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	sig, err := identity.SignCanonical(agentPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	ok, err := VerifyMessage(loaded, "mira", 1, canonical, sig, fixedNow)
+	if err != nil {
+		t.Fatalf("VerifyMessage: %v", err)
+	}
+	if !ok {
+		t.Fatal("VerifyMessage = false, want true")
+	}
+}
+
+func TestVerifyAndLoad_AntiRollback(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// epoch == persistedHighest must be rejected.
+	if _, _, err := VerifyAndLoad(rootPub, env, 5, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("expected rollback reject for epoch == persistedHighest")
+	}
+	// epoch < persistedHighest must be rejected.
+	if _, _, err := VerifyAndLoad(rootPub, env, 6, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("expected rollback reject for epoch < persistedHighest")
+	}
+}
+
+func TestVerifyAndLoad_FreshnessFailClosed_PastValidUntil(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// now past valid_until => fail closed.
+	past := time.Unix(reg.ValidUntil+1, 0)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, past, time.Hour*24*365); err == nil {
+		t.Fatal("expected freshness reject for now past valid_until")
+	}
+}
+
+func TestVerifyAndLoad_FreshnessFailClosed_StaleBeyondMax(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// now - valid_from exceeds maxStaleness => fail closed, must NOT load.
+	staleNow := time.Unix(reg.ValidFrom, 0).Add(time.Hour * 48)
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, staleNow, time.Hour); err == nil {
+		t.Fatal("expected freshness reject for staleness beyond maxStaleness")
+	}
+}
+
+func TestVerifyAndLoad_RootForgery_DifferentKey(t *testing.T) {
+	rootPub, _ := genKey(t)
+	_, otherPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	// Sign with a DIFFERENT private key than the pinned root pubkey.
+	env, err := SignRegistry(otherPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("expected root-forgery reject for mismatched signing key")
+	}
+}
+
+func TestVerifyAndLoad_SmallOrderRootKey(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+	_ = rootPub
+	// Pin an all-zero (small-order) root pubkey: must be rejected by VerifyCanonical.
+	smallOrder := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	if _, _, err := VerifyAndLoad(smallOrder, env, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("expected small-order root pubkey reject")
+	}
+}
+
+func TestVerifyAndLoad_TamperedBody(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+	// Flip a byte in the canonical registry body; the root_sig must no longer verify.
+	tampered := env
+	body := make([]byte, len(env.Registry))
+	copy(body, env.Registry)
+	body[10] ^= 0xFF
+	tampered.Registry = body
+	if _, _, err := VerifyAndLoad(rootPub, tampered, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("expected reject for tampered registry body")
+	}
+}
+
+func TestResolve_RejectsRevoked(t *testing.T) {
+	revokedAt := int(1_770_000_100)
+	b := liveBinding(t, "mira", mustKey(t), 1)
+	b.RevokedAt = &revokedAt
+	reg := freshRegistry(5, b)
+	if _, err := Resolve(reg, "mira", fixedNow); err == nil {
+		t.Fatal("expected Resolve reject for revoked binding")
+	}
+}
+
+func TestResolve_RejectsExpiredBinding(t *testing.T) {
+	b := liveBinding(t, "mira", mustKey(t), 1)
+	reg := freshRegistry(5, b)
+	// now past the binding's valid_until.
+	expiredNow := time.Unix(b.ValidUntil+1, 0)
+	if _, err := Resolve(reg, "mira", expiredNow); err == nil {
+		t.Fatal("expected Resolve reject for expired binding")
+	}
+}
+
+func TestResolve_UnknownSlug(t *testing.T) {
+	reg := freshRegistry(5, liveBinding(t, "mira", mustKey(t), 1))
+	if _, err := Resolve(reg, "nobody", fixedNow); err == nil {
+		t.Fatal("expected Resolve reject for unknown slug")
+	}
+}
+
+func TestVerifyMessage_RevokedBindingRejected(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	revokedAt := int(1_770_000_100)
+	pk, err := NewPublicKey(agentPub)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	b := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: pk, KeyEpoch: 1,
+		ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		AuthorizedOriginDaemons: []string{"d"}, RevokedAt: &revokedAt,
+	}
+	reg := freshRegistry(5, b)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("expected VerifyMessage reject for revoked binding")
+	}
+}
+
+func TestVerifyMessage_KeyEpochMismatchRejected(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 2))
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	// caller claims epoch 1, binding is epoch 2 => default-deny.
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("expected VerifyMessage reject for key_epoch mismatch")
+	}
+}
+
+func TestVerifyMessage_NoBindingDefaultDeny(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(reg, "ghost", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("expected VerifyMessage default-deny for unknown slug")
+	}
+}
+
+func TestVerifyMessage_WrongSignatureNoMatch(t *testing.T) {
+	agentPub, _ := genKey(t)
+	_, otherPriv := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	// Sign with a key that is NOT the binding's key.
+	sig, _ := identity.SignCanonical(otherPriv, canonical)
+	ok, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow)
+	if err != nil {
+		t.Fatalf("VerifyMessage err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected VerifyMessage = false for non-matching signature")
+	}
+}
+
+func TestRotation_NewTupleWorksOldRevoked(t *testing.T) {
+	oldPub, _ := genKey(t)
+	newPub, newPriv := genKey(t)
+	revokedAt := int(1_770_000_100)
+
+	oldPk, _ := NewPublicKey(oldPub)
+	newPk, _ := NewPublicKey(newPub)
+
+	old := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: oldPk, KeyEpoch: 1,
+		ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		AuthorizedOriginDaemons: []string{"d"}, RevokedAt: &revokedAt,
+	}
+	fresh := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: newPk, KeyEpoch: 2,
+		ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		AuthorizedOriginDaemons: []string{"d"}, RevokedAt: nil,
+	}
+	// New tuple resolves; Resolve returns the live (epoch 2) binding.
+	reg := freshRegistry(6, fresh, old)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(newPriv, canonical)
+	ok, err := VerifyMessage(reg, "mira", 2, canonical, sig, fixedNow)
+	if err != nil {
+		t.Fatalf("VerifyMessage(new): %v", err)
+	}
+	if !ok {
+		t.Fatal("expected new rotated tuple to verify")
+	}
+	// Old tuple (epoch 1) is revoked => rejected.
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("expected old revoked tuple to be rejected")
+	}
+}
+
+func TestNewPublicKey_RejectsWrongLength(t *testing.T) {
+	if _, err := NewPublicKey([]byte{1, 2, 3}); err == nil {
+		t.Fatal("expected NewPublicKey reject for wrong length")
+	}
+}
+
+func TestNewPublicKey_RejectsSmallOrder(t *testing.T) {
+	smallOrder := make([]byte, ed25519.PublicKeySize) // all zero is small-order
+	if _, err := NewPublicKey(smallOrder); err == nil {
+		t.Fatal("expected NewPublicKey reject for small-order key")
+	}
+}
+
+func TestNewPublicKey_Bytes(t *testing.T) {
+	pub, _ := genKey(t)
+	pk, err := NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	if string(pk.Bytes()) != string(pub) {
+		t.Fatal("Bytes() did not round-trip the public key")
+	}
+}
+
+func TestNetworkID_DerivedFromPubkey(t *testing.T) {
+	pub, _ := genKey(t)
+	other, _ := genKey(t)
+
+	id1 := NetworkID(pub)
+	id2 := NetworkID(pub)
+	id3 := NetworkID(other)
+
+	if id1 != id2 {
+		t.Fatal("NetworkID is not deterministic for the same pubkey")
+	}
+	if id1 == id3 {
+		t.Fatal("NetworkID collided for distinct pubkeys")
+	}
+	if !strings.HasPrefix(id1, GlobalPrefix) {
+		t.Fatalf("NetworkID %q missing reserved global prefix %q", id1, GlobalPrefix)
+	}
+}
+
+func TestSignedEntry_GateRunsAndVerifies(t *testing.T) {
+	pub, priv := genKey(t)
+	pk, err := NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	raw := []byte(`{"msg":"hi"}`)
+	sig, err := identity.SignEntry(priv, raw)
+	if err != nil {
+		t.Fatalf("SignEntry: %v", err)
+	}
+	se, err := NewSignedEntry(pk, raw, sig)
+	if err != nil {
+		t.Fatalf("NewSignedEntry: %v", err)
+	}
+	if se.Slug() == "" && len(se.Canonical().Bytes()) == 0 {
+		t.Fatal("SignedEntry exposes no canonical bytes")
+	}
+}
+
+func TestSignedEntry_RejectsBadSchema(t *testing.T) {
+	pub, priv := genKey(t)
+	pk, _ := NewPublicKey(pub)
+	// A bare scalar is not a Contract-B object => schema gate must reject.
+	raw := []byte(`42`)
+	sig, _ := identity.SignCanonical(priv, identity.CanonicalBytesFromTrusted(raw))
+	if _, err := NewSignedEntry(pk, raw, sig); err == nil {
+		t.Fatal("expected NewSignedEntry reject for non-conformant entry")
+	}
+}
+
+func TestSignedEntry_RejectsBadSignature(t *testing.T) {
+	pub, _ := genKey(t)
+	_, otherPriv := genKey(t)
+	pk, _ := NewPublicKey(pub)
+	raw := []byte(`{"msg":"hi"}`)
+	sig, _ := identity.SignEntry(otherPriv, raw)
+	if _, err := NewSignedEntry(pk, raw, sig); err == nil {
+		t.Fatal("expected NewSignedEntry reject for non-matching signature")
+	}
+}
+
+func TestSignRegistry_RejectsBadRootKey(t *testing.T) {
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	if _, err := SignRegistry(nil, reg); err == nil {
+		t.Fatal("expected SignRegistry reject for nil root key")
+	}
+}
+
+// TestCanonicalBindingMatchesDecisionsDoc pins the cross-language canonical form:
+// a live binding must serialize to the EXACT JCS bytes ratified in
+// docs/mesh/contractb-decisions.md (snake_case keys, base64 pubkey, raw-UTF-8
+// display name, no revoked_at for a live tuple). A drift here breaks the Rust
+// verifier, so this is a load-bearing regression pin.
+func TestCanonicalBindingMatchesDecisionsDoc(t *testing.T) {
+	// Use a real (validatable) pubkey; the decisions-doc example string is a
+	// synthetic placeholder. The load-bearing assertion is the KEY ORDERING and
+	// shape (snake_case, base64 pubkey, raw-UTF-8 display name, no revoked_at for
+	// a live tuple), which must match the ratified canonical form.
+	pub, _ := genKey(t)
+	pk, err := NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	b64 := base64.StdEncoding.EncodeToString(pub)
+	reg := Registry{
+		Epoch: 1, ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		Agents: []AgentBinding{{
+			Slug: "mira", DisplayName: "Mira ⭐", PubKey: pk, KeyEpoch: 1,
+			ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+			AuthorizedOriginDaemons: []string{"daemon-eu-1", "daemon-us-2"},
+		}},
+	}
+	cb, err := canonicalBytes(reg)
+	if err != nil {
+		t.Fatalf("canonicalBytes: %v", err)
+	}
+	wantBinding := `{"authorized_origin_daemons":["daemon-eu-1","daemon-us-2"],` +
+		`"display_name":"Mira ⭐","key_epoch":1,` +
+		`"pubkey":"` + b64 + `",` +
+		`"slug":"mira","valid_from":1770000000,"valid_until":1780000000}`
+	if !strings.Contains(string(cb.Bytes()), wantBinding) {
+		t.Fatalf("canonical binding drift:\n got: %s\nwant substring: %s", cb.Bytes(), wantBinding)
+	}
+	// A live binding must NOT emit revoked_at.
+	if strings.Contains(string(cb.Bytes()), "revoked_at") {
+		t.Fatal("live binding leaked a revoked_at field into the canonical form")
+	}
+}
+
+func TestDecodePubKey_RejectsBadBase64(t *testing.T) {
+	if _, err := decodePubKey("not!base64!!"); err == nil {
+		t.Fatal("expected decodePubKey reject for invalid base64")
+	}
+}
+
+func TestVerifyAndLoad_RejectsSmallOrderPubkeyInBody(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	// Hand-build an envelope whose canonical body contains an all-zero (small-order)
+	// pubkey: the body verifies under the root, but fromWire must reject the key.
+	smallOrderB64 := base64Std(make([]byte, ed25519.PublicKeySize))
+	body := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X",` +
+		`"key_epoch":1,"pubkey":"` + smallOrderB64 + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":5,"valid_from":1770000000,"valid_until":1780000000}`
+	canonical, err := identity.Canonicalize([]byte(body))
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("expected reject for small-order pubkey in authenticated body")
+	}
+}
+
+func TestVerifyAndLoad_RejectsMalformedBody(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	// Authenticated but non-object body: passes root sig, fails JSON unmarshal.
+	body := []byte(`"not an object"`)
+	canonical := identity.CanonicalBytesFromTrusted(body)
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	env := SignedRegistry{Registry: body, RootSig: sig, RootKeyEpoch: 0}
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("expected reject for malformed authenticated body")
+	}
+}
+
+// base64Std encodes b with standard padded base64.
+func base64Std(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
+
+// mustKey returns a fresh public key, failing the test on error.
+func mustKey(t *testing.T) ed25519.PublicKey {
+	t.Helper()
+	pub, _ := genKey(t)
+	return pub
+}

--- a/internal/identity/registry/revocation_adversarial_test.go
+++ b/internal/identity/registry/revocation_adversarial_test.go
@@ -1,0 +1,407 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// =====================================================================
+// ADVERSARIAL REVOCATION + EXPIRY BYPASS TESTS
+// =====================================================================
+
+// Attack 1: RevokedAt=0 (zero value via pointer) — does Resolve still reject?
+// If the code checks `*b.RevokedAt == 0` it might treat zero as "not revoked".
+func TestAdversarial_RevokedAtZero_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	zero := int(0)
+	b.RevokedAt = &zero
+	reg := freshRegistry(5, b)
+	if _, err := Resolve(reg, "mira", fixedNow); err == nil {
+		t.Fatal("SECURITY: Resolve accepted a binding with RevokedAt=0 — revocation bypass!")
+	}
+}
+
+// Attack 2: RevokedAt negative (e.g. -1) — could trip up a "if *revokedAt > 0" check.
+func TestAdversarial_RevokedAtNegative_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	neg := int(-1)
+	b.RevokedAt = &neg
+	reg := freshRegistry(5, b)
+	if _, err := Resolve(reg, "mira", fixedNow); err == nil {
+		t.Fatal("SECURITY: Resolve accepted a binding with RevokedAt=-1 — revocation bypass!")
+	}
+}
+
+// Attack 3: RevokedAt in the far future — "not yet revoked" bypass attempt.
+func TestAdversarial_RevokedAtFuture_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	future := int(9_999_999_999)
+	b.RevokedAt = &future
+	reg := freshRegistry(5, b)
+	if _, err := Resolve(reg, "mira", fixedNow); err == nil {
+		t.Fatal("SECURITY: Resolve accepted a binding with future RevokedAt — revocation bypass!")
+	}
+}
+
+// Attack 4: RevokedAt=0 + VerifyMessage — can we get a valid verify through the revoked binding?
+func TestAdversarial_RevokedAtZero_VerifyMessage(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	zero := int(0)
+	b.RevokedAt = &zero
+	reg := freshRegistry(5, b)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted a revoked binding (RevokedAt=0) — revocation bypass!")
+	}
+}
+
+// Attack 5: RevokedAt negative + VerifyMessage
+func TestAdversarial_RevokedAtNegative_VerifyMessage(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	neg := int(-1)
+	b.RevokedAt = &neg
+	reg := freshRegistry(5, b)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted a revoked binding (RevokedAt=-1) — revocation bypass!")
+	}
+}
+
+// Attack 6: Key rotation — old {pubkey, epoch=1} is revoked, can the OLD private key
+// still verify messages under epoch=1?
+func TestAdversarial_RotatedKey_OldEpochStillVerifies(t *testing.T) {
+	oldPub, oldPriv := genKey(t)
+	newPub, _ := genKey(t)
+	revokedAt := int(1_770_000_100)
+
+	oldPk, _ := NewPublicKey(oldPub)
+	newPk, _ := NewPublicKey(newPub)
+
+	old := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: oldPk, KeyEpoch: 1,
+		ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		AuthorizedOriginDaemons: []string{"d"}, RevokedAt: &revokedAt,
+	}
+	fresh := AgentBinding{
+		Slug: "mira", DisplayName: "M", PubKey: newPk, KeyEpoch: 2,
+		ValidFrom: 1_770_000_000, ValidUntil: 1_780_000_000,
+		AuthorizedOriginDaemons: []string{"d"}, RevokedAt: nil,
+	}
+	reg := freshRegistry(6, old, fresh)
+
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"hello from old key"}`))
+	sig, _ := identity.SignCanonical(oldPriv, canonical)
+
+	// The old key with epoch 1 must NOT verify
+	ok, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow)
+	if err == nil && ok {
+		t.Fatal("SECURITY: old revoked key still verifies messages — rotation bypass!")
+	}
+	if err == nil {
+		t.Fatal("SECURITY: VerifyMessage returned no error for revoked old tuple (returned false,nil instead of error)")
+	}
+}
+
+// Attack 7: Binding exactly at valid_until boundary (now == valid_until).
+// Boundary convention (documented on VerifyAndLoad/Resolve): valid_until is
+// INCLUSIVE — a binding is honored AT exactly now == valid_until and rejected
+// one second past it. This test pins that intended, consistent behavior.
+func TestAdversarial_BindingExactlyAtValidUntil_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	// b.ValidUntil is 1_780_000_000; set now to exactly that.
+	exactNow := time.Unix(b.ValidUntil, 0)
+	resolved, err := Resolve(freshRegistry(5, b), "mira", exactNow)
+	if err != nil {
+		t.Fatalf("valid_until is inclusive: binding must resolve AT exactly valid_until, got: %v", err)
+	}
+	if resolved.Slug != "mira" {
+		t.Fatalf("resolved slug = %q, want mira", resolved.Slug)
+	}
+}
+
+// Attack 8: Binding at valid_until+1 must be rejected
+func TestAdversarial_BindingOneSecondPastValidUntil_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	pastNow := time.Unix(b.ValidUntil+1, 0)
+	if _, err := Resolve(freshRegistry(5, b), "mira", pastNow); err == nil {
+		t.Fatal("SECURITY: Resolve accepted a binding 1 second past valid_until — expiry bypass!")
+	}
+}
+
+// Attack 9: Binding at valid_until+1 must be rejected by VerifyMessage too
+func TestAdversarial_ExpiredBinding_VerifyMessage(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	reg := freshRegistry(5, b)
+	pastNow := time.Unix(b.ValidUntil+1, 0)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, pastNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted a binding 1 second past valid_until — expiry bypass!")
+	}
+}
+
+// Attack 10: Key epoch mismatch — claim epoch 2 when binding is epoch 1
+func TestAdversarial_KeyEpochMismatch_HigherClaimed(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	// Claim epoch 2, binding is epoch 1
+	if _, err := VerifyMessage(reg, "mira", 2, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted a key_epoch mismatch (2 vs 1) — epoch bypass!")
+	}
+}
+
+// Attack 11: Key epoch mismatch — claim epoch 0 when binding is epoch 1
+func TestAdversarial_KeyEpochMismatch_ZeroClaimed(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(reg, "mira", 0, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted epoch 0 for binding epoch 1 — epoch bypass!")
+	}
+}
+
+// Attack 12: Unknown slug must be default-denied
+func TestAdversarial_UnknownSlug_DefaultDeny(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	// slug "ghost" has no binding
+	if _, err := VerifyMessage(reg, "ghost", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted an unknown slug — default-deny violated!")
+	}
+}
+
+// Attack 13: Empty slug
+func TestAdversarial_EmptySlug_DefaultDeny(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(reg, "", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted an empty slug — default-deny violated!")
+	}
+}
+
+// Attack 14: Empty registry (no agents at all) — must default-deny
+func TestAdversarial_EmptyRegistry_DefaultDeny(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	_ = agentPub
+	reg := freshRegistry(5) // no agents
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted against an empty registry — default-deny violated!")
+	}
+}
+
+// Attack 15: Resolve on a slug where ALL bindings are revoked — should get error, not succeed
+func TestAdversarial_AllBindingsRevoked_Resolve(t *testing.T) {
+	pub1, _ := genKey(t)
+	pub2, _ := genKey(t)
+	revokedAt := int(1_770_000_100)
+
+	b1 := liveBinding(t, "mira", pub1, 1)
+	b1.RevokedAt = &revokedAt
+	b2 := liveBinding(t, "mira", pub2, 2)
+	b2.RevokedAt = &revokedAt
+
+	reg := freshRegistry(5, b1, b2)
+	if _, err := Resolve(reg, "mira", fixedNow); err == nil {
+		t.Fatal("SECURITY: Resolve found a live binding when all are revoked — revocation bypass!")
+	}
+}
+
+// Attack 16: Resolve on a slug where ALL bindings are expired — should get error
+func TestAdversarial_AllBindingsExpired_Resolve(t *testing.T) {
+	pub1, _ := genKey(t)
+	pub2, _ := genKey(t)
+
+	b1 := liveBinding(t, "mira", pub1, 1)
+	b1.ValidUntil = 1_770_000_100 // expired relative to fixedNow (1_770_000_500)
+	b2 := liveBinding(t, "mira", pub2, 2)
+	b2.ValidUntil = 1_770_000_200 // also expired
+
+	reg := freshRegistry(5, b1, b2)
+	if _, err := Resolve(reg, "mira", fixedNow); err == nil {
+		t.Fatal("SECURITY: Resolve found a live binding when all are expired — expiry bypass!")
+	}
+}
+
+// Attack 17: Resolve returns wrong error type when slug exists but is revoked
+// This is an information-disclosure concern: callers can't distinguish "revoked"
+// from "never existed" via Resolve.
+func TestAdversarial_Resolve_RevokedReturnsUnknownSlugError(t *testing.T) {
+	agentPub, _ := genKey(t)
+	revokedAt := int(1_770_000_100)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.RevokedAt = &revokedAt
+	reg := freshRegistry(5, b)
+
+	_, err := Resolve(reg, "mira", fixedNow)
+	if err == nil {
+		t.Fatal("SECURITY: Resolve accepted a revoked binding")
+	}
+	// Resolve must surface ErrRevoked (not ErrUnknownSlug) so callers can
+	// log/alert specifically on revocation attempts.
+	if !strings.Contains(err.Error(), ErrRevoked) {
+		t.Fatalf("Resolve on a revoked slug must return ErrRevoked, got: %v", err)
+	}
+}
+
+// Attack 18: VerifyMessage with correct slug+epoch but the binding is BOTH
+// revoked AND expired — does the code check both?
+func TestAdversarial_RevokedAndExpired_VerifyMessage(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	revokedAt := int(1_770_000_100)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.RevokedAt = &revokedAt
+	b.ValidUntil = 1_770_000_200 // also expired relative to fixedNow
+
+	reg := freshRegistry(5, b)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted a both-revoked-and-expired binding!")
+	}
+}
+
+// Attack 19: Binding with ValidUntil=0 (epoch zero) — if now.Unix() > 0, should be expired.
+func TestAdversarial_BindingValidUntilZero(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.ValidUntil = 0 // far in the past
+	reg := freshRegistry(5, b)
+	if _, err := Resolve(reg, "mira", fixedNow); err == nil {
+		t.Fatal("SECURITY: Resolve accepted a binding with ValidUntil=0 — expiry bypass!")
+	}
+}
+
+// Attack 20: RevokedAt set to math.MaxInt — extreme value
+func TestAdversarial_RevokedAtMaxInt_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	maxInt := int(1<<63 - 1)
+	b.RevokedAt = &maxInt
+	reg := freshRegistry(5, b)
+	if _, err := Resolve(reg, "mira", fixedNow); err == nil {
+		t.Fatal("SECURITY: Resolve accepted a binding with RevokedAt=MaxInt — revocation bypass!")
+	}
+}
+
+// Attack 21: Multiple bindings for same slug, one revoked one live — ensure
+// the live one is returned, not the revoked one.
+func TestAdversarial_MultipleSameSlug_LiveAfterRevoked(t *testing.T) {
+	pub1, _ := genKey(t)
+	pub2, _ := genKey(t)
+	revokedAt := int(1_770_000_100)
+
+	b1 := liveBinding(t, "mira", pub1, 1)
+	b1.RevokedAt = &revokedAt
+	b2 := liveBinding(t, "mira", pub2, 2)
+
+	// Revoked first, live second
+	reg := freshRegistry(5, b1, b2)
+	resolved, err := Resolve(reg, "mira", fixedNow)
+	if err != nil {
+		t.Fatalf("Resolve should find the live binding: %v", err)
+	}
+	if resolved.KeyEpoch != 2 {
+		t.Fatalf("Resolve returned epoch %d, want 2 (the live binding)", resolved.KeyEpoch)
+	}
+}
+
+// Attack 22: Multiple bindings for same slug, live first then revoked — order test
+func TestAdversarial_MultipleSameSlug_LiveBeforeRevoked(t *testing.T) {
+	pub1, _ := genKey(t)
+	pub2, _ := genKey(t)
+	revokedAt := int(1_770_000_100)
+
+	b1 := liveBinding(t, "mira", pub1, 1) // live
+	b2 := liveBinding(t, "mira", pub2, 2)
+	b2.RevokedAt = &revokedAt // revoked
+
+	// Live first, revoked second
+	reg := freshRegistry(5, b1, b2)
+	resolved, err := Resolve(reg, "mira", fixedNow)
+	if err != nil {
+		t.Fatalf("Resolve should find the live binding: %v", err)
+	}
+	if resolved.KeyEpoch != 1 {
+		t.Fatalf("Resolve returned epoch %d, want 1 (the first live binding)", resolved.KeyEpoch)
+	}
+}
+
+// Attack 23: resolveTuple — same slug, multiple epochs, the matching epoch is revoked
+// but a different epoch is live. The revoked epoch should still be rejected.
+func TestAdversarial_ResolveTuple_MatchingEpochRevoked_OtherLive(t *testing.T) {
+	pub1, priv1 := genKey(t)
+	pub2, _ := genKey(t)
+	revokedAt := int(1_770_000_100)
+
+	b1 := liveBinding(t, "mira", pub1, 1)
+	b1.RevokedAt = &revokedAt             // epoch 1 revoked
+	b2 := liveBinding(t, "mira", pub2, 2) // epoch 2 live
+
+	reg := freshRegistry(5, b1, b2)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(priv1, canonical)
+
+	// Try to verify with the revoked epoch 1
+	ok, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow)
+	if err == nil && ok {
+		t.Fatal("SECURITY: VerifyMessage accepted a revoked epoch even though another epoch is live — revocation bypass!")
+	}
+	if err == nil {
+		t.Fatal("SECURITY: VerifyMessage returned no error for revoked epoch (false,nil instead of error)")
+	}
+}
+
+// Attack 24: ValidFrom in the future — binding not yet active.
+// NOTE: Resolve does NOT check ValidFrom! Only ValidUntil and RevokedAt.
+func TestAdversarial_BindingValidFromInFuture_Resolve(t *testing.T) {
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.ValidFrom = fixedNow.Unix() + 86400 // 1 day in the future
+	b.ValidUntil = fixedNow.Unix() + 86400*2
+
+	reg := freshRegistry(5, b)
+	if _, err := Resolve(reg, "mira", fixedNow); err == nil {
+		t.Fatal("SECURITY: Resolve accepted a binding whose ValidFrom is in the future — " +
+			"a not-yet-active binding must not resolve (premature identity use)")
+	}
+}
+
+// Attack 25: ValidFrom in the future + VerifyMessage — same check via verify path
+func TestAdversarial_BindingValidFromInFuture_VerifyMessage(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.ValidFrom = fixedNow.Unix() + 86400
+	b.ValidUntil = fixedNow.Unix() + 86400*2
+
+	reg := freshRegistry(5, b)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted a message under a not-yet-active binding " +
+			"(future ValidFrom) — premature identity use")
+	}
+}

--- a/internal/identity/registry/validfrom_adversarial_test.go
+++ b/internal/identity/registry/validfrom_adversarial_test.go
@@ -1,0 +1,187 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+)
+
+// Attack 26: Registry-level ValidFrom in the future — VerifyAndLoad should reject
+// a registry that hasn't started its validity window yet.
+func TestAdversarial_RegistryValidFromFuture_VerifyAndLoad(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// Registry valid from 1 day in the future
+	futureStart := fixedNow.Unix() + 86400
+	futureEnd := fixedNow.Unix() + 86400*2
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  futureStart,
+		ValidUntil: futureEnd,
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// VerifyAndLoad at fixedNow (before the registry's ValidFrom) MUST reject:
+	// a not-yet-valid registry fails closed even with a large maxStaleness.
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted a registry whose ValidFrom is in the future — " +
+			"a pre-signed future registry must not load early (perpetual-freshness bypass)")
+	}
+}
+
+// Attack 27: Binding ValidFrom in the future, verify message through it
+// A binding not yet active should not be used for signature verification.
+func TestAdversarial_BindingNotYetActive_FullE2E(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, agentPriv := genKey(t)
+
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.ValidFrom = fixedNow.Unix() + 86400
+	b.ValidUntil = fixedNow.Unix() + 86400*2
+
+	reg := freshRegistry(5, b)
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// The registry itself is in-window here (freshRegistry), so it LOADS; the
+	// not-yet-active BINDING must then refuse to resolve/verify a message.
+	loaded, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad should load an in-window registry: %v", err)
+	}
+
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"premature"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+
+	// A binding whose ValidFrom is in the future must NOT verify a message, even
+	// with an authentic signature by that agent's key.
+	if _, err := VerifyMessage(loaded, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: a not-yet-active binding (future ValidFrom) verified a message — " +
+			"premature identity use")
+	}
+}
+
+// Attack 28: Stale maxStaleness with future ValidFrom — the staleness check
+// `now.Sub(time.Unix(reg.ValidFrom, 0))` would be NEGATIVE (now < ValidFrom),
+// which means the Duration is negative, which is < maxStaleness. So staleness
+// check always passes for future registries!
+func TestAdversarial_StalenessNegativeDuration(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+
+	// Registry starts 1 hour in the future
+	reg := Registry{
+		Epoch:      5,
+		ValidFrom:  fixedNow.Unix() + 3600,
+		ValidUntil: fixedNow.Unix() + 86400,
+		Agents:     []AgentBinding{liveBinding(t, "mira", agentPub, 1)},
+	}
+
+	env, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	// Very tight maxStaleness (1 minute): the now < valid_from guard must reject
+	// BEFORE the staleness check, so a negative duration can never bypass it.
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Minute); err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted a future-ValidFrom registry — " +
+			"the negative staleness duration must not bypass the staleness check")
+	}
+}
+
+// Attack 29: Resolve does not return ErrRevoked — it returns ErrUnknownSlug.
+// This means callers cannot distinguish between "slug never existed" and
+// "slug was specifically revoked". Can an attacker use this to avoid detection?
+func TestAdversarial_Resolve_ErrorMessage_Differentiation(t *testing.T) {
+	agentPub, _ := genKey(t)
+	revokedAt := int(1_770_000_100)
+	b := liveBinding(t, "mira", agentPub, 1)
+	b.RevokedAt = &revokedAt
+	reg := freshRegistry(5, b)
+
+	_, errRevoked := Resolve(reg, "mira", fixedNow)
+	_, errUnknown := Resolve(reg, "nonexistent", fixedNow)
+
+	if errRevoked == nil || errUnknown == nil {
+		t.Fatal("expected both to error")
+	}
+
+	// The revoked slug must surface ErrRevoked (distinguishable), the unknown
+	// slug ErrUnknownSlug — security monitoring can now tell revocation probing
+	// from typos.
+	if !strings.Contains(errRevoked.Error(), ErrRevoked) {
+		t.Fatalf("Resolve on a revoked slug must return ErrRevoked, got: %v", errRevoked)
+	}
+	if !strings.Contains(errUnknown.Error(), ErrUnknownSlug) {
+		t.Fatalf("Resolve on an unknown slug must return ErrUnknownSlug, got: %v", errUnknown)
+	}
+	if errRevoked.Error() == errUnknown.Error() {
+		t.Fatal("Resolve must distinguish a revoked slug from an unknown slug")
+	}
+}
+
+// Attack 30: Binding with KeyEpoch=0 — zero epoch should still match if claimed
+func TestAdversarial_BindingKeyEpochZero_Accepted(t *testing.T) {
+	agentPub, agentPriv := genKey(t)
+	b := liveBinding(t, "mira", agentPub, 0) // key epoch 0
+	reg := freshRegistry(5, b)
+	canonical, _ := identity.Canonicalize([]byte(`{"msg":"x"}`))
+	sig, _ := identity.SignCanonical(agentPriv, canonical)
+	ok, err := VerifyMessage(reg, "mira", 0, canonical, sig, fixedNow)
+	if err != nil {
+		t.Fatalf("VerifyMessage: %v", err)
+	}
+	if !ok {
+		t.Fatal("VerifyMessage should accept epoch 0 when binding is epoch 0")
+	}
+	// Now try with epoch 1 — should be rejected
+	if _, err := VerifyMessage(reg, "mira", 1, canonical, sig, fixedNow); err == nil {
+		t.Fatal("SECURITY: VerifyMessage accepted epoch 1 for binding epoch 0 — epoch bypass!")
+	}
+}
+
+// Attack 31: Negative KeyEpoch in a binding — the trust gate must reject a
+// registry carrying an out-of-range (negative) binding key_epoch, both at sign
+// time and at load time.
+func TestAdversarial_NegativeKeyEpoch(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	b := liveBinding(t, "mira", agentPub, -1) // negative key epoch
+	reg := freshRegistry(5, b)
+
+	// SignRegistry must refuse to mint a negative binding key_epoch.
+	if _, err := SignRegistry(rootPriv, reg); err == nil {
+		t.Fatal("SECURITY: SignRegistry accepted a binding with negative key_epoch — epoch floor bypass")
+	}
+
+	// And even if an attacker hand-signs such a body, VerifyAndLoad must reject
+	// it on the load path. Build a body whose binding key_epoch is -1, sign it
+	// with the real root key, and confirm the load gate rejects it.
+	body := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"X",` +
+		`"key_epoch":-1,"pubkey":"` + base64Std(agentPub) + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":5,"valid_from":1770000000,"valid_until":1780000000}`
+	canonical, err := identity.Canonicalize([]byte(body))
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+	if _, _, err := VerifyAndLoad(rootPub, env, 4, fixedNow, time.Hour*24*365); err == nil {
+		t.Fatal("SECURITY: VerifyAndLoad accepted a hand-signed binding with negative key_epoch")
+	}
+}


### PR DESCRIPTION
## Contract B — slice 3: the registry (the trust root)

The mesh trust root. A root-signed, epoched, freshness-bounded `slug→pubkey` registry that agent-chat's verifier will check every message against. Builds on slice 1 (signing core) + slice 2 (custody).

### What's in it (`internal/identity/registry/`)
- **`SignRegistry`** — root-signs the JCS-canonical registry (ed25519).
- **`VerifyAndLoad`** — the load-bearing trust logic, fail-closed in order: root-sig verify (via slice 1's small-order-rejecting `VerifyCanonical`) → epoch `[1, 2^53]` (JCS-safe) → binding uniqueness → **anti-rollback** (epoch strictly > persisted-highest) → **freshness** (rejects past `valid_until`, past `max_staleness`, **and a future `valid_from`**). A rejected load never advances the anti-rollback floor.
- **`Resolve` / `VerifyMessage`** — default-deny: revoked / expired / not-yet-valid / epoch-mismatched / unknown-slug all rejected; `ErrRevoked` distinguishable from `ErrUnknownSlug`.
- **`PublicKey`** (validating constructor — rejects wrong-length + small-order at construction, `Bytes()` defensive-copies) and **`SignedEntry`** (proof an entry passed schema+canonicalize+verify) — the domain types the slice-1 type-design review asked for.
- **`NetworkID`** — pubkey-derived (NOT git-remote-seeded → not precomputable), reserved `vmnet1:` global prefix.

### How it was reviewed (it's the trust root)
- **Adversarial red-team → fix → re-red-team.** The first build passed its own tests + 94.8% coverage but the red-team found a **CRITICAL freeze/eclipse hole** (a future `valid_from` made staleness negative → perpetually-fresh registry → defeats revocation-withholding) and a JCS epoch-precision break. Both fixed; re-red-team confirmed **all four trust-root gates hold** and honest registries still load (no over-rejection). 126 tests, committed adversarial suites for freeze, rollback, epoch-range, revocation, JCS-precision, root-forgery.
- **pr-review-toolkit** (code/tests/silent-failure/types/comments): no blocking findings; fail-closed posture confirmed. `task check` green; patch coverage 96.4%.

### ⚠ Cross-language (workhorse's Rust verifier): the registry is signed/verified over identical RFC-8785 JCS bytes; epoch bounded to `[1, 2^53]` for IEEE-754 parity. See the private vaults repo `docs/mesh/contractb-decisions.md`.

### Tracked follow-ups (from the toolkit; non-blocking, hardening/polish)
- `RevokedAt`/epoch → `int64` (32-bit overflow safety + consistency; 64-bit target unaffected).
- Replace the small-order check's error-string match with a typed sentinel (`errors.Is`) in slice 1 (currently fails *safe* — deeper guard re-checks).
- Strengthen a weak `SignedEntry` test assertion (`&&`-in-`if`); assert `ErrDuplicateBinding` reason + `newHighestEpoch` on all reject paths; `NetworkID` length/avalanche; `AuthorizedOriginDaemons` round-trip.
- Re-canonicalization-equality check in `VerifyAndLoad` (closes the whole JCS-normalized-field-smuggling class; subsumes the `MaxSafeEpoch=2^53-1` TODO).
- Confirm `SignedEntry`'s home (orphaned in slice 3; likely slice 4 distribution path).

### Next: slice 4 — agent-chat wiring + the live Go→Rust round trip (the gate). This merge is workhorse's ping to wire its verifier.
