### PR TITLE
feat(identity): keyless 'identity sign-registry' CLI (Contract-B)

### DIFF
--- a/.ckeletin/pkg/config/keys_generated.go
+++ b/.ckeletin/pkg/config/keys_generated.go
@@ -136,6 +136,8 @@ const (
 	KeyAppIdentitysignenvelopeFile         = "app.identitysignenvelope.file"          // Read envelope JSON from this file instead of stdin
 	KeyAppIdentitysignenvelopeSignerSocket = "app.identitysignenvelope.signer_socket" // Signer socket path (default: XDG state dir)
 	KeyAppIdentitysignenvelopeFromPubkey   = "app.identitysignenvelope.from_pubkey"   // Signer public key (base64) stamped as the from_pubkey hint; not signed
+	KeyAppIdentitysignregistryFile         = "app.identitysignregistry.file"          // Read registry JSON from this file instead of stdin
+	KeyAppIdentitysignregistrySignerSocket = "app.identitysignregistry.signer_socket" // Signer socket path (default: XDG state dir)
 	KeyAppIndexVault                       = "app.index.vault"                        // Path to the vault root directory
 	KeyAppIndexJson                        = "app.index.json"                         // Output in JSON format
 	KeyAppIndexFull                        = "app.index.full"                         // Force full rebuild instead of incremental index

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -72,6 +72,7 @@ rules:
         - cmd/dataview_lint.go  # Reads vault .md files via paths from vault scanner (user-provided vault path)
         - cmd/identity_sign.go  # Reads the Contract-B entry from the operator-provided --file path (same trust tier as cmd/apply.go)
         - cmd/identity_sign_envelope.go  # Reads the chat-message envelope from the operator-provided --file path (same trust tier as cmd/identity_sign.go)
+        - cmd/identity_sign_registry.go  # Reads the unsigned trust-root registry from the operator-provided --file path (same trust tier as cmd/identity_sign_envelope.go)
         - internal/identity/signer/signer.go  # Reads the operator-configured sealed signer key file (0600, path from signer Config, not runtime user input)
         - internal/mutation/lint.go  # Reads/writes vault .md files via WalkDir (user-provided vault path, paths from filesystem walk)
         - internal/baseline/fixture.go  # Reads project-internal baseline fixture + snapshot paths from test callers (filepath.Clean applied, not user input at runtime)

--- a/cmd/identity_sign_registry.go
+++ b/cmd/identity_sign_registry.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/identity/signer"
+	"github.com/peiman/vaultmind/internal/identitycli"
+	"github.com/spf13/cobra"
+)
+
+var identitySignRegistryCmd = MustNewCommand(commands.IdentitySignRegistryMetadata, runIdentitySignRegistry)
+
+func init() {
+	identityCmd.AddCommand(identitySignRegistryCmd)
+	setupCommandConfig(identitySignRegistryCmd)
+}
+
+func runIdentitySignRegistry(cmd *cobra.Command, _ []string) error {
+	sockPath := getConfigValueWithFlags[string](cmd, "signer-socket", config.KeyAppIdentitysignregistrySignerSocket)
+	if sockPath == "" {
+		p, err := defaultSignerSocketPath()
+		if err != nil {
+			return fmt.Errorf("resolving signer socket path: %w", err)
+		}
+		sockPath = p
+	}
+	registryJSON, err := readRegistryJSON(cmd)
+	if err != nil {
+		return err
+	}
+	client := &signer.Client{SocketPath: sockPath}
+	return identitycli.SignRegistry(cmd.OutOrStdout(), client, registryJSON)
+}
+
+// readRegistryJSON reads the registry from --file when set, else from stdin.
+func readRegistryJSON(cmd *cobra.Command) ([]byte, error) {
+	filePath := getConfigValueWithFlags[string](cmd, "file", config.KeyAppIdentitysignregistryFile)
+	if filePath != "" {
+		b, err := os.ReadFile(filePath) //nolint:gosec // operator-provided registry path
+		if err != nil {
+			return nil, fmt.Errorf("reading registry file: %w", err)
+		}
+		return b, nil
+	}
+	b, err := io.ReadAll(cmd.InOrStdin())
+	if err != nil {
+		return nil, fmt.Errorf("reading registry from stdin: %w", err)
+	}
+	return b, nil
+}

--- a/cmd/identity_test.go
+++ b/cmd/identity_test.go
@@ -260,6 +260,96 @@ func TestIdentitySignEnvelopeCommandFileNotFound(t *testing.T) {
 	}
 }
 
+// signRegistryCmdInput builds a valid unsigned-registry JSON for the cmd tests,
+// with the given agent pubkey (base64-std) bound under slug "mira".
+func signRegistryCmdInput(pubB64 string) string {
+	return `{"agents":[{"authorized_origin_daemons":["daemon-eu-1"],"display_name":"Mira",` +
+		`"key_epoch":1,"pubkey":"` + pubB64 + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":5,"valid_from":1770000000,"valid_until":1780000000}`
+}
+
+// TestIdentitySignRegistryCommandViaStdin drives `identity sign-registry` reading
+// the registry from STDIN against a live signer, then proves the emitted
+// distribution envelope verifies under the root key via ParseDistribution +
+// VerifyAndLoad (the consumer's trust gate).
+func TestIdentitySignRegistryCommandViaStdin(t *testing.T) {
+	sockPath, rootPub := startCmdSigner(t)
+	agentPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey agent: %v", err)
+	}
+	in := signRegistryCmdInput(base64.StdEncoding.EncodeToString(agentPub))
+
+	RootCmd.SetIn(strings.NewReader(in))
+	defer RootCmd.SetIn(os.Stdin)
+
+	out, _, err := runRootCmd(t, "identity", "sign-registry", "--signer-socket", sockPath)
+	if err != nil {
+		t.Fatalf("identity sign-registry via stdin: %v", err)
+	}
+
+	env, err := registry.ParseDistribution(out.Bytes())
+	if err != nil {
+		t.Fatalf("ParseDistribution(output): %v\noutput=%q", err, out.String())
+	}
+	loaded, _, err := registry.VerifyAndLoad(
+		rootPub, env, 4, time.Unix(1_770_000_500, 0), time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad: %v", err)
+	}
+	if len(loaded.Agents) != 1 || loaded.Agents[0].Slug != "mira" {
+		t.Fatalf("loaded registry mismatch: %+v", loaded.Agents)
+	}
+}
+
+// TestIdentitySignRegistryCommandFailsClosedWhenSignerUnreachable drives the
+// command at a non-existent socket and asserts it fails closed (no output).
+func TestIdentitySignRegistryCommandFailsClosedWhenSignerUnreachable(t *testing.T) {
+	dir, err := os.MkdirTemp("", "vmcmdsignreg")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	agentPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey agent: %v", err)
+	}
+	regPath := filepath.Join(dir, "reg.json")
+	if err := os.WriteFile(regPath, []byte(signRegistryCmdInput(base64.StdEncoding.EncodeToString(agentPub))), 0o600); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	sockPath := filepath.Join(dir, "nope.sock")
+
+	out, _, err := runRootCmd(t, "identity", "sign-registry", "--file", regPath, "--signer-socket", sockPath)
+	if err == nil {
+		t.Fatal("expected fail-closed error when signer unreachable, got nil")
+	}
+	if strings.Contains(out.String(), "root_sig") {
+		t.Fatalf("fail-closed path must not print a result, got %q", out.String())
+	}
+}
+
+// TestIdentitySignRegistryCommandFileNotFound asserts the --file branch fails
+// closed (and exercises runIdentitySignRegistry's default-socket resolution,
+// since no --signer-socket is passed) when the registry file is missing.
+func TestIdentitySignRegistryCommandFileNotFound(t *testing.T) {
+	dir, err := os.MkdirTemp("", "vmcmdsignregnf")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	missing := filepath.Join(dir, "does-not-exist.json")
+
+	out, _, err := runRootCmd(t, "identity", "sign-registry", "--file", missing)
+	if err == nil {
+		t.Fatal("expected error for nonexistent --file, got nil")
+	}
+	if strings.Contains(out.String(), "root_sig") {
+		t.Fatalf("file-not-found path must not print a result, got %q", out.String())
+	}
+}
+
 // TestDefaultSignerPathsResolveUnderXDG asserts the XDG path helpers return
 // non-empty, distinct paths ending in the SSOT filenames. This covers the
 // happy path of defaultSignerKeyPath / defaultSignerSocketPath.

--- a/cmd/zz_catalog.go
+++ b/cmd/zz_catalog.go
@@ -269,6 +269,11 @@ var commandCatalog = map[string]catalogEntry{
 		when:  "you have a chat MESSAGE envelope to sign so a receiving daemon can verify the signature and the signer's registry binding.",
 		short: "Sign a chat message envelope via the keyless signer (Contract-B slice 5)",
 	},
+	"vaultmind identity sign-registry": {
+		group: groupLifecycle,
+		when:  "you have a trust-root registry to sign so consumers can verify the root signature, anti-rollback epoch, and freshness at load.",
+		short: "Sign a trust-root registry via the keyless signer (Contract-B)",
+	},
 	"vaultmind hooks": {
 		group: groupLifecycle,
 		when:  "you need to install, remove, or check VaultMind's Claude Code hook scripts.",

--- a/internal/config/commands/identity_sign_registry_config.go
+++ b/internal/config/commands/identity_sign_registry_config.go
@@ -1,0 +1,42 @@
+package commands
+
+import "github.com/peiman/vaultmind/.ckeletin/pkg/config"
+
+// IdentitySignRegistryMetadata defines metadata for the
+// `identity sign-registry` command.
+var IdentitySignRegistryMetadata = config.CommandMetadata{
+	Use:   "sign-registry",
+	Short: "Sign a trust-root REGISTRY via the keyless signer (Contract-B)",
+	Long: `Read an UNSIGNED registry (stdin or --file), enforce the Contract-B epoch
+gate, CANONICALIZE it (RFC 8785 JCS), then sign the canonical bytes via the
+signer over its 0600 socket and print the distribution envelope
+{registry, root_sig, root_key_epoch} as JSON.
+
+The input is a registry.Registry: { agents[], epoch, valid_from, valid_until },
+where each binding is { authorized_origin_daemons[], display_name, key_epoch,
+pubkey (base64-std), revoked_at? (absent == live), slug, valid_from,
+valid_until }. Every pubkey is re-validated (wrong-length / small-order keys are
+rejected) so a hostile key cannot enter a binding.
+
+This CLI is KEYLESS: it NEVER opens the root private-key file. If the signer is
+unreachable it FAILS CLOSED with an error (never a silent unsigned result). The
+consumer trust gate (root-sig verify, anti-rollback, freshness) runs at load via
+VerifyAndLoad, not here.`,
+	ConfigPrefix: "app.identitysignregistry",
+	FlagOverrides: map[string]string{
+		"app.identitysignregistry.file":          "file",
+		"app.identitysignregistry.signer_socket": "signer-socket",
+	},
+}
+
+// IdentitySignRegistryOptions returns config options for `identity sign-registry`.
+func IdentitySignRegistryOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.identitysignregistry.file", DefaultValue: "", Description: "Read registry JSON from this file instead of stdin", Type: "string"},
+		{Key: "app.identitysignregistry.signer_socket", DefaultValue: "", Description: "Signer socket path (default: XDG state dir)", Type: "string"},
+	}
+}
+
+func init() {
+	config.RegisterOptionsProvider(IdentitySignRegistryOptions)
+}

--- a/internal/identity/registry/registry.go
+++ b/internal/identity/registry/registry.go
@@ -236,6 +236,32 @@ func canonicalBytes(reg Registry) (identity.CanonicalBytes, error) {
 	return identity.Canonicalize(raw)
 }
 
+// RegistrySigner signs JCS-canonical registry bytes via the keyless custody
+// signer. The root private key stays in the signer process; the caller (the
+// CLI) never loads it. The real implementation is *signer.Client; tests inject a
+// fake to prove the sign path never opens the key file.
+type RegistrySigner interface {
+	Sign(canonicalBytes []byte) ([]byte, error)
+}
+
+// canonicalizeForSign runs the shared pre-sign gate for BOTH SignRegistry and
+// SignRegistryWithSigner: it refuses an out-of-range epoch (registry or any
+// binding key_epoch) — JCS-unsafe / anti-rollback-floor violations that must
+// never be minted — then JCS-canonicalizes reg to the EXACT bytes the root
+// signs. The signing seam (raw key vs custody signer) is the ONLY thing that
+// differs between the two callers, so the canonical bytes are byte-identical.
+func canonicalizeForSign(reg Registry) (identity.CanonicalBytes, error) {
+	if !epochInRange(reg.Epoch) {
+		return identity.CanonicalBytes{}, fmt.Errorf("%s", ErrEpochRange)
+	}
+	for _, a := range reg.Agents {
+		if !epochInRange(a.KeyEpoch) {
+			return identity.CanonicalBytes{}, fmt.Errorf("%s", ErrEpochRange)
+		}
+	}
+	return canonicalBytes(reg)
+}
+
 // SignRegistry is the OFFLINE-ROOT operation: it JCS-canonicalizes reg and
 // ed25519-signs the canonical bytes with the root private key, returning the
 // distribution envelope. It reuses the slice-1 SignCanonical primitive and
@@ -244,24 +270,35 @@ func SignRegistry(rootPriv ed25519.PrivateKey, reg Registry) (SignedRegistry, er
 	if len(rootPriv) != ed25519.PrivateKeySize {
 		return SignedRegistry{}, fmt.Errorf("%s", ErrBadRootKey)
 	}
-	// Refuse to sign an out-of-range epoch (registry or any binding key_epoch):
-	// these are JCS-unsafe / break the anti-rollback floor, so they must never be
-	// minted in the first place.
-	if !epochInRange(reg.Epoch) {
-		return SignedRegistry{}, fmt.Errorf("%s", ErrEpochRange)
-	}
-	for _, a := range reg.Agents {
-		if !epochInRange(a.KeyEpoch) {
-			return SignedRegistry{}, fmt.Errorf("%s", ErrEpochRange)
-		}
-	}
-	canonical, err := canonicalBytes(reg)
+	canonical, err := canonicalizeForSign(reg)
 	if err != nil {
 		return SignedRegistry{}, err
 	}
 	sig, err := identity.SignCanonical(rootPriv, canonical)
 	if err != nil {
 		return SignedRegistry{}, err
+	}
+	return SignedRegistry{
+		Registry:     canonical.Bytes(),
+		RootSig:      sig,
+		RootKeyEpoch: 0,
+	}, nil
+}
+
+// SignRegistryWithSigner is the KEYLESS parallel of SignRegistry: it runs the
+// SAME epoch gate + JCS-canonicalization, then signs the canonical bytes via the
+// custody signer (the root private key never enters this process) instead of a
+// raw key. The result is byte-identical to SignRegistry over the same registry —
+// only the signing seam differs. It FAILS CLOSED: any gate, canonicalize, or
+// signer error returns a non-nil error and a zero SignedRegistry.
+func SignRegistryWithSigner(client RegistrySigner, reg Registry) (SignedRegistry, error) {
+	canonical, err := canonicalizeForSign(reg)
+	if err != nil {
+		return SignedRegistry{}, err
+	}
+	sig, err := client.Sign(canonical.Bytes())
+	if err != nil {
+		return SignedRegistry{}, fmt.Errorf("registry: sign via signer: %w", err)
 	}
 	return SignedRegistry{
 		Registry:     canonical.Bytes(),

--- a/internal/identity/registry/sign_with_signer_test.go
+++ b/internal/identity/registry/sign_with_signer_test.go
@@ -1,0 +1,118 @@
+package registry
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"testing"
+)
+
+// keyBackedSigner is a RegistrySigner that signs with a held ed25519 key. It
+// exists ONLY to drive SignRegistryWithSigner through the keyless seam in a test
+// and prove byte-identity with the raw-key SignRegistry over the same registry.
+type keyBackedSigner struct {
+	priv         ed25519.PrivateKey
+	gotCanonical []byte
+}
+
+func (k *keyBackedSigner) Sign(canonicalBytes []byte) ([]byte, error) {
+	k.gotCanonical = append([]byte(nil), canonicalBytes...)
+	return ed25519.Sign(k.priv, canonicalBytes), nil
+}
+
+// failingSigner is a RegistrySigner that always errors, to prove
+// SignRegistryWithSigner FAILS CLOSED.
+type failingSigner struct{ err error }
+
+func (f *failingSigner) Sign([]byte) ([]byte, error) { return nil, f.err }
+
+type sentinel string
+
+func (s sentinel) Error() string { return string(s) }
+
+// TestSignRegistryWithSignerMatchesSignRegistry proves the keyless variant is
+// byte-identical to the raw-key SignRegistry for the same registry: same
+// canonical bytes AND same signature (the signer wraps the same root key), only
+// the signing seam differs.
+func TestSignRegistryWithSignerMatchesSignRegistry(t *testing.T) {
+	rootPub, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+
+	want, err := SignRegistry(rootPriv, reg)
+	if err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	signer := &keyBackedSigner{priv: rootPriv}
+	got, err := SignRegistryWithSigner(signer, reg)
+	if err != nil {
+		t.Fatalf("SignRegistryWithSigner: %v", err)
+	}
+
+	if !bytes.Equal(got.Registry, want.Registry) {
+		t.Fatalf("canonical registry bytes differ:\n got=%q\nwant=%q", got.Registry, want.Registry)
+	}
+	if !bytes.Equal(got.RootSig, want.RootSig) {
+		t.Fatalf("root signatures differ (signer-side mismatch)")
+	}
+	if got.RootKeyEpoch != want.RootKeyEpoch {
+		t.Fatalf("root key epoch = %d, want %d", got.RootKeyEpoch, want.RootKeyEpoch)
+	}
+	// The signer must have received exactly the canonical registry bytes.
+	if !bytes.Equal(signer.gotCanonical, want.Registry) {
+		t.Fatalf("signer got %q, want canonical %q", signer.gotCanonical, want.Registry)
+	}
+	// The signature must verify under the root pubkey (end-to-end sanity).
+	if !ed25519.Verify(rootPub, got.Registry, got.RootSig) {
+		t.Fatal("SignRegistryWithSigner signature did not verify under the root key")
+	}
+}
+
+// TestSignRegistryWithSignerRejectsOutOfRangeEpoch proves the SAME epoch gate as
+// SignRegistry runs before the signer is ever called (fail closed, never sign an
+// out-of-range epoch).
+func TestSignRegistryWithSignerRejectsOutOfRangeEpoch(t *testing.T) {
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(0, liveBinding(t, "mira", agentPub, 1)) // epoch 0 < 1
+
+	signer := &keyBackedSigner{priv: rootPriv}
+	if _, err := SignRegistryWithSigner(signer, reg); err == nil {
+		t.Fatal("expected out-of-range epoch rejection, got nil")
+	}
+	if signer.gotCanonical != nil {
+		t.Fatal("signer was called for an out-of-range epoch")
+	}
+}
+
+// TestSignRegistryWithSignerRejectsOutOfRangeKeyEpoch covers a binding key_epoch
+// out of range (the second arm of the shared gate).
+func TestSignRegistryWithSignerRejectsOutOfRangeKeyEpoch(t *testing.T) {
+	_, rootPriv := genKey(t)
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 0)) // key_epoch 0 < 1
+
+	signer := &keyBackedSigner{priv: rootPriv}
+	if _, err := SignRegistryWithSigner(signer, reg); err == nil {
+		t.Fatal("expected out-of-range key_epoch rejection, got nil")
+	}
+	if signer.gotCanonical != nil {
+		t.Fatal("signer was called for an out-of-range key_epoch")
+	}
+}
+
+// TestSignRegistryWithSignerFailsClosedOnSignerError proves a signer error
+// surfaces and no SignedRegistry is produced.
+func TestSignRegistryWithSignerFailsClosedOnSignerError(t *testing.T) {
+	agentPub, _ := genKey(t)
+	reg := freshRegistry(5, liveBinding(t, "mira", agentPub, 1))
+
+	signer := &failingSigner{err: sentinel("signer unreachable")}
+	got, err := SignRegistryWithSigner(signer, reg)
+	if err == nil {
+		t.Fatal("expected fail-closed signer error, got nil")
+	}
+	if len(got.Registry) != 0 || len(got.RootSig) != 0 {
+		t.Fatal("fail-closed must return a zero SignedRegistry")
+	}
+}

--- a/internal/identitycli/sign_registry.go
+++ b/internal/identitycli/sign_registry.go
@@ -1,0 +1,180 @@
+package identitycli
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/peiman/vaultmind/internal/identity/registry"
+)
+
+// Registry-signing error strings (SSOT).
+const (
+	// ErrRegistryParse is returned by SignRegistry when the registry JSON cannot
+	// be decoded (bad JSON, unknown field, or trailing data — strict, fail closed).
+	ErrRegistryParse = "identitycli: parse registry JSON"
+	// ErrRegistryBadPubKey is returned when a binding's pubkey is not valid
+	// base64-std of a validatable ed25519 public key.
+	ErrRegistryBadPubKey = "identitycli: binding pubkey must be base64-std of an ed25519 public key"
+	// ErrRegistryMarshalDist wraps a distribution-envelope marshal failure.
+	ErrRegistryMarshalDist = "identitycli: marshal distribution envelope"
+	// ErrRegistryRevokedAtNegative is returned when a binding's revoked_at is
+	// negative (a pre-epoch revocation timestamp is nonsensical — fail closed).
+	ErrRegistryRevokedAtNegative = "identitycli: binding revoked_at must not be negative"
+)
+
+// wireBinding is the JSON shape SignRegistry reads for one agent binding. Field
+// names match the registry package's canonical/distribution names (snake_case,
+// pubkey base64-std). revoked_at is a pointer so absent == live. The signed
+// integers (key_epoch, timestamps) decode as int64 and the epoch range gate runs
+// on the int64 value BEFORE any int64->int narrowing (see epochInRangeI64), so
+// the wire boundary is the single authority and a >2^31 value cannot truncate
+// past the gate on a 32-bit build. key_epoch narrows to int; the validity
+// timestamps stay int64; revoked_at maps to *int (64-bit-target-safe; widening
+// tracked as hardening).
+type wireBinding struct {
+	AuthorizedOriginDaemons []string `json:"authorized_origin_daemons"`
+	DisplayName             string   `json:"display_name"`
+	KeyEpoch                int64    `json:"key_epoch"`
+	PubKey                  string   `json:"pubkey"`
+	RevokedAt               *int64   `json:"revoked_at,omitempty"`
+	Slug                    string   `json:"slug"`
+	ValidFrom               int64    `json:"valid_from"`
+	ValidUntil              int64    `json:"valid_until"`
+}
+
+// wireRegistry is the JSON shape SignRegistry reads from stdin/--file: the
+// UNSIGNED registry (NOT a SignedRegistry). epoch decodes as int64 for the same
+// platform-parity reason as the binding integers.
+type wireRegistry struct {
+	Agents     []wireBinding `json:"agents"`
+	Epoch      int64         `json:"epoch"`
+	ValidFrom  int64         `json:"valid_from"`
+	ValidUntil int64         `json:"valid_until"`
+}
+
+// SignRegistry reads an UNSIGNED registry (the registry.Registry shape), signs
+// its JCS-canonical bytes through the KEYLESS SignerClient (the root key stays in
+// the signer), assembles the distribution envelope via the registry package, and
+// writes the envelope JSON to out. It is KEYLESS and FAILS CLOSED: any parse, bad
+// pubkey, epoch-gate, signer, or marshal error returns non-nil and prints
+// nothing (never a partial/unsigned result).
+func SignRegistry(out io.Writer, client registry.RegistrySigner, registryJSON []byte) error {
+	w, err := decodeWireRegistry(registryJSON)
+	if err != nil {
+		return err
+	}
+	reg, err := buildRegistry(w)
+	if err != nil {
+		return err
+	}
+	env, err := registry.SignRegistryWithSigner(client, reg)
+	if err != nil {
+		return fmt.Errorf("signing registry via signer: %w", err)
+	}
+	outJSON, err := registry.MarshalDistribution(env)
+	if err != nil {
+		return fmt.Errorf("%s: %w", ErrRegistryMarshalDist, err)
+	}
+	_, werr := fmt.Fprintf(out, "%s\n", outJSON)
+	return werr
+}
+
+// decodeWireRegistry strictly decodes the unsigned-registry JSON: unknown fields
+// and trailing data are rejected (fail closed).
+func decodeWireRegistry(registryJSON []byte) (wireRegistry, error) {
+	dec := json.NewDecoder(bytes.NewReader(registryJSON))
+	dec.DisallowUnknownFields()
+	var w wireRegistry
+	if err := dec.Decode(&w); err != nil {
+		return wireRegistry{}, fmt.Errorf("%s: %w", ErrRegistryParse, err)
+	}
+	if dec.More() {
+		return wireRegistry{}, fmt.Errorf("%s: trailing data after JSON object", ErrRegistryParse)
+	}
+	return w, nil
+}
+
+// buildRegistry converts the decoded wire registry into a registry.Registry. It
+// gates the registry epoch on the int64 wire value BEFORE narrowing (the wire
+// boundary is the range authority), then builds each binding. Fails closed.
+func buildRegistry(w wireRegistry) (registry.Registry, error) {
+	if !epochInRangeI64(w.Epoch) {
+		return registry.Registry{}, fmt.Errorf("%s", registry.ErrEpochRange)
+	}
+	agents := make([]registry.AgentBinding, len(w.Agents))
+	for i, b := range w.Agents {
+		ab, err := buildBinding(b)
+		if err != nil {
+			return registry.Registry{}, err
+		}
+		agents[i] = ab
+	}
+	return registry.Registry{
+		Epoch:      int(w.Epoch),
+		ValidFrom:  w.ValidFrom,
+		ValidUntil: w.ValidUntil,
+		Agents:     agents,
+	}, nil
+}
+
+// buildBinding validates + converts one wire binding. The key_epoch range gate
+// runs on the int64 value BEFORE narrowing; the pubkey is base64-std-decoded +
+// validated; revoked_at is range-checked. Any failure fails closed.
+func buildBinding(b wireBinding) (registry.AgentBinding, error) {
+	if !epochInRangeI64(b.KeyEpoch) {
+		return registry.AgentBinding{}, fmt.Errorf("%s", registry.ErrEpochRange)
+	}
+	if b.RevokedAt != nil && *b.RevokedAt < 0 {
+		return registry.AgentBinding{}, fmt.Errorf("%s", ErrRegistryRevokedAtNegative)
+	}
+	pk, err := decodeBindingPubKey(b.PubKey)
+	if err != nil {
+		return registry.AgentBinding{}, err
+	}
+	return registry.AgentBinding{
+		Slug:                    b.Slug,
+		DisplayName:             b.DisplayName,
+		PubKey:                  pk,
+		KeyEpoch:                int(b.KeyEpoch),
+		ValidFrom:               b.ValidFrom,
+		ValidUntil:              b.ValidUntil,
+		AuthorizedOriginDaemons: b.AuthorizedOriginDaemons,
+		RevokedAt:               revokedAtPtr(b.RevokedAt),
+	}, nil
+}
+
+// epochInRangeI64 mirrors registry's epoch gate on the int64 wire value, so the
+// range [1, MaxSafeEpoch] is enforced BEFORE any int64->int narrowing — a value
+// above 2^31 cannot truncate past the gate on a 32-bit build.
+func epochInRangeI64(e int64) bool { return e >= 1 && e <= registry.MaxSafeEpoch }
+
+// decodeBindingPubKey base64-std-decodes a binding pubkey and routes it through
+// registry.NewPublicKey, so a wrong-length or small-order key cannot enter a
+// binding. Both the base64 and the validation failures fail closed.
+func decodeBindingPubKey(b64 string) (registry.PublicKey, error) {
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return registry.PublicKey{}, fmt.Errorf("%s: %w", ErrRegistryBadPubKey, err)
+	}
+	pk, err := registry.NewPublicKey(raw)
+	if err != nil {
+		return registry.PublicKey{}, fmt.Errorf("%s: %w", ErrRegistryBadPubKey, err)
+	}
+	return pk, nil
+}
+
+// revokedAtPtr narrows the int64 wire revoked_at to the registry's *int. A nil
+// wire pointer (absent revoked_at) stays nil (== live). Negativity is gated in
+// buildBinding before this runs. The int64->int narrowing is safe on 64-bit
+// targets (the only build targets); widening registry.RevokedAt to *int64 is
+// tracked as Contract-B hardening.
+func revokedAtPtr(v *int64) *int {
+	if v == nil {
+		return nil
+	}
+	n := int(*v)
+	return &n
+}

--- a/internal/identitycli/sign_registry_test.go
+++ b/internal/identitycli/sign_registry_test.go
@@ -1,0 +1,319 @@
+package identitycli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity/registry"
+)
+
+// testRegistryJSON is a valid unsigned registry (one live binding) whose pubkey
+// is filled in per-test (the agent key is generated fresh so we can verify the
+// emitted distribution envelope).
+func testRegistryJSON(pubB64 string) string {
+	return `{"agents":[{"authorized_origin_daemons":["daemon-eu-1"],"display_name":"Mira",` +
+		`"key_epoch":1,"pubkey":"` + pubB64 + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":5,"valid_from":1770000000,"valid_until":1780000000}`
+}
+
+// TestSignRegistryProducesVerifyingDistributionKeylessly proves SignRegistry
+// signs the JCS-canonical registry through the SignerClient seam (no key file)
+// and emits a distribution envelope that ParseDistribution+VerifyAndLoad accept.
+func TestSignRegistryProducesVerifyingDistributionKeylessly(t *testing.T) {
+	rootPub, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey root: %v", err)
+	}
+	agentPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey agent: %v", err)
+	}
+	fake := &fakeSignerClient{priv: rootPriv}
+
+	var out bytes.Buffer
+	in := testRegistryJSON(base64.StdEncoding.EncodeToString(agentPub))
+	if err := SignRegistry(&out, fake, []byte(in)); err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+
+	env, err := registry.ParseDistribution(out.Bytes())
+	if err != nil {
+		t.Fatalf("ParseDistribution(output): %v\noutput=%q", err, out.String())
+	}
+	now := time.Unix(1_770_000_500, 0)
+	loaded, newHighest, err := registry.VerifyAndLoad(rootPub, env, 4, now, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad: %v", err)
+	}
+	if newHighest != 5 {
+		t.Fatalf("newHighest = %d, want 5", newHighest)
+	}
+	if len(loaded.Agents) != 1 || loaded.Agents[0].Slug != "mira" {
+		t.Fatalf("loaded registry mismatch: %+v", loaded.Agents)
+	}
+}
+
+// TestSignRegistryByteIdenticalToDomain proves the CLI path yields the SAME
+// distribution as registry.SignRegistryWithSigner over the same registry — the
+// CLI wire-decode introduces no drift.
+func TestSignRegistryByteIdenticalToDomain(t *testing.T) {
+	_, rootPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	agentPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey agent: %v", err)
+	}
+	fake := &fakeSignerClient{priv: rootPriv}
+
+	var out bytes.Buffer
+	in := testRegistryJSON(base64.StdEncoding.EncodeToString(agentPub))
+	if err := SignRegistry(&out, fake, []byte(in)); err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+	cliEnv, err := registry.ParseDistribution(out.Bytes())
+	if err != nil {
+		t.Fatalf("ParseDistribution: %v", err)
+	}
+
+	pk, err := registry.NewPublicKey(agentPub)
+	if err != nil {
+		t.Fatalf("NewPublicKey: %v", err)
+	}
+	reg := registry.Registry{
+		Epoch: 5, ValidFrom: 1770000000, ValidUntil: 1780000000,
+		Agents: []registry.AgentBinding{{
+			Slug: "mira", DisplayName: "Mira", PubKey: pk, KeyEpoch: 1,
+			ValidFrom: 1770000000, ValidUntil: 1780000000,
+			AuthorizedOriginDaemons: []string{"daemon-eu-1"},
+		}},
+	}
+	domEnv, err := registry.SignRegistryWithSigner(&keyBackedSigner{priv: rootPriv}, reg)
+	if err != nil {
+		t.Fatalf("SignRegistryWithSigner: %v", err)
+	}
+	if !bytes.Equal(cliEnv.Registry, domEnv.Registry) {
+		t.Fatalf("canonical bytes differ:\n cli=%q\n dom=%q", cliEnv.Registry, domEnv.Registry)
+	}
+	if !bytes.Equal(cliEnv.RootSig, domEnv.RootSig) {
+		t.Fatal("root sigs differ")
+	}
+}
+
+// keyBackedSigner signs with a held root key (mirrors the registry-package test
+// helper) so the CLI-vs-domain parity test can use a deterministic signer.
+type keyBackedSigner struct{ priv ed25519.PrivateKey }
+
+func (k *keyBackedSigner) Sign(b []byte) ([]byte, error) { return ed25519.Sign(k.priv, b), nil }
+
+// TestSignRegistryCarriesRevokedAt proves a binding with revoked_at set (a
+// revoked rotation tuple) round-trips through the CLI into the signed
+// distribution. It covers the revoked_at narrowing branch. The registry pairs a
+// live mira@2 with a revoked mira@1 (uniqueness allows one live + one revoked).
+func TestSignRegistryCarriesRevokedAt(t *testing.T) {
+	rootPub, rootPriv, _ := ed25519.GenerateKey(rand.Reader)
+	livePub, _, _ := ed25519.GenerateKey(rand.Reader)
+	oldPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	fake := &fakeSignerClient{priv: rootPriv}
+
+	in := `{"agents":[` +
+		`{"authorized_origin_daemons":["d"],"display_name":"Mira","key_epoch":2,` +
+		`"pubkey":"` + base64.StdEncoding.EncodeToString(livePub) + `","slug":"mira",` +
+		`"valid_from":1770000000,"valid_until":1780000000},` +
+		`{"authorized_origin_daemons":["d"],"display_name":"Mira","key_epoch":1,` +
+		`"pubkey":"` + base64.StdEncoding.EncodeToString(oldPub) + `","revoked_at":1770000100,` +
+		`"slug":"mira","valid_from":1770000000,"valid_until":1780000000}],` +
+		`"epoch":5,"valid_from":1770000000,"valid_until":1780000000}`
+
+	var out bytes.Buffer
+	if err := SignRegistry(&out, fake, []byte(in)); err != nil {
+		t.Fatalf("SignRegistry: %v", err)
+	}
+	env, err := registry.ParseDistribution(out.Bytes())
+	if err != nil {
+		t.Fatalf("ParseDistribution: %v", err)
+	}
+	now := time.Unix(1_770_000_500, 0)
+	loaded, _, err := registry.VerifyAndLoad(rootPub, env, 4, now, time.Hour*24*365)
+	if err != nil {
+		t.Fatalf("VerifyAndLoad: %v", err)
+	}
+	var sawRevoked bool
+	for _, b := range loaded.Agents {
+		if b.KeyEpoch == 1 {
+			if b.RevokedAt == nil || *b.RevokedAt != 1770000100 {
+				t.Fatalf("revoked_at did not round-trip: %+v", b.RevokedAt)
+			}
+			sawRevoked = true
+		}
+	}
+	if !sawRevoked {
+		t.Fatal("revoked binding (key_epoch 1) missing from loaded registry")
+	}
+}
+
+func TestSignRegistryRejectsBadBase64PubKey(t *testing.T) {
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	in := testRegistryJSON("not-base64!!!")
+	if err := SignRegistry(&out, fake, []byte(in)); err == nil {
+		t.Fatal("expected bad-base64 pubkey rejection, got nil")
+	}
+	if fake.gotCanonical != nil {
+		t.Fatal("signer was called for a bad-base64 pubkey")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("reject must print nothing, got %q", out.String())
+	}
+}
+
+func TestSignRegistryRejectsSmallOrderPubKey(t *testing.T) {
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	// 32 zero bytes is a small-order point -> NewPublicKey rejects it.
+	zero := base64.StdEncoding.EncodeToString(make([]byte, ed25519.PublicKeySize))
+	in := testRegistryJSON(zero)
+	if err := SignRegistry(&out, fake, []byte(in)); err == nil {
+		t.Fatal("expected small-order pubkey rejection, got nil")
+	}
+	if fake.gotCanonical != nil {
+		t.Fatal("signer was called for a small-order pubkey")
+	}
+}
+
+func TestSignRegistryRejectsUnknownField(t *testing.T) {
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	bad := `{"agents":[],"epoch":5,"valid_from":1,"valid_until":2,"evil":true}`
+	if err := SignRegistry(&out, fake, []byte(bad)); err == nil {
+		t.Fatal("expected unknown-field rejection, got nil")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("parse reject must print nothing, got %q", out.String())
+	}
+}
+
+func TestSignRegistryRejectsTrailingData(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	in := testRegistryJSON(base64.StdEncoding.EncodeToString(pub)) + ` {"trailing":true}`
+	if err := SignRegistry(&out, fake, []byte(in)); err == nil {
+		t.Fatal("expected trailing-data rejection, got nil")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("parse reject must print nothing, got %q", out.String())
+	}
+}
+
+func TestSignRegistryFailsClosedOnSignerError(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	fake := &fakeSignerClient{failErr: sentinelErr("signer unreachable")}
+	var out bytes.Buffer
+	in := testRegistryJSON(base64.StdEncoding.EncodeToString(pub))
+	if err := SignRegistry(&out, fake, []byte(in)); err == nil {
+		t.Fatal("expected fail-closed error, got nil")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("fail-closed must print nothing, got %q", out.String())
+	}
+}
+
+func TestSignRegistryRejectsOutOfRangeEpoch(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	// epoch 0 is below the [1, 2^53] floor -> rejected by the registry gate.
+	in := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"M",` +
+		`"key_epoch":1,"pubkey":"` + base64.StdEncoding.EncodeToString(pub) + `","slug":"mira",` +
+		`"valid_from":1,"valid_until":2}],"epoch":0,"valid_from":1,"valid_until":2}`
+	if err := SignRegistry(&out, fake, []byte(in)); err == nil {
+		t.Fatal("expected out-of-range epoch rejection, got nil")
+	}
+	if fake.gotCanonical != nil {
+		t.Fatal("signer was called for an out-of-range epoch")
+	}
+}
+
+// TestSignRegistryRejectsRegistryEpochAbove2Pow53 covers the registry-epoch gate
+// at the JCS-safe ceiling. The gate runs on the int64 wire value BEFORE narrowing
+// (epochInRangeI64), so the wire boundary is the range authority — a >2^53 value
+// cannot reach the signer.
+func TestSignRegistryRejectsRegistryEpochAbove2Pow53(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	// 2^53 + 1 = 9007199254740993, one past MaxSafeEpoch.
+	in := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"M",` +
+		`"key_epoch":1,"pubkey":"` + base64.StdEncoding.EncodeToString(pub) + `","slug":"mira",` +
+		`"valid_from":1,"valid_until":2}],"epoch":9007199254740993,"valid_from":1,"valid_until":2}`
+	if err := SignRegistry(&out, fake, []byte(in)); err == nil {
+		t.Fatal("expected >2^53 registry epoch rejection, got nil")
+	}
+	if fake.gotCanonical != nil {
+		t.Fatal("signer was called for a >2^53 registry epoch")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("reject must print nothing, got %q", out.String())
+	}
+}
+
+// TestSignRegistryRejectsBindingKeyEpochAbove2Pow53 covers the BINDING key_epoch
+// gate (distinct from the registry epoch) — the path the original out-of-range
+// test did not exercise.
+func TestSignRegistryRejectsBindingKeyEpochAbove2Pow53(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	in := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"M",` +
+		`"key_epoch":9007199254740993,"pubkey":"` + base64.StdEncoding.EncodeToString(pub) + `","slug":"mira",` +
+		`"valid_from":1,"valid_until":2}],"epoch":1,"valid_from":1,"valid_until":2}`
+	if err := SignRegistry(&out, fake, []byte(in)); err == nil {
+		t.Fatal("expected >2^53 binding key_epoch rejection, got nil")
+	}
+	if fake.gotCanonical != nil {
+		t.Fatal("signer was called for a >2^53 binding key_epoch")
+	}
+}
+
+// TestSignRegistryRejectsWrongLengthPubKey covers a well-formed base64 string
+// that decodes to the wrong number of bytes (not 32) — a distinct NewPublicKey
+// reject path from bad-base64 and small-order, exercised at the CLI boundary.
+func TestSignRegistryRejectsWrongLengthPubKey(t *testing.T) {
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	short := base64.StdEncoding.EncodeToString(make([]byte, 16)) // 16 != 32
+	in := testRegistryJSON(short)
+	if err := SignRegistry(&out, fake, []byte(in)); err == nil {
+		t.Fatal("expected wrong-length pubkey rejection, got nil")
+	}
+	if fake.gotCanonical != nil {
+		t.Fatal("signer was called for a wrong-length pubkey")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("reject must print nothing, got %q", out.String())
+	}
+}
+
+// TestSignRegistryRejectsNegativeRevokedAt covers the revoked_at sanity gate: a
+// negative (pre-epoch) revocation timestamp fails closed.
+func TestSignRegistryRejectsNegativeRevokedAt(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	fake := &fakeSignerClient{}
+	var out bytes.Buffer
+	in := `{"agents":[{"authorized_origin_daemons":["d"],"display_name":"M",` +
+		`"key_epoch":1,"pubkey":"` + base64.StdEncoding.EncodeToString(pub) + `","revoked_at":-1,` +
+		`"slug":"mira","valid_from":1,"valid_until":2}],"epoch":1,"valid_from":1,"valid_until":2}`
+	if err := SignRegistry(&out, fake, []byte(in)); err == nil {
+		t.Fatal("expected negative revoked_at rejection, got nil")
+	}
+	if fake.gotCanonical != nil {
+		t.Fatal("signer was called for a negative revoked_at")
+	}
+}

--- a/internal/onboard/COMMANDS.md
+++ b/internal/onboard/COMMANDS.md
@@ -59,6 +59,7 @@ Generated from the command tree — do not edit by hand (run `task generate:docs
 | `vaultmind identity init` | Mint an agent keypair and seal the private key to the signer | you are setting up an agent and need to mint its ed25519 keypair and seal the private key to the signer. |
 | `vaultmind identity sign` | Validate, canonicalize, and sign an entry via the keyless signer | you have a Contract-B entry to sign and want it validated, canonicalized, and signed by the keyless signer. |
 | `vaultmind identity sign-envelope` | Sign a chat message envelope via the keyless signer (Contract-B slice 5) | you have a chat MESSAGE envelope to sign so a receiving daemon can verify the signature and the signer's registry binding. |
+| `vaultmind identity sign-registry` | Sign a trust-root registry via the keyless signer (Contract-B) | you have a trust-root registry to sign so consumers can verify the root signature, anti-rollback epoch, and freshness at load. |
 | `vaultmind init` | Scaffold a fresh persona-shaped vault, ready for you and your agent | you are starting fresh and need to scaffold a new persona-shaped vault. |
 
 ## Setup & introspection:


### PR DESCRIPTION
Keyless CLI that signs an agent-identity trust-root registry's JCS-canonical bytes via the custody signer (root key stays in the signer, never loaded by the CLI) and emits the distribution envelope — the keyless parallel of `identity sign-envelope`. Unblocks Contract-B live-enablement re-signing (drop workhorse's binding in → re-sign) without the root key entering the CLI process.

## Changes
- `registry.SignRegistryWithSigner` + `RegistrySigner` interface; shared `canonicalizeForSign` extraction (epoch gate + canonicalBytes) — byte-identical to `SignRegistry`.
- `identitycli.SignRegistry`: strict wire decode (`DisallowUnknownFields` + trailing-data), validated `PublicKey` per binding, fail-closed on every error path (never a partial/unsigned result).
- `cmd/identity_sign_registry.go` + config metadata (ADR-005 constants), `--file`/`--signer-socket`.

## pr-review applied (code-reviewer + silent-failure-hunter)
Both converged on one real finding (rated HIGH by the silent-failure hunter): the `int64→int` narrowing ran **before** the epoch range gate — the slice-5 parity trap reintroduced in a trust-root. Fixed: the gate (`epochInRangeI64`) now runs on the int64 wire value **before** narrowing, so the wire boundary is the single range authority (a `>2^31` value can't truncate past the gate on a 32-bit build). Also: negative `revoked_at` rejected; comment made truthful. Added regression tests: registry + binding `>2^53` epoch, wrong-length pubkey, negative `revoked_at`.

## Verification
`task check` green (23/23, coverage 86.97%); patch coverage 95%+; the keyless path is byte-identical to `SignRegistry` (test-proven). Build target is 64-bit only; the gate is structurally pre-narrow regardless.