### PR TITLE
feat(identity): Contract B --registry distribution envelope + cross-language fixture (slice 4)

### DIFF
--- a/internal/identity/registry/README.md
+++ b/internal/identity/registry/README.md
@@ -1,0 +1,151 @@
+# Contract B — Registry Distribution Envelope (Slice 4)
+
+This package implements the Contract-B **trust-root registry** (slice 3) and its
+**`--registry` distribution envelope** (slice 4): the on-disk / over-wire format
+a root-signed `SignedRegistry` is serialized to, plus the deterministic
+cross-language acceptance fixture that workhorse's Rust verifier binds to.
+
+The distribution layer is **(de)serialization + fail-closed parsing only**. All
+trust logic (root-sig verify, anti-rollback, freshness, revocation, resolve,
+message verify) lives in `registry.go` (slice 3) and is **not** duplicated here.
+
+## Distribution envelope JSON
+
+A distributed `SignedRegistry` is a single JSON object:
+
+```json
+{
+  "registry": "<base64-std of the JCS-canonical registry bytes>",
+  "root_sig": "<base64-std of the 64-byte ed25519 root signature>",
+  "root_key_epoch": 0
+}
+```
+
+- `registry` — base64-std (RFC 4648, padded) of the **exact** JCS-canonical
+  registry bytes that `root_sig` covers. These bytes are emitted **verbatim**;
+  they are never re-canonicalized or double-JSON-encoded. The decoded payload is
+  raw JCS JSON (begins with `{`), not a quoted string.
+- `root_sig` — base64-std of the ed25519 signature by the offline root key over
+  the decoded `registry` bytes. Must decode to exactly `ed25519.SignatureSize`
+  (64) bytes.
+- `root_key_epoch` — a bare JSON integer identifying which root key signed (for
+  root rotation).
+
+`MarshalDistribution(SignedRegistry) ([]byte, error)` produces this JSON;
+`ParseDistribution([]byte) (SignedRegistry, error)` parses it.
+
+### Fail-closed parsing
+
+`ParseDistribution` returns an error **and a zero `SignedRegistry`** (never a
+partial value that could be mistaken for valid) on any malformed input:
+
+- non-JSON / malformed JSON,
+- an unknown/extra field (strict decoding — no silent drop of a smuggled key),
+- a missing or empty `registry` or `root_sig`,
+- a `registry` or `root_sig` that is not valid base64-std,
+- a `root_sig` that does not decode to 64 bytes.
+
+It never panics. It does **not** verify the root signature, freshness, or
+anti-rollback — those are `VerifyAndLoad`'s job.
+
+## JCS canonical registry / binding shape
+
+The registry bytes inside the envelope are the RFC 8785 (JCS) canonical form of:
+
+```jsonc
+{
+  "agents": [
+    {
+      "authorized_origin_daemons": ["daemon-1"],
+      "display_name": "Mira ⭐",     // raw UTF-8, never \u-escaped
+      "key_epoch": 1,                // bare integer
+      "pubkey": "<base64-std 32-byte ed25519 pubkey>",
+      "revoked_at": 1700000000,      // OMITTED when the binding is live
+      "slug": "mira",
+      "valid_from": 1990000,         // unix seconds, bare integer
+      "valid_until": 3000000
+    }
+  ],
+  "epoch": 10,                       // monotonic anti-rollback counter, bare int
+  "valid_from": 1990000,
+  "valid_until": 3000000
+}
+```
+
+Canonicalization rules (enforced by `identity.Canonicalize`):
+
+- object keys sorted lexicographically by UTF-16 code unit,
+- field names `snake_case`,
+- pubkeys base64-std,
+- integers rendered bare (no decimal point / exponent); epochs are bounded to
+  `[1, 2^53]` so they round-trip across languages without IEEE-754 precision
+  loss,
+- `revoked_at` **omitted** when the binding is live (nil pointer == live),
+  present only when revoked,
+- string values preserved as raw UTF-8 (e.g. `⭐` stays `0xE2 0xAD 0x90`).
+
+## Verify order (consumer / Rust verifier contract)
+
+`ParseDistribution` then `registry.VerifyAndLoad` perform, **fail-closed at every
+step, in this order**:
+
+1. **Parse** the envelope (fail-closed on malformed input, above).
+2. **Root signature first**, over the **received** registry bytes — verify
+   `root_sig` against the **pinned** root pubkey using ZIP-215 strict
+   verification with an explicit small-order pubkey reject (cofactor check). A
+   tampered body or a small-order root key is rejected **before** the body is
+   trusted.
+3. **Decode** the now-authenticated bytes; every agent pubkey is re-validated
+   (wrong-length / small-order / undecodable agent keys are rejected at load).
+4. **Epoch range** — reject a registry epoch or any binding `key_epoch` outside
+   `[1, 2^53]`.
+5. **Uniqueness** — reject duplicate `{slug, key_epoch}` tuples or more than one
+   live binding per slug (shadowing defense).
+6. **Anti-rollback** — reject `epoch <= persistedHighestEpoch`.
+7. **Freshness (fail closed)** — reject if `now < valid_from`
+   (**reject-future-`valid_from`**), `now > valid_until`, or
+   `now - valid_from > maxStaleness`. A stale registry may hide a revocation.
+
+Then, per message:
+
+8. **Resolve** the live binding for the slug at `now`, default-denying a
+   **revoked**, **expired**, or **not-yet-valid** (`now < binding.valid_from`)
+   binding.
+9. **VerifyMessage** — require the caller's `key_epoch` to match the resolved
+   binding (default-deny on mismatch), then verify the message signature under
+   the binding's pubkey with the same ZIP-215 strict + small-order +
+   non-canonical-S rejection.
+
+## Cross-language acceptance fixture
+
+`testdata/cross_language_vectors.json` is the **gating acceptance test** and the
+stable artifact workhorse's Rust verifier binds to. It is generated
+deterministically (fixed ed25519 seeds) by `TestGenerate_CrossLanguageFixture`
+(run `go test ./internal/identity/registry/ -run TestGenerate_CrossLanguageFixture -update`)
+and committed.
+
+Top-level shape:
+
+- `root_pubkey` — base64-std of the pinned root pubkey to verify against.
+- `now`, `max_staleness_secs` — the reference time and staleness bound the
+  negatives are relative to.
+- `valid` — a complete `--registry` envelope that loads under
+  `root_pubkey`/`now`/`max_staleness_secs`, plus the expected resolved binding
+  (`expect_slug` / `expect_key_epoch` / `expect_pubkey`) and a sample
+  `{slug, key_epoch, canonical_message_bytes, signature}` that `VerifyMessage`
+  **accepts**.
+- `reject` — named negative cases, each `{name, reason, expect:"reject",
+  envelope, ...}` with optional `root_pubkey` / `now` / `persisted_highest_epoch`
+  overrides and an optional message sample. Cases cover: small-order root pubkey,
+  small-order agent pubkey, non-canonical S in the message signature,
+  future `valid_from` (registry-level and binding-level), rollback
+  (`epoch <= persisted`), stale (`now > valid_until` and beyond `max_staleness`),
+  revoked binding, and a tampered registry body.
+
+The Go side proves the fixture is correct **before** Rust consumes it:
+`TestCrossLanguageFixture_ValidLoadsAndVerifies` asserts the valid case
+loads + resolves + verifies, and `TestCrossLanguageFixture_AllRejectsAreRejected`
+asserts **every** reject case is rejected somewhere in
+`ParseDistribution` / `VerifyAndLoad` / `Resolve` / `VerifyMessage`. The Rust
+`verify_strict` + cofactor + freshness + anti-rollback path must reject the same
+cases and accept the same valid case.

--- a/internal/identity/registry/README.md
+++ b/internal/identity/registry/README.md
@@ -16,8 +16,8 @@ A distributed `SignedRegistry` is a single JSON object:
 ```json
 {
   "registry": "<base64-std of the JCS-canonical registry bytes>",
-  "root_sig": "<base64-std of the 64-byte ed25519 root signature>",
-  "root_key_epoch": 0
+  "root_key_epoch": 0,
+  "root_sig": "<base64-std of the 64-byte ed25519 root signature>"
 }
 ```
 
@@ -41,9 +41,11 @@ partial value that could be mistaken for valid) on any malformed input:
 
 - non-JSON / malformed JSON,
 - an unknown/extra field (strict decoding — no silent drop of a smuggled key),
+- trailing bytes after the envelope object (concatenated-object or garbage defense),
 - a missing or empty `registry` or `root_sig`,
 - a `registry` or `root_sig` that is not valid base64-std,
-- a `root_sig` that does not decode to 64 bytes.
+- a `root_sig` that does not decode to 64 bytes,
+- a negative `root_key_epoch` (key epochs are non-negative; a negative value is structurally invalid).
 
 It never panics. It does **not** verify the root signature, freshness, or
 anti-rollback — those are `VerifyAndLoad`'s job.

--- a/internal/identity/registry/crosslang_fixture_test.go
+++ b/internal/identity/registry/crosslang_fixture_test.go
@@ -216,7 +216,7 @@ func buildFixture(t *testing.T) crossLangFixture {
 	// SignRegistry/NewPublicKey reject small-order keys; mutate the canonical
 	// bytes, re-sign with the root, then the agent-key validation (fromWire)
 	// rejects at load.
-	rejects = append(rejects, genSmallOrderAgent(t, rootPriv, rootPub, baseReg, smallPub))
+	rejects = append(rejects, genSmallOrderAgent(t, rootPriv, baseReg, smallPub))
 
 	// 3. Future valid_from at REGISTRY level.
 	futureReg := baseReg
@@ -336,7 +336,7 @@ func hexNibble(c byte) (byte, error) {
 // genSmallOrderAgent crafts an envelope whose binding carries a small-order
 // agent pubkey, re-signed by the legitimate root so root_sig verifies but the
 // agent-key validation (fromWire) rejects at load.
-func genSmallOrderAgent(t *testing.T, rootPriv ed25519.PrivateKey, rootPub ed25519.PublicKey, base Registry, smallPub ed25519.PublicKey) rejectCase {
+func genSmallOrderAgent(t *testing.T, rootPriv ed25519.PrivateKey, base Registry, smallPub ed25519.PublicKey) rejectCase {
 	t.Helper()
 	// Build the wire registry directly, inject the small-order pubkey, canonicalize,
 	// and sign with the real root key.
@@ -351,7 +351,6 @@ func genSmallOrderAgent(t *testing.T, rootPriv ed25519.PrivateKey, rootPub ed255
 	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
 	out, err := MarshalDistribution(env)
 	require.NoError(t, err)
-	_ = rootPub
 	return rejectCase{
 		Name: "small_order_agent_pubkey", Reason: "binding agent pubkey is small-order; load rejects the binding",
 		Expect: "reject", Envelope: out,
@@ -385,6 +384,28 @@ func TestGenerate_CrossLanguageFixture(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(fixturePath), 0o755))
 	require.NoError(t, os.WriteFile(fixturePath, out, 0o644))
 	t.Logf("wrote %s (%d bytes, %d reject cases)", fixturePath, len(out), len(fx.Reject))
+}
+
+// TestCrossLanguageFixture_MatchesGenerator is a CI-guard that fails if the
+// committed testdata/cross_language_vectors.json diverges byte-for-byte from
+// what buildFixture() + json.MarshalIndent currently generates. If this test
+// fails, regenerate with: go test ./internal/identity/registry/ -run
+// TestGenerate_CrossLanguageFixture -update
+func TestCrossLanguageFixture_MatchesGenerator(t *testing.T) {
+	if *updateFixture {
+		t.Skip("skipping match check during -update regeneration")
+	}
+	committed, err := os.ReadFile(fixturePath)
+	require.NoError(t, err, "committed fixture must exist; run with -update to generate it")
+
+	fx := buildFixture(t)
+	generated, err := json.MarshalIndent(fx, "", "  ")
+	require.NoError(t, err)
+	generated = append(generated, '\n')
+
+	assert.Equal(t, string(committed), string(generated),
+		"committed fixture diverges from generator output — regenerate with: "+
+			"go test ./internal/identity/registry/ -run TestGenerate_CrossLanguageFixture -update")
 }
 
 // TestCrossLanguageFixture_ValidLoadsAndVerifies proves, against the COMMITTED

--- a/internal/identity/registry/crosslang_fixture_test.go
+++ b/internal/identity/registry/crosslang_fixture_test.go
@@ -1,0 +1,539 @@
+package registry
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// updateFixture, when set (-update), regenerates the committed cross-language
+// vectors file. Without it, the fixture is treated as a stable artifact and only
+// loaded/asserted.
+var updateFixture = flag.Bool("update", false, "regenerate the committed cross-language fixture")
+
+// fixturePath is the committed cross-language acceptance fixture — the artifact
+// workhorse's Rust verifier binds to.
+const fixturePath = "testdata/cross_language_vectors.json"
+
+// --- Fixture JSON schema (the cross-language acceptance contract) ---
+
+// crossLangFixture is the top-level fixture: a pinned root pubkey, a reference
+// time + staleness bound, a single VALID distribution case, and an array of
+// named REJECT cases. Every byte is deterministic (fixed seeds).
+type crossLangFixture struct {
+	RootPubKey      string       `json:"root_pubkey"`
+	Now             int64        `json:"now"`
+	MaxStalenessSec int64        `json:"max_staleness_secs"`
+	Valid           validCase    `json:"valid"`
+	Reject          []rejectCase `json:"reject"`
+}
+
+// validCase is a complete envelope that loads, plus the expected resolved
+// binding for a slug and a sample message the resolved key verifies.
+type validCase struct {
+	Envelope       json.RawMessage `json:"envelope"`
+	PersistedEpoch int             `json:"persisted_highest_epoch"`
+	ExpectSlug     string          `json:"expect_slug"`
+	ExpectKeyEpoch int             `json:"expect_key_epoch"`
+	ExpectPubKey   string          `json:"expect_pubkey"`
+	Message        messageCase     `json:"message"`
+}
+
+// messageCase is a {slug, key_epoch, canonical message bytes, signature} sample
+// that VerifyMessage accepts under the resolved binding.
+type messageCase struct {
+	Slug             string `json:"slug"`
+	KeyEpoch         int    `json:"key_epoch"`
+	CanonicalMessage string `json:"canonical_message_bytes"`
+	Signature        string `json:"signature"`
+}
+
+// rejectCase is a negative case: an envelope (or mutated field) that, under the
+// supplied (or top-level) root pubkey/now/persisted epoch, MUST be rejected by
+// the Go (and Rust) verify path. RootPubKey/Now/PersistedEpoch override the
+// top-level defaults when non-zero/non-empty.
+type rejectCase struct {
+	Name           string          `json:"name"`
+	Reason         string          `json:"reason"`
+	Expect         string          `json:"expect"` // always "reject"
+	Envelope       json.RawMessage `json:"envelope"`
+	RootPubKey     string          `json:"root_pubkey,omitempty"`
+	Now            *int64          `json:"now,omitempty"`
+	PersistedEpoch *int            `json:"persisted_highest_epoch,omitempty"`
+	// Message, when set, is a per-case message whose VerifyMessage must reject
+	// (non-canonical S, revoked binding, etc.) AFTER the envelope itself loads.
+	Message *messageCase `json:"message,omitempty"`
+}
+
+// --- Deterministic generation helpers ---
+
+const (
+	// ed25519 group order L = 2^252 + 27742317777372353535851937790883648493.
+	groupOrderHex = "1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed"
+	// smallOrderPubKeyHex is the all-zero (identity) small-order point: a
+	// universal-forgery vector that VerifyCanonical/Rust verify_strict reject.
+	smallOrderPubKeyHex = "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+func b64(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
+
+// genEnvelope signs reg with rootPriv and returns the distribution-envelope JSON.
+func genEnvelope(t *testing.T, rootPriv ed25519.PrivateKey, reg Registry) json.RawMessage {
+	t.Helper()
+	env, err := SignRegistry(rootPriv, reg)
+	require.NoError(t, err)
+	out, err := MarshalDistribution(env)
+	require.NoError(t, err)
+	return out
+}
+
+// signCanonicalMsg signs an arbitrary canonical message with priv (used for the
+// per-message samples). The message bytes are the EXACT bytes the binding key
+// verifies — not schema-gated, mirroring VerifyMessage's CanonicalBytes input.
+func signCanonicalMsg(t *testing.T, priv ed25519.PrivateKey, msg []byte) []byte {
+	t.Helper()
+	sig, err := identity.SignCanonical(priv, identity.CanonicalBytesFromTrusted(msg))
+	require.NoError(t, err)
+	return sig
+}
+
+// nonCanonicalS takes a valid (R||S) signature and returns R||(S+L). S+L ≡ S
+// (mod L) so it is the "same" scalar, but its 32-byte little-endian encoding is
+// non-canonical (>= L), which ZIP-215 / verify_strict reject (signature
+// malleability defense).
+func nonCanonicalS(t *testing.T, sig []byte) []byte {
+	t.Helper()
+	require.Len(t, sig, ed25519.SignatureSize)
+	order := new(big.Int)
+	order.SetString(groupOrderHex, 16)
+
+	// S is the high 32 bytes, little-endian.
+	sLE := make([]byte, 32)
+	copy(sLE, sig[32:])
+	sBE := reverse(sLE)
+	s := new(big.Int).SetBytes(sBE)
+	s.Add(s, order) // S + L, still < 2^256 for honest signatures
+
+	outBE := s.Bytes()
+	// Left-pad to 32 bytes big-endian, then reverse to little-endian.
+	padded := make([]byte, 32)
+	copy(padded[32-len(outBE):], outBE)
+	sLEout := reverse(padded)
+
+	out := make([]byte, ed25519.SignatureSize)
+	copy(out, sig[:32])
+	copy(out[32:], sLEout)
+	return out
+}
+
+func reverse(b []byte) []byte {
+	out := make([]byte, len(b))
+	for i := range b {
+		out[len(b)-1-i] = b[i]
+	}
+	return out
+}
+
+// buildFixture deterministically constructs the entire fixture from fixed seeds.
+func buildFixture(t *testing.T) crossLangFixture {
+	t.Helper()
+	rootPub, rootPriv := fixedEd25519(t, 0xA1)
+	agentPub, agentPriv := fixedEd25519(t, 0xB2)
+	smallPub, err := ed25519HexToPub(smallOrderPubKeyHex)
+	require.NoError(t, err)
+
+	apk, err := NewPublicKey(agentPub)
+	require.NoError(t, err)
+
+	const (
+		now          int64 = 2_000_000
+		maxStale     int64 = 86_400 // 1 day
+		regFrom      int64 = 1_990_000
+		regUntil     int64 = 3_000_000
+		bindFrom     int64 = 1_990_000
+		bindUntil    int64 = 3_000_000
+		validEpoch         = 10
+		validKeyEp         = 1
+		persistedLow       = 9
+	)
+
+	baseBinding := AgentBinding{
+		Slug: "mira", DisplayName: "Mira ⭐", PubKey: apk, KeyEpoch: validKeyEp,
+		ValidFrom: bindFrom, ValidUntil: bindUntil, AuthorizedOriginDaemons: []string{"daemon-1"},
+	}
+	baseReg := Registry{
+		Epoch: validEpoch, ValidFrom: regFrom, ValidUntil: regUntil,
+		Agents: []AgentBinding{baseBinding},
+	}
+
+	// VALID envelope + a real signed message under the agent key.
+	validEnv := genEnvelope(t, rootPriv, baseReg)
+	msgBytes := []byte(`{"body":"hello","from":"mira"}`)
+	msgSig := signCanonicalMsg(t, agentPriv, msgBytes)
+
+	fx := crossLangFixture{
+		RootPubKey:      b64(rootPub),
+		Now:             now,
+		MaxStalenessSec: maxStale,
+		Valid: validCase{
+			Envelope:       validEnv,
+			PersistedEpoch: persistedLow,
+			ExpectSlug:     "mira",
+			ExpectKeyEpoch: validKeyEp,
+			ExpectPubKey:   b64(agentPub),
+			Message: messageCase{
+				Slug: "mira", KeyEpoch: validKeyEp,
+				CanonicalMessage: b64(msgBytes), Signature: b64(msgSig),
+			},
+		},
+	}
+
+	// --- REJECT cases ---
+	var rejects []rejectCase
+	add := func(name, reason string, env json.RawMessage) {
+		rejects = append(rejects, rejectCase{Name: name, Reason: reason, Expect: "reject", Envelope: env})
+	}
+
+	// 1. Small-order ROOT pubkey: the valid envelope, but verified against a
+	// small-order pinned root key (verify_strict must reject the root key itself).
+	rejects = append(rejects, rejectCase{
+		Name: "small_order_root_pubkey", Reason: "pinned root pubkey is small-order (universal-forgery vector)",
+		Expect: "reject", Envelope: validEnv, RootPubKey: b64(smallPub),
+	})
+
+	// 2. Small-order AGENT pubkey in a binding: a registry whose binding carries a
+	// small-order agent key. We must sign it with a wire-level injection because
+	// SignRegistry/NewPublicKey reject small-order keys; mutate the canonical
+	// bytes, re-sign with the root, then the agent-key validation (fromWire)
+	// rejects at load.
+	rejects = append(rejects, genSmallOrderAgent(t, rootPriv, rootPub, baseReg, smallPub))
+
+	// 3. Future valid_from at REGISTRY level.
+	futureReg := baseReg
+	futureReg.ValidFrom = now + 100_000
+	futureReg.Epoch = validEpoch
+	add("future_valid_from_registry", "registry valid_from is in the future (not yet fresh)",
+		genEnvelope(t, rootPriv, futureReg))
+
+	// 4. Future valid_from at BINDING level (registry fresh, binding not yet valid).
+	futureBindReg := baseReg
+	fb := baseBinding
+	fb.ValidFrom = now + 100_000
+	futureBindReg.Agents = []AgentBinding{fb}
+	rejects = append(rejects, rejectCase{
+		Name: "future_valid_from_binding", Reason: "binding valid_from is in the future (resolve/verify must reject)",
+		Expect: "reject", Envelope: genEnvelope(t, rootPriv, futureBindReg),
+		Message: &messageCase{Slug: "mira", KeyEpoch: validKeyEp, CanonicalMessage: b64(msgBytes), Signature: b64(msgSig)},
+	})
+
+	// 5. Rollback: epoch <= persisted highest. Use persisted == validEpoch so the
+	// valid envelope's epoch is not strictly greater.
+	pe := validEpoch
+	rejects = append(rejects, rejectCase{
+		Name: "rollback_epoch_at_or_below_persisted", Reason: "registry epoch <= persisted highest seen (anti-rollback)",
+		Expect: "reject", Envelope: validEnv, PersistedEpoch: &pe,
+	})
+
+	// 6a. Stale: now past valid_until.
+	pastNow := regUntil + 1
+	rejects = append(rejects, rejectCase{
+		Name: "stale_past_valid_until", Reason: "now is past registry valid_until (fail closed)",
+		Expect: "reject", Envelope: validEnv, Now: &pastNow,
+	})
+	// 6b. Stale: now - valid_from exceeds max_staleness (within valid_until).
+	staleNow := regFrom + maxStale + 1
+	rejects = append(rejects, rejectCase{
+		Name: "stale_beyond_max_staleness", Reason: "now - valid_from exceeds max_staleness_secs (fail closed)",
+		Expect: "reject", Envelope: validEnv, Now: &staleNow,
+	})
+
+	// 7. Revoked binding: resolve/verify must reject.
+	revAt := int(bindFrom + 1000)
+	revReg := baseReg
+	rb := baseBinding
+	rb.RevokedAt = &revAt
+	revReg.Agents = []AgentBinding{rb}
+	rejects = append(rejects, rejectCase{
+		Name: "revoked_binding", Reason: "binding is revoked (resolve/verify must reject)",
+		Expect: "reject", Envelope: genEnvelope(t, rootPriv, revReg),
+		Message: &messageCase{Slug: "mira", KeyEpoch: validKeyEp, CanonicalMessage: b64(msgBytes), Signature: b64(msgSig)},
+	})
+
+	// 8. Tampered registry body: valid envelope with one byte of the registry flipped
+	// so root_sig no longer matches.
+	add("tampered_registry_body", "registry bytes mutated; root_sig no longer matches",
+		tamperEnvelope(t, validEnv))
+
+	// 9. Non-canonical S in the MESSAGE signature: envelope loads, but the
+	// per-message sample carries S+L which verify_strict rejects.
+	rejects = append(rejects, rejectCase{
+		Name: "non_canonical_s_message_sig", Reason: "message signature has non-canonical S (S >= L); verify_strict rejects",
+		Expect: "reject", Envelope: validEnv,
+		Message: &messageCase{Slug: "mira", KeyEpoch: validKeyEp, CanonicalMessage: b64(msgBytes), Signature: b64(nonCanonicalS(t, msgSig))},
+	})
+
+	fx.Reject = append(rejects, fx.Reject...)
+	return fx
+}
+
+// ed25519HexToPub decodes a hex pubkey string into an ed25519.PublicKey.
+func ed25519HexToPub(h string) (ed25519.PublicKey, error) {
+	raw := make([]byte, ed25519.PublicKeySize)
+	_, err := hexDecode(h, raw)
+	if err != nil {
+		return nil, err
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
+// hexDecode decodes hex string h into dst, returning the byte count.
+func hexDecode(h string, dst []byte) (int, error) {
+	b, err := hexBytes(h)
+	if err != nil {
+		return 0, err
+	}
+	return copy(dst, b), nil
+}
+
+func hexBytes(h string) ([]byte, error) {
+	out := make([]byte, len(h)/2)
+	for i := 0; i < len(out); i++ {
+		var hi, lo byte
+		var err error
+		if hi, err = hexNibble(h[2*i]); err != nil {
+			return nil, err
+		}
+		if lo, err = hexNibble(h[2*i+1]); err != nil {
+			return nil, err
+		}
+		out[i] = hi<<4 | lo
+	}
+	return out, nil
+}
+
+func hexNibble(c byte) (byte, error) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', nil
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, nil
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, nil
+	}
+	return 0, assert.AnError
+}
+
+// genSmallOrderAgent crafts an envelope whose binding carries a small-order
+// agent pubkey, re-signed by the legitimate root so root_sig verifies but the
+// agent-key validation (fromWire) rejects at load.
+func genSmallOrderAgent(t *testing.T, rootPriv ed25519.PrivateKey, rootPub ed25519.PublicKey, base Registry, smallPub ed25519.PublicKey) rejectCase {
+	t.Helper()
+	// Build the wire registry directly, inject the small-order pubkey, canonicalize,
+	// and sign with the real root key.
+	w := toWire(base)
+	w.Agents[0].PubKey = b64(smallPub)
+	raw, err := json.Marshal(w)
+	require.NoError(t, err)
+	canonical, err := identity.Canonicalize(raw)
+	require.NoError(t, err)
+	sig, err := identity.SignCanonical(rootPriv, canonical)
+	require.NoError(t, err)
+	env := SignedRegistry{Registry: canonical.Bytes(), RootSig: sig, RootKeyEpoch: 0}
+	out, err := MarshalDistribution(env)
+	require.NoError(t, err)
+	_ = rootPub
+	return rejectCase{
+		Name: "small_order_agent_pubkey", Reason: "binding agent pubkey is small-order; load rejects the binding",
+		Expect: "reject", Envelope: out,
+	}
+}
+
+// tamperEnvelope parses the envelope, flips one byte of the registry payload,
+// re-marshals (keeping the now-mismatched root_sig), so root_sig fails to verify.
+func tamperEnvelope(t *testing.T, env json.RawMessage) json.RawMessage {
+	t.Helper()
+	parsed, err := ParseDistribution(env)
+	require.NoError(t, err)
+	tampered := make([]byte, len(parsed.Registry))
+	copy(tampered, parsed.Registry)
+	tampered[len(tampered)/2] ^= 0xFF
+	out, err := MarshalDistribution(SignedRegistry{Registry: tampered, RootSig: parsed.RootSig, RootKeyEpoch: parsed.RootKeyEpoch})
+	require.NoError(t, err)
+	return out
+}
+
+// TestGenerate_CrossLanguageFixture writes the deterministic fixture to disk
+// when -update is set. It is the SSOT generator for the committed artifact.
+func TestGenerate_CrossLanguageFixture(t *testing.T) {
+	if !*updateFixture {
+		t.Skip("run with -update to regenerate the committed fixture")
+	}
+	fx := buildFixture(t)
+	out, err := json.MarshalIndent(fx, "", "  ")
+	require.NoError(t, err)
+	out = append(out, '\n')
+	require.NoError(t, os.MkdirAll(filepath.Dir(fixturePath), 0o755))
+	require.NoError(t, os.WriteFile(fixturePath, out, 0o644))
+	t.Logf("wrote %s (%d bytes, %d reject cases)", fixturePath, len(out), len(fx.Reject))
+}
+
+// TestCrossLanguageFixture_ValidLoadsAndVerifies proves, against the COMMITTED
+// artifact, that the valid case loads + resolves + verifies — so the Go side
+// guarantees correctness before Rust consumes the bytes.
+func TestCrossLanguageFixture_ValidLoadsAndVerifies(t *testing.T) {
+	fx := loadFixture(t)
+	rootPub := mustB64Pub(t, fx.RootPubKey)
+
+	parsed, err := ParseDistribution(fx.Valid.Envelope)
+	require.NoError(t, err)
+
+	reg, _, err := VerifyAndLoad(rootPub, parsed, fx.Valid.PersistedEpoch,
+		time.Unix(fx.Now, 0), time.Duration(fx.MaxStalenessSec)*time.Second)
+	require.NoError(t, err, "the valid envelope must load")
+
+	b, err := Resolve(reg, fx.Valid.ExpectSlug, time.Unix(fx.Now, 0))
+	require.NoError(t, err, "the valid slug must resolve")
+	assert.Equal(t, fx.Valid.ExpectKeyEpoch, b.KeyEpoch)
+	assert.Equal(t, fx.Valid.ExpectPubKey, b64(b.PubKey.Bytes()), "resolved binding pubkey must match expected")
+
+	msg, err := base64.StdEncoding.DecodeString(fx.Valid.Message.CanonicalMessage)
+	require.NoError(t, err)
+	sig, err := base64.StdEncoding.DecodeString(fx.Valid.Message.Signature)
+	require.NoError(t, err)
+	ok, err := VerifyMessage(reg, fx.Valid.Message.Slug, fx.Valid.Message.KeyEpoch,
+		identity.CanonicalBytesFromTrusted(msg), sig, time.Unix(fx.Now, 0))
+	require.NoError(t, err)
+	assert.True(t, ok, "the valid message sample must verify under the resolved binding")
+}
+
+// TestCrossLanguageFixture_AllRejectsAreRejected proves EVERY committed reject
+// case is rejected by ParseDistribution/VerifyAndLoad/Resolve/VerifyMessage —
+// the gating acceptance contract the Rust verifier must match.
+func TestCrossLanguageFixture_AllRejectsAreRejected(t *testing.T) {
+	fx := loadFixture(t)
+	require.NotEmpty(t, fx.Reject, "fixture must carry reject cases")
+
+	for _, rc := range fx.Reject {
+		t.Run(rc.Name, func(t *testing.T) {
+			assert.Equal(t, "reject", rc.Expect, "every negative case must declare expect=reject")
+			rootPub := mustB64Pub(t, firstNonEmpty(rc.RootPubKey, fx.RootPubKey))
+			now := fx.Now
+			if rc.Now != nil {
+				now = *rc.Now
+			}
+			persisted := fx.Valid.PersistedEpoch
+			if rc.PersistedEpoch != nil {
+				persisted = *rc.PersistedEpoch
+			}
+
+			staleness := time.Duration(fx.MaxStalenessSec) * time.Second
+			rejected := caseIsRejected(t, rc, rootPub, persisted, now, staleness)
+			assert.True(t, rejected, "case %q (%s) MUST be rejected somewhere in parse/load/resolve/verify", rc.Name, rc.Reason)
+		})
+	}
+}
+
+// caseIsRejected runs a reject case through the full consumer path and reports
+// whether it is rejected at any stage: parse -> load -> (if a message) resolve +
+// VerifyMessage. A case is "rejected" if any stage errors or VerifyMessage
+// returns (false, _).
+func caseIsRejected(t *testing.T, rc rejectCase, rootPub ed25519.PublicKey, persisted int, now int64, staleness time.Duration) bool {
+	t.Helper()
+	parsed, err := ParseDistribution(rc.Envelope)
+	if err != nil {
+		return true
+	}
+	reg, _, err := VerifyAndLoad(rootPub, parsed, persisted, time.Unix(now, 0), staleness)
+	if err != nil {
+		return true
+	}
+	if rc.Message == nil {
+		// No message: the envelope itself was expected to be rejected at load,
+		// but it loaded — that is NOT a rejection.
+		return false
+	}
+	// Envelope loaded; the rejection must come from resolve/verify of the message.
+	if _, rerr := Resolve(reg, rc.Message.Slug, time.Unix(now, 0)); rerr != nil {
+		return true
+	}
+	msg, err := base64.StdEncoding.DecodeString(rc.Message.CanonicalMessage)
+	require.NoError(t, err)
+	sig, err := base64.StdEncoding.DecodeString(rc.Message.Signature)
+	require.NoError(t, err)
+	ok, verr := VerifyMessage(reg, rc.Message.Slug, rc.Message.KeyEpoch,
+		identity.CanonicalBytesFromTrusted(msg), sig, time.Unix(now, 0))
+	return verr != nil || !ok
+}
+
+// TestCrossLanguageFixture_MessageCasesLoadThenRejectAtMessage proves the
+// message-layer reject cases (future-valid binding, revoked binding,
+// non-canonical S) are NOT accidentally rejected at the envelope layer: their
+// envelope must LOAD, and the rejection must come from resolve/VerifyMessage.
+// This pins the failure stage so the Rust verifier binds to the same contract.
+func TestCrossLanguageFixture_MessageCasesLoadThenRejectAtMessage(t *testing.T) {
+	fx := loadFixture(t)
+	rootPub := mustB64Pub(t, fx.RootPubKey)
+	staleness := time.Duration(fx.MaxStalenessSec) * time.Second
+
+	wantMessageLayer := map[string]bool{
+		"future_valid_from_binding":   true,
+		"revoked_binding":             true,
+		"non_canonical_s_message_sig": true,
+	}
+	seen := map[string]bool{}
+	for _, rc := range fx.Reject {
+		if !wantMessageLayer[rc.Name] {
+			continue
+		}
+		seen[rc.Name] = true
+		require.NotNil(t, rc.Message, "case %q must carry a message sample", rc.Name)
+		parsed, err := ParseDistribution(rc.Envelope)
+		require.NoError(t, err, "case %q envelope must parse", rc.Name)
+		now := fx.Now
+		if rc.Now != nil {
+			now = *rc.Now
+		}
+		// The envelope itself must LOAD (root sig + freshness + anti-rollback OK).
+		_, _, err = VerifyAndLoad(rootPub, parsed, fx.Valid.PersistedEpoch, time.Unix(now, 0), staleness)
+		require.NoError(t, err, "case %q envelope must load; rejection belongs to the message layer", rc.Name)
+	}
+	for name := range wantMessageLayer {
+		assert.True(t, seen[name], "expected message-layer case %q in the fixture", name)
+	}
+}
+
+// --- fixture load helpers ---
+
+func loadFixture(t *testing.T) crossLangFixture {
+	t.Helper()
+	data, err := os.ReadFile(fixturePath)
+	require.NoError(t, err, "committed fixture must exist; run with -update to generate it")
+	var fx crossLangFixture
+	require.NoError(t, json.Unmarshal(data, &fx))
+	return fx
+}
+
+func mustB64Pub(t *testing.T, s string) ed25519.PublicKey {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(s)
+	require.NoError(t, err)
+	require.Len(t, raw, ed25519.PublicKeySize)
+	return ed25519.PublicKey(raw)
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/internal/identity/registry/distribution.go
+++ b/internal/identity/registry/distribution.go
@@ -41,6 +41,12 @@ const (
 	// ed25519.SignatureSize bytes (fail closed before the verify path ever sees a
 	// malformed signature).
 	ErrDistBadSigLen = "registry: distribution root_sig must be ed25519.SignatureSize bytes"
+	// ErrDistBadRootKeyEpoch is returned when root_key_epoch is negative (key
+	// epochs are non-negative; a negative value is structurally invalid).
+	ErrDistBadRootKeyEpoch = "registry: distribution root_key_epoch must be non-negative"
+	// ErrDistTrailingData is returned when bytes remain in the input after the
+	// envelope object (a trailing-data smuggling defense).
+	ErrDistTrailingData = "registry: distribution envelope has trailing data after the JSON object"
 )
 
 // MarshalDistribution serializes a SignedRegistry to the distribution-envelope
@@ -78,6 +84,10 @@ func ParseDistribution(data []byte) (SignedRegistry, error) {
 	if err := dec.Decode(&raw); err != nil {
 		return SignedRegistry{}, fmt.Errorf("%s: %w", ErrDistUnmarshal, err)
 	}
+	// Reject trailing data: bytes after the envelope object are a smuggling vector.
+	if dec.More() {
+		return SignedRegistry{}, fmt.Errorf("%s", ErrDistTrailingData)
+	}
 	// Reject any unknown field: a smuggled extra key must not be silently dropped.
 	for k := range raw {
 		if k != fieldDistRegistry && k != fieldDistRootSig && k != fieldDistRootKeyEpoch {
@@ -97,6 +107,9 @@ func ParseDistribution(data []byte) (SignedRegistry, error) {
 	if rkeRaw, ok := raw[fieldDistRootKeyEpoch]; ok {
 		if err := json.Unmarshal(rkeRaw, &rootKeyEpoch); err != nil {
 			return SignedRegistry{}, fmt.Errorf("%s: %s: %w", ErrDistUnmarshal, fieldDistRootKeyEpoch, err)
+		}
+		if rootKeyEpoch < 0 {
+			return SignedRegistry{}, fmt.Errorf("%s", ErrDistBadRootKeyEpoch)
 		}
 	}
 

--- a/internal/identity/registry/distribution.go
+++ b/internal/identity/registry/distribution.go
@@ -1,0 +1,138 @@
+package registry
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// Distribution-envelope field names and error strings (SSOT — referenced from
+// the (de)serialization path and asserted by tests, never inlined).
+const (
+	// fieldDistRegistry is the envelope field carrying base64-std of the
+	// JCS-canonical registry bytes — the EXACT bytes root_sig covers.
+	fieldDistRegistry = "registry"
+	// fieldDistRootSig is the envelope field carrying base64-std of the ed25519
+	// root signature over the registry bytes.
+	fieldDistRootSig = "root_sig"
+	// fieldDistRootKeyEpoch is the envelope field carrying which root key signed.
+	fieldDistRootKeyEpoch = "root_key_epoch"
+
+	// ErrDistMarshal wraps a distribution-envelope marshal failure.
+	ErrDistMarshal = "registry: marshal distribution envelope"
+	// ErrDistUnmarshal wraps a distribution-envelope unmarshal failure (bad JSON
+	// or an unknown field — strict, fail-closed decoding).
+	ErrDistUnmarshal = "registry: parse distribution envelope"
+	// ErrDistMissingRegistry is returned by ParseDistribution when the registry
+	// field is absent or empty.
+	ErrDistMissingRegistry = "registry: distribution envelope is missing the registry field"
+	// ErrDistMissingRootSig is returned by ParseDistribution when the root_sig
+	// field is absent or empty.
+	ErrDistMissingRootSig = "registry: distribution envelope is missing the root_sig field"
+	// ErrDistBadRegistryB64 is returned when the registry field is not valid
+	// base64-std.
+	ErrDistBadRegistryB64 = "registry: distribution registry field is not valid base64"
+	// ErrDistBadRootSigB64 is returned when the root_sig field is not valid
+	// base64-std.
+	ErrDistBadRootSigB64 = "registry: distribution root_sig field is not valid base64"
+	// ErrDistBadSigLen is returned when the decoded root_sig is not
+	// ed25519.SignatureSize bytes (fail closed before the verify path ever sees a
+	// malformed signature).
+	ErrDistBadSigLen = "registry: distribution root_sig must be ed25519.SignatureSize bytes"
+)
+
+// MarshalDistribution serializes a SignedRegistry to the distribution-envelope
+// JSON, keyed by the fieldDist* SSOT constants. The registry bytes are emitted
+// base64-std VERBATIM — they are the exact bytes root_sig covers and must not be
+// re-canonicalized or double-encoded.
+func MarshalDistribution(env SignedRegistry) ([]byte, error) {
+	out, err := json.Marshal(map[string]any{
+		fieldDistRegistry:     base64.StdEncoding.EncodeToString(env.Registry),
+		fieldDistRootSig:      base64.StdEncoding.EncodeToString(env.RootSig),
+		fieldDistRootKeyEpoch: env.RootKeyEpoch,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ErrDistMarshal, err)
+	}
+	return out, nil
+}
+
+// ParseDistribution deserializes a distribution-envelope JSON into a
+// SignedRegistry. It FAILS CLOSED on every malformed input — bad JSON, an
+// unknown field, a missing/empty required field, bad base64, or a wrong-length
+// signature — returning an error and a zero SignedRegistry (never a partial that
+// could be mistaken for valid). It never panics.
+//
+// ParseDistribution is ONLY (de)serialization + structural fail-closed parsing;
+// it does NOT verify the root signature, freshness, or anti-rollback. The
+// consumer flow is ParseDistribution -> VerifyAndLoad, which performs the full
+// slice-3 trust logic over the parsed bytes.
+func ParseDistribution(data []byte) (SignedRegistry, error) {
+	// Decode into a raw map so the strict unknown-field check and the
+	// presence/type checks are keyed by the fieldDist* SSOT constants (no struct
+	// tags to drift from the named constants).
+	var raw map[string]json.RawMessage
+	dec := json.NewDecoder(bytes.NewReader(data))
+	if err := dec.Decode(&raw); err != nil {
+		return SignedRegistry{}, fmt.Errorf("%s: %w", ErrDistUnmarshal, err)
+	}
+	// Reject any unknown field: a smuggled extra key must not be silently dropped.
+	for k := range raw {
+		if k != fieldDistRegistry && k != fieldDistRootSig && k != fieldDistRootKeyEpoch {
+			return SignedRegistry{}, fmt.Errorf("%s: unknown field %q", ErrDistUnmarshal, k)
+		}
+	}
+
+	regB64, err := decodeStringField(raw, fieldDistRegistry, ErrDistMissingRegistry)
+	if err != nil {
+		return SignedRegistry{}, err
+	}
+	sigB64, err := decodeStringField(raw, fieldDistRootSig, ErrDistMissingRootSig)
+	if err != nil {
+		return SignedRegistry{}, err
+	}
+	var rootKeyEpoch int
+	if rkeRaw, ok := raw[fieldDistRootKeyEpoch]; ok {
+		if err := json.Unmarshal(rkeRaw, &rootKeyEpoch); err != nil {
+			return SignedRegistry{}, fmt.Errorf("%s: %s: %w", ErrDistUnmarshal, fieldDistRootKeyEpoch, err)
+		}
+	}
+
+	regBytes, err := base64.StdEncoding.DecodeString(regB64)
+	if err != nil {
+		return SignedRegistry{}, fmt.Errorf("%s: %w", ErrDistBadRegistryB64, err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(sigB64)
+	if err != nil {
+		return SignedRegistry{}, fmt.Errorf("%s: %w", ErrDistBadRootSigB64, err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return SignedRegistry{}, fmt.Errorf("%s", ErrDistBadSigLen)
+	}
+
+	return SignedRegistry{
+		Registry:     regBytes,
+		RootSig:      sig,
+		RootKeyEpoch: rootKeyEpoch,
+	}, nil
+}
+
+// decodeStringField extracts a required, non-empty JSON string field from raw,
+// returning missingErr (fail closed) when the field is absent or empty and
+// ErrDistUnmarshal when it is present but not a JSON string.
+func decodeStringField(raw map[string]json.RawMessage, field, missingErr string) (string, error) {
+	rawVal, ok := raw[field]
+	if !ok {
+		return "", fmt.Errorf("%s", missingErr)
+	}
+	var s string
+	if err := json.Unmarshal(rawVal, &s); err != nil {
+		return "", fmt.Errorf("%s: %s: %w", ErrDistUnmarshal, field, err)
+	}
+	if s == "" {
+		return "", fmt.Errorf("%s", missingErr)
+	}
+	return s, nil
+}

--- a/internal/identity/registry/distribution_test.go
+++ b/internal/identity/registry/distribution_test.go
@@ -1,0 +1,256 @@
+package registry
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedEd25519 returns a deterministic ed25519 keypair from a one-byte seed
+// filler so test vectors are stable across runs.
+func fixedEd25519(t *testing.T, fill byte) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = fill
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	return priv.Public().(ed25519.PublicKey), priv
+}
+
+// TestMarshalDistribution_RoundTrips: a SignedRegistry marshals to the envelope
+// JSON and parses back byte-identically (registry bytes, root sig, epoch).
+func TestMarshalDistribution_RoundTrips(t *testing.T) {
+	rootPub, rootPriv := fixedEd25519(t, 0x11)
+	agentPub, _ := fixedEd25519(t, 0x22)
+	apk, err := NewPublicKey(agentPub)
+	require.NoError(t, err)
+
+	reg := Registry{
+		Epoch:      2,
+		ValidFrom:  1000,
+		ValidUntil: 9000,
+		Agents: []AgentBinding{{
+			Slug:                    "mira",
+			DisplayName:             "Mira ⭐",
+			PubKey:                  apk,
+			KeyEpoch:                1,
+			ValidFrom:               1000,
+			ValidUntil:              9000,
+			AuthorizedOriginDaemons: []string{"d1"},
+		}},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	require.NoError(t, err)
+	_ = rootPub
+
+	out, err := MarshalDistribution(env)
+	require.NoError(t, err)
+
+	got, err := ParseDistribution(out)
+	require.NoError(t, err)
+	assert.Equal(t, env.Registry, got.Registry, "registry bytes must round-trip")
+	assert.Equal(t, env.RootSig, got.RootSig, "root sig must round-trip")
+	assert.Equal(t, env.RootKeyEpoch, got.RootKeyEpoch, "root key epoch must round-trip")
+}
+
+// TestMarshalDistribution_NonZeroRootKeyEpoch round-trips a non-zero root key
+// epoch (root rotation), confirming the integer is encoded bare, not as a float.
+func TestMarshalDistribution_NonZeroRootKeyEpoch(t *testing.T) {
+	env := SignedRegistry{
+		Registry:     []byte(`{}`),
+		RootSig:      make([]byte, ed25519.SignatureSize),
+		RootKeyEpoch: 7,
+	}
+	out, err := MarshalDistribution(env)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"root_key_epoch":7`, "root_key_epoch must encode bare")
+	got, err := ParseDistribution(out)
+	require.NoError(t, err)
+	assert.Equal(t, 7, got.RootKeyEpoch)
+}
+
+// TestMarshalDistribution_FieldNamesAndBase64: the envelope uses the SSOT field
+// names and base64-std encodes the registry + sig.
+func TestMarshalDistribution_FieldNamesAndBase64(t *testing.T) {
+	_, rootPriv := fixedEd25519(t, 0x11)
+	reg := Registry{Epoch: 1, ValidFrom: 1, ValidUntil: 2}
+	env, err := SignRegistry(rootPriv, reg)
+	require.NoError(t, err)
+
+	out, err := MarshalDistribution(env)
+	require.NoError(t, err)
+
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(out, &m))
+	_, hasReg := m[fieldDistRegistry]
+	_, hasSig := m[fieldDistRootSig]
+	_, hasEpoch := m[fieldDistRootKeyEpoch]
+	assert.True(t, hasReg, "envelope must carry the registry field")
+	assert.True(t, hasSig, "envelope must carry the root_sig field")
+	assert.True(t, hasEpoch, "envelope must carry the root_key_epoch field")
+
+	var b64 string
+	require.NoError(t, json.Unmarshal(m[fieldDistRegistry], &b64))
+	decoded, err := base64.StdEncoding.DecodeString(b64)
+	require.NoError(t, err, "registry field must be base64-std")
+	assert.Equal(t, env.Registry, decoded, "registry field must decode to the exact signed bytes")
+}
+
+// TestParseDistribution_FailsClosed_BadJSON: non-JSON input is a fail-closed
+// error and a zero SignedRegistry.
+func TestParseDistribution_FailsClosed_BadJSON(t *testing.T) {
+	got, err := ParseDistribution([]byte("not json{"))
+	require.Error(t, err)
+	assert.Equal(t, SignedRegistry{}, got, "bad JSON must yield a zero SignedRegistry, never a partial")
+}
+
+// TestParseDistribution_FailsClosed_MissingFields: each missing required field
+// is a fail-closed error.
+func TestParseDistribution_FailsClosed_MissingFields(t *testing.T) {
+	goodReg := base64.StdEncoding.EncodeToString([]byte(`{"agents":[],"epoch":1,"valid_from":1,"valid_until":2}`))
+	goodSig := base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+
+	cases := map[string]string{
+		"missing registry":      `{"root_sig":"` + goodSig + `","root_key_epoch":0}`,
+		"missing root_sig":      `{"registry":"` + goodReg + `","root_key_epoch":0}`,
+		"empty registry string": `{"registry":"","root_sig":"` + goodSig + `","root_key_epoch":0}`,
+		"empty root_sig string": `{"registry":"` + goodReg + `","root_sig":"","root_key_epoch":0}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseDistribution([]byte(body))
+			require.Error(t, err, "missing/empty required field must fail closed")
+			assert.Equal(t, SignedRegistry{}, got)
+		})
+	}
+}
+
+// TestParseDistribution_FailsClosed_BadBase64: non-base64 registry/sig fields
+// fail closed.
+func TestParseDistribution_FailsClosed_BadBase64(t *testing.T) {
+	goodReg := base64.StdEncoding.EncodeToString([]byte(`{}`))
+	goodSig := base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+
+	cases := map[string]string{
+		"bad base64 registry": `{"registry":"!!!not base64!!!","root_sig":"` + goodSig + `","root_key_epoch":0}`,
+		"bad base64 root_sig": `{"registry":"` + goodReg + `","root_sig":"@@@","root_key_epoch":0}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseDistribution([]byte(body))
+			require.Error(t, err, "bad base64 must fail closed")
+			assert.Equal(t, SignedRegistry{}, got)
+		})
+	}
+}
+
+// TestParseDistribution_FailsClosed_WrongSigLen: a sig that is not
+// ed25519.SignatureSize bytes fails closed at parse (never reaching the verify
+// path with a malformed sig).
+func TestParseDistribution_FailsClosed_WrongSigLen(t *testing.T) {
+	goodReg := base64.StdEncoding.EncodeToString([]byte(`{}`))
+	shortSig := base64.StdEncoding.EncodeToString(make([]byte, 10))
+	body := `{"registry":"` + goodReg + `","root_sig":"` + shortSig + `","root_key_epoch":0}`
+	got, err := ParseDistribution([]byte(body))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, ErrDistBadSigLen)
+	assert.Equal(t, SignedRegistry{}, got)
+}
+
+// TestParseDistribution_FailsClosed_UnknownField: an extra/unknown field is a
+// fail-closed reject (strict decoding — no silent acceptance of smuggled keys).
+func TestParseDistribution_FailsClosed_UnknownField(t *testing.T) {
+	goodReg := base64.StdEncoding.EncodeToString([]byte(`{}`))
+	goodSig := base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	body := `{"registry":"` + goodReg + `","root_sig":"` + goodSig + `","root_key_epoch":0,"x":1}`
+	got, err := ParseDistribution([]byte(body))
+	require.Error(t, err, "unknown field must fail closed")
+	assert.Equal(t, SignedRegistry{}, got)
+}
+
+// TestParseDistribution_FailsClosed_WrongFieldType: a required field present
+// with the wrong JSON type (registry as a number, root_key_epoch as a string)
+// fails closed.
+func TestParseDistribution_FailsClosed_WrongFieldType(t *testing.T) {
+	goodReg := base64.StdEncoding.EncodeToString([]byte(`{}`))
+	goodSig := base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+
+	cases := map[string]string{
+		"registry not a string":     `{"registry":123,"root_sig":"` + goodSig + `","root_key_epoch":0}`,
+		"root_key_epoch not an int": `{"registry":"` + goodReg + `","root_sig":"` + goodSig + `","root_key_epoch":"x"}`,
+		"root_sig not a string":     `{"registry":"` + goodReg + `","root_sig":true,"root_key_epoch":0}`,
+		"top-level not an object":   `["registry"]`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseDistribution([]byte(body))
+			require.Error(t, err, "wrong field type must fail closed")
+			assert.Equal(t, SignedRegistry{}, got)
+		})
+	}
+}
+
+// TestParseDistribution_OmittedRootKeyEpoch_DefaultsZero: an envelope with the
+// required fields but no root_key_epoch parses with epoch defaulting to 0 (a
+// bare optional integer), since slice-3 only uses epoch 0 today.
+func TestParseDistribution_OmittedRootKeyEpoch_DefaultsZero(t *testing.T) {
+	goodReg := base64.StdEncoding.EncodeToString([]byte(`{}`))
+	goodSig := base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	body := `{"registry":"` + goodReg + `","root_sig":"` + goodSig + `"}`
+	got, err := ParseDistribution([]byte(body))
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.RootKeyEpoch)
+}
+
+// TestParseDistribution_ThenVerifyAndLoad: ParseDistribution feeds straight into
+// the slice-3 trust gate, which loads the valid envelope.
+func TestParseDistribution_ThenVerifyAndLoad(t *testing.T) {
+	rootPub, rootPriv := fixedEd25519(t, 0x11)
+	agentPub, _ := fixedEd25519(t, 0x22)
+	apk, err := NewPublicKey(agentPub)
+	require.NoError(t, err)
+
+	reg := Registry{
+		Epoch: 5, ValidFrom: 1000, ValidUntil: 100000,
+		Agents: []AgentBinding{{
+			Slug: "mira", DisplayName: "Mira", PubKey: apk, KeyEpoch: 1,
+			ValidFrom: 1000, ValidUntil: 100000, AuthorizedOriginDaemons: []string{"d1"},
+		}},
+	}
+	env, err := SignRegistry(rootPriv, reg)
+	require.NoError(t, err)
+
+	wire, err := MarshalDistribution(env)
+	require.NoError(t, err)
+	parsed, err := ParseDistribution(wire)
+	require.NoError(t, err)
+
+	loaded, newHighest, err := VerifyAndLoad(rootPub, parsed, 4, time.Unix(2000, 0), time.Hour*24*365)
+	require.NoError(t, err)
+	assert.Equal(t, 5, loaded.Epoch)
+	assert.Equal(t, 5, newHighest)
+}
+
+// TestParseDistribution_NotDoubleEncoded ensures MarshalDistribution does not
+// accidentally JSON-quote the canonical registry inside the base64 (the bytes
+// must be the EXACT root-signed bytes, not re-marshaled).
+func TestParseDistribution_NotDoubleEncoded(t *testing.T) {
+	_, rootPriv := fixedEd25519(t, 0x11)
+	reg := Registry{Epoch: 1, ValidFrom: 1, ValidUntil: 2}
+	env, err := SignRegistry(rootPriv, reg)
+	require.NoError(t, err)
+	out, err := MarshalDistribution(env)
+	require.NoError(t, err)
+	// The canonical registry begins with '{' — confirm the decoded payload is
+	// raw JCS, not a quoted string.
+	parsed, err := ParseDistribution(out)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(parsed.Registry), "{"), "decoded registry must be raw JCS JSON")
+}

--- a/internal/identity/registry/distribution_test.go
+++ b/internal/identity/registry/distribution_test.go
@@ -238,6 +238,40 @@ func TestParseDistribution_ThenVerifyAndLoad(t *testing.T) {
 	assert.Equal(t, 5, newHighest)
 }
 
+// TestParseDistribution_FailsClosed_NegativeRootKeyEpoch: a negative
+// root_key_epoch is structurally invalid and must be rejected fail-closed.
+func TestParseDistribution_FailsClosed_NegativeRootKeyEpoch(t *testing.T) {
+	goodReg := base64.StdEncoding.EncodeToString([]byte(`{}`))
+	goodSig := base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	body := `{"registry":"` + goodReg + `","root_sig":"` + goodSig + `","root_key_epoch":-1}`
+	got, err := ParseDistribution([]byte(body))
+	require.Error(t, err, "negative root_key_epoch must fail closed")
+	assert.ErrorContains(t, err, ErrDistBadRootKeyEpoch)
+	assert.Equal(t, SignedRegistry{}, got)
+}
+
+// TestParseDistribution_FailsClosed_TrailingData: bytes after the envelope
+// object must be rejected fail-closed (concatenated JSON objects and garbage
+// alike are structural smuggling vectors).
+func TestParseDistribution_FailsClosed_TrailingData(t *testing.T) {
+	goodReg := base64.StdEncoding.EncodeToString([]byte(`{}`))
+	goodSig := base64.StdEncoding.EncodeToString(make([]byte, ed25519.SignatureSize))
+	base := `{"registry":"` + goodReg + `","root_sig":"` + goodSig + `","root_key_epoch":0}`
+
+	cases := map[string]string{
+		"concatenated object":   base + `{"x":1}`,
+		"trailing garbage":      base + `<junk>`,
+		"trailing newline+junk": base + "\nextra",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseDistribution([]byte(body))
+			require.Error(t, err, "trailing data after envelope must fail closed")
+			assert.Equal(t, SignedRegistry{}, got)
+		})
+	}
+}
+
 // TestParseDistribution_NotDoubleEncoded ensures MarshalDistribution does not
 // accidentally JSON-quote the canonical registry inside the base64 (the bytes
 // must be the EXACT root-signed bytes, not re-marshaled).

--- a/internal/identity/registry/testdata/cross_language_vectors.json
+++ b/internal/identity/registry/testdata/cross_language_vectors.json
@@ -1,0 +1,146 @@
+{
+  "root_pubkey": "vHy8tWNjdfodgkNNRmck2SN39TuYBpXdSdJtDOEiBaU=",
+  "now": 2000000,
+  "max_staleness_secs": 86400,
+  "valid": {
+    "envelope": {
+      "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+      "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
+      "root_key_epoch": 0
+    },
+    "persisted_highest_epoch": 9,
+    "expect_slug": "mira",
+    "expect_key_epoch": 1,
+    "expect_pubkey": "VRVPQgZepaG+oFRjgmviaE65LfksEAAnqrquV8pVQgc=",
+    "message": {
+      "slug": "mira",
+      "key_epoch": 1,
+      "canonical_message_bytes": "eyJib2R5IjoiaGVsbG8iLCJmcm9tIjoibWlyYSJ9",
+      "signature": "K2ZbXlLsJJyybfKphh+/+DT37+6LqS2y8G1JNgkfob1miDzPGpCR/3nebiZtA8HgcfkxrFSwMqwjNcdvLfYrBg=="
+    }
+  },
+  "reject": [
+    {
+      "name": "small_order_root_pubkey",
+      "reason": "pinned root pubkey is small-order (universal-forgery vector)",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
+        "root_key_epoch": 0
+      },
+      "root_pubkey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    },
+    {
+      "name": "small_order_agent_pubkey",
+      "reason": "binding agent pubkey is small-order; load rejects the binding",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "A+qP/1UDlO8oOfscebaBcRJKf7vuII2si9GrBeV31Xg3st1bQjBkudVQUiOlBL0cKZWrFjE9FB7dCcXdOovXAg==",
+        "root_key_epoch": 0
+      }
+    },
+    {
+      "name": "future_valid_from_registry",
+      "reason": "registry valid_from is in the future (not yet fresh)",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjIxMDAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "fbIyMQ0oxB/uuB2q3tvJ+IRdHGqEUfanLtfcdNy3Kmj8Z0Pr8RDeKAEPo4g/bj2+pV9HeLoZVfFqOjUREEb2Dw==",
+        "root_key_epoch": 0
+      }
+    },
+    {
+      "name": "future_valid_from_binding",
+      "reason": "binding valid_from is in the future (resolve/verify must reject)",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoyMTAwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "BkOROB2xKQqZE91vle/mDHXHQeQQ9LfQ3ff0r6jnJ4Iv223qDYPCqDA+74Cyk+q8vlVpP8K61yv0RnihjKFaBA==",
+        "root_key_epoch": 0
+      },
+      "message": {
+        "slug": "mira",
+        "key_epoch": 1,
+        "canonical_message_bytes": "eyJib2R5IjoiaGVsbG8iLCJmcm9tIjoibWlyYSJ9",
+        "signature": "K2ZbXlLsJJyybfKphh+/+DT37+6LqS2y8G1JNgkfob1miDzPGpCR/3nebiZtA8HgcfkxrFSwMqwjNcdvLfYrBg=="
+      }
+    },
+    {
+      "name": "rollback_epoch_at_or_below_persisted",
+      "reason": "registry epoch \u003c= persisted highest seen (anti-rollback)",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
+        "root_key_epoch": 0
+      },
+      "persisted_highest_epoch": 10
+    },
+    {
+      "name": "stale_past_valid_until",
+      "reason": "now is past registry valid_until (fail closed)",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
+        "root_key_epoch": 0
+      },
+      "now": 3000001
+    },
+    {
+      "name": "stale_beyond_max_staleness",
+      "reason": "now - valid_from exceeds max_staleness_secs (fail closed)",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
+        "root_key_epoch": 0
+      },
+      "now": 2076401
+    },
+    {
+      "name": "revoked_binding",
+      "reason": "binding is revoked (resolve/verify must reject)",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9IiwicmV2b2tlZF9hdCI6MTk5MTAwMCwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "t0r+3vJYbVwRXpzmqJ9hlHgzlQUU/avA8iV/ukA1lm0dDaN01OS//C2TWgCx8fdbqrDPjYREKky0cjDYTnwKDQ==",
+        "root_key_epoch": 0
+      },
+      "message": {
+        "slug": "mira",
+        "key_epoch": 1,
+        "canonical_message_bytes": "eyJib2R5IjoiaGVsbG8iLCJmcm9tIjoibWlyYSJ9",
+        "signature": "K2ZbXlLsJJyybfKphh+/+DT37+6LqS2y8G1JNgkfob1miDzPGpCR/3nebiZtA8HgcfkxrFSwMqwjNcdvLfYrBg=="
+      }
+    },
+    {
+      "name": "tampered_registry_body",
+      "reason": "registry bytes mutated; root_sig no longer matches",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3O6QUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
+        "root_key_epoch": 0
+      }
+    },
+    {
+      "name": "non_canonical_s_message_sig",
+      "reason": "message signature has non-canonical S (S \u003e= L); verify_strict rejects",
+      "expect": "reject",
+      "envelope": {
+        "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
+        "root_key_epoch": 0
+      },
+      "message": {
+        "slug": "mira",
+        "key_epoch": 1,
+        "canonical_message_bytes": "eyJib2R5IjoiaGVsbG8iLCJmcm9tIjoibWlyYSJ9",
+        "signature": "K2ZbXlLsJJyybfKphh+/+DT37+6LqS2y8G1JNgkfob1TXDIsNfOjV1B7ZslL/Z/1cfkxrFSwMqwjNcdvLfYrFg=="
+      }
+    }
+  ]
+}

--- a/internal/identity/registry/testdata/cross_language_vectors.json
+++ b/internal/identity/registry/testdata/cross_language_vectors.json
@@ -5,8 +5,8 @@
   "valid": {
     "envelope": {
       "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-      "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
-      "root_key_epoch": 0
+      "root_key_epoch": 0,
+      "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ=="
     },
     "persisted_highest_epoch": 9,
     "expect_slug": "mira",
@@ -26,8 +26,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ=="
       },
       "root_pubkey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     },
@@ -37,8 +37,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "A+qP/1UDlO8oOfscebaBcRJKf7vuII2si9GrBeV31Xg3st1bQjBkudVQUiOlBL0cKZWrFjE9FB7dCcXdOovXAg==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "A+qP/1UDlO8oOfscebaBcRJKf7vuII2si9GrBeV31Xg3st1bQjBkudVQUiOlBL0cKZWrFjE9FB7dCcXdOovXAg=="
       }
     },
     {
@@ -47,8 +47,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjIxMDAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "fbIyMQ0oxB/uuB2q3tvJ+IRdHGqEUfanLtfcdNy3Kmj8Z0Pr8RDeKAEPo4g/bj2+pV9HeLoZVfFqOjUREEb2Dw==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "fbIyMQ0oxB/uuB2q3tvJ+IRdHGqEUfanLtfcdNy3Kmj8Z0Pr8RDeKAEPo4g/bj2+pV9HeLoZVfFqOjUREEb2Dw=="
       }
     },
     {
@@ -57,8 +57,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoyMTAwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "BkOROB2xKQqZE91vle/mDHXHQeQQ9LfQ3ff0r6jnJ4Iv223qDYPCqDA+74Cyk+q8vlVpP8K61yv0RnihjKFaBA==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "BkOROB2xKQqZE91vle/mDHXHQeQQ9LfQ3ff0r6jnJ4Iv223qDYPCqDA+74Cyk+q8vlVpP8K61yv0RnihjKFaBA=="
       },
       "message": {
         "slug": "mira",
@@ -73,8 +73,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ=="
       },
       "persisted_highest_epoch": 10
     },
@@ -84,8 +84,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ=="
       },
       "now": 3000001
     },
@@ -95,8 +95,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ=="
       },
       "now": 2076401
     },
@@ -106,8 +106,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9IiwicmV2b2tlZF9hdCI6MTk5MTAwMCwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "t0r+3vJYbVwRXpzmqJ9hlHgzlQUU/avA8iV/ukA1lm0dDaN01OS//C2TWgCx8fdbqrDPjYREKky0cjDYTnwKDQ==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "t0r+3vJYbVwRXpzmqJ9hlHgzlQUU/avA8iV/ukA1lm0dDaN01OS//C2TWgCx8fdbqrDPjYREKky0cjDYTnwKDQ=="
       },
       "message": {
         "slug": "mira",
@@ -122,8 +122,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3O6QUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ=="
       }
     },
     {
@@ -132,8 +132,8 @@
       "expect": "reject",
       "envelope": {
         "registry": "eyJhZ2VudHMiOlt7ImF1dGhvcml6ZWRfb3JpZ2luX2RhZW1vbnMiOlsiZGFlbW9uLTEiXSwiZGlzcGxheV9uYW1lIjoiTWlyYSDirZAiLCJrZXlfZXBvY2giOjEsInB1YmtleSI6IlZSVlBRZ1plcGFHK29GUmpnbXZpYUU2NUxma3NFQUFucXJxdVY4cFZRZ2M9Iiwic2x1ZyI6Im1pcmEiLCJ2YWxpZF9mcm9tIjoxOTkwMDAwLCJ2YWxpZF91bnRpbCI6MzAwMDAwMH1dLCJlcG9jaCI6MTAsInZhbGlkX2Zyb20iOjE5OTAwMDAsInZhbGlkX3VudGlsIjozMDAwMDAwfQ==",
-        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ==",
-        "root_key_epoch": 0
+        "root_key_epoch": 0,
+        "root_sig": "7mp/FjRH2QivUFgEFrJQx0PylKRhXBIkC4vawJq97Z/5C4BIpgvPM+WJJm9c9wAC9zdnAd0JpvPwC8EKj1QaAQ=="
       },
       "message": {
         "slug": "mira",


### PR DESCRIPTION
## Contract B — slice 4 (vaultmind half): `--registry` distribution envelope + cross-language fixture

The vaultmind half of the integration. Builds on slice 3's registry; produces what workhorse's Rust verifier binds to.

### What's in it (`internal/identity/registry/`)
- **`distribution.go`** — `MarshalDistribution`/`ParseDistribution` for the `--registry` envelope JSON `{registry: base64(JCS-canonical registry bytes — the exact bytes root_sig covers), root_sig: base64, root_key_epoch}`. `ParseDistribution` **fails closed** on every malformed input (bad JSON, missing/empty/wrong-type fields, bad base64, wrong-length sig, **negative root_key_epoch**, **trailing data**) — error + zero value, never a partial, never panic. Trust logic stays in slice-3 `VerifyAndLoad`.
- **`testdata/cross_language_vectors.json`** — the deterministic cross-language acceptance fixture: `root_pubkey`/`now`/`max_staleness_secs`, one `valid` envelope (loads → resolves the `mira` binding → a message `VerifyMessage` accepts) + **10 reject cases** (small-order root/agent pubkey, non-canonical S, future-`valid_from` registry+binding, rollback, stale past `valid_until`/`max_staleness`, revoked binding, tampered body). The Go side proves the valid case and every reject case before Rust consumes it; a CI guard (`TestCrossLanguageFixture_MatchesGenerator`) keeps the committed file lockstep with its generator.
- **`README.md`** — the envelope SPEC: JSON shape, JCS canonical registry/binding form, the verify order (root_sig over the received bytes FIRST, then parse; anti-rollback; freshness incl. reject-future-`valid_from`; revocation), base64-std. This is what workhorse binds to.

### Reviewed
silent-failure-hunter + code-reviewer; both findings applied (fixture reproducibility + CI guard; the two fail-closed parse hardenings; dead param). `task check` green; patch coverage 97.2%.

### The gate: workhorse's Rust verifier runs Go-signs / Rust-`verify_strict`'s over this fixture; default-deny flips on only when the valid case + all negatives pass.
