### PR TITLE
feat(identity): 'identity signer' custody-signer daemon (Contract-B)

### DIFF
--- a/.ckeletin/pkg/config/keys_generated.go
+++ b/.ckeletin/pkg/config/keys_generated.go
@@ -138,6 +138,8 @@ const (
 	KeyAppIdentitysignenvelopeFromPubkey   = "app.identitysignenvelope.from_pubkey"   // Signer public key (base64) stamped as the from_pubkey hint; not signed
 	KeyAppIdentitysignregistryFile         = "app.identitysignregistry.file"          // Read registry JSON from this file instead of stdin
 	KeyAppIdentitysignregistrySignerSocket = "app.identitysignregistry.signer_socket" // Signer socket path (default: XDG state dir)
+	KeyAppIdentitysignerSignerKey          = "app.identitysigner.signer_key"          // Sealed signer key path (default: XDG data dir)
+	KeyAppIdentitysignerSignerSocket       = "app.identitysigner.signer_socket"       // Signer socket path (default: XDG state dir)
 	KeyAppIndexVault                       = "app.index.vault"                        // Path to the vault root directory
 	KeyAppIndexJson                        = "app.index.json"                         // Output in JSON format
 	KeyAppIndexFull                        = "app.index.full"                         // Force full rebuild instead of incremental index

--- a/cmd/identity_signer.go
+++ b/cmd/identity_signer.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -92,8 +93,7 @@ func serveIdentitySigner(ctx context.Context, out io.Writer, cfg signer.Config) 
 		return fmt.Errorf("signer: listen: %w", err)
 	}
 	if _, err := fmt.Fprintf(out, signerListeningMsg, cfg.SocketPath); err != nil {
-		_ = s.Close()
-		return fmt.Errorf("signer: write startup line: %w", err)
+		return errors.Join(fmt.Errorf("signer: write startup line: %w", err), s.Close())
 	}
 
 	serveErr := make(chan error, 1)
@@ -101,10 +101,19 @@ func serveIdentitySigner(ctx context.Context, out io.Writer, cfg signer.Config) 
 
 	select {
 	case <-ctx.Done():
+		// Cleanup precedes cosmetics: Close (load-bearing socket removal) FIRST,
+		// so a SIGPIPE on a closed stdout can't kill us before cleanup; then
+		// best-effort print. Drain any Serve error that raced the signal so a real
+		// failure isn't silently dropped on the exit-0 path.
+		err := s.Close()
+		select {
+		case se := <-serveErr:
+			err = errors.Join(err, se)
+		default:
+		}
 		_, _ = fmt.Fprintf(out, signerShutdownMsg, cfg.SocketPath)
-		return s.Close()
-	case err := <-serveErr:
-		_ = s.Close()
 		return err
+	case err := <-serveErr:
+		return errors.Join(err, s.Close())
 	}
 }

--- a/cmd/identity_signer.go
+++ b/cmd/identity_signer.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/identity/signer"
+	"github.com/spf13/cobra"
+)
+
+// Signer-daemon startup/shutdown lines (SSOT). These are the ONLY things the
+// command prints — never the key, never key bytes.
+const (
+	signerListeningMsg = "custody signer listening on %s (uid-gated, dev-interim)\n"
+	signerShutdownMsg  = "shutting down, removing socket %s\n"
+
+	// errSignerEmptyAllowlist is the command-level fail-closed message when the
+	// computed uid allowlist is empty (defense-in-depth alongside signer.New's
+	// own guard). An empty allowlist would otherwise deny every caller silently.
+	errSignerEmptyAllowlist = "signer: refusing to start with an empty uid allowlist"
+)
+
+var identitySignerCmd = MustNewCommand(commands.IdentitySignerMetadata, runIdentitySignerCmd)
+
+func init() {
+	identityCmd.AddCommand(identitySignerCmd)
+	setupCommandConfig(identitySignerCmd)
+}
+
+// runIdentitySignerCmd is the cobra entrypoint: it resolves the key/socket
+// paths, installs a SIGINT/SIGTERM-cancelled context, and runs the signer in
+// the foreground until a signal arrives.
+func runIdentitySignerCmd(cmd *cobra.Command, _ []string) error {
+	keyPath, sockPath, err := resolveSignerPaths(cmd)
+	if err != nil {
+		return err
+	}
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return runIdentitySigner(ctx, cmd.OutOrStdout(), keyPath, sockPath)
+}
+
+// resolveSignerPaths reads --signer-key / --signer-socket, falling back to the
+// XDG default paths when unset.
+func resolveSignerPaths(cmd *cobra.Command) (keyPath, sockPath string, err error) {
+	keyPath = getConfigValueWithFlags[string](cmd, "signer-key", config.KeyAppIdentitysignerSignerKey)
+	if keyPath == "" {
+		if keyPath, err = defaultSignerKeyPath(); err != nil {
+			return "", "", fmt.Errorf("resolving signer key path: %w", err)
+		}
+	}
+	sockPath = getConfigValueWithFlags[string](cmd, "signer-socket", config.KeyAppIdentitysignerSignerSocket)
+	if sockPath == "" {
+		if sockPath, err = defaultSignerSocketPath(); err != nil {
+			return "", "", fmt.Errorf("resolving signer socket path: %w", err)
+		}
+	}
+	return keyPath, sockPath, nil
+}
+
+// runIdentitySigner builds the single-uid (current user) dev-interim signer
+// config and serves it until ctx is cancelled. The allowlist is the current
+// uid only — fail-closed on an empty/zero allowlist is enforced by serve.
+func runIdentitySigner(ctx context.Context, out io.Writer, keyPath, sockPath string) error {
+	cfg := signer.Config{
+		KeyPath:     keyPath,
+		SocketPath:  sockPath,
+		AllowedUIDs: []uint32{uint32(os.Getuid())}, //nolint:gosec // G115: os.Getuid() is the current real uid, always non-negative and within uint32
+	}
+	return serveIdentitySigner(ctx, out, cfg)
+}
+
+// serveIdentitySigner runs a signer with the given config until ctx is
+// cancelled, then Closes it (removing the socket). It FAILS CLOSED: an empty
+// allowlist, a missing/unreadable key, or a bind failure returns an error
+// having printed nothing sensitive.
+func serveIdentitySigner(ctx context.Context, out io.Writer, cfg signer.Config) error {
+	if len(cfg.AllowedUIDs) == 0 {
+		return fmt.Errorf("%s", errSignerEmptyAllowlist)
+	}
+	s, err := signer.New(cfg)
+	if err != nil {
+		return fmt.Errorf("signer: init: %w", err)
+	}
+	if err := s.Listen(); err != nil {
+		return fmt.Errorf("signer: listen: %w", err)
+	}
+	if _, err := fmt.Fprintf(out, signerListeningMsg, cfg.SocketPath); err != nil {
+		_ = s.Close()
+		return fmt.Errorf("signer: write startup line: %w", err)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- s.Serve() }()
+
+	select {
+	case <-ctx.Done():
+		_, _ = fmt.Fprintf(out, signerShutdownMsg, cfg.SocketPath)
+		return s.Close()
+	case err := <-serveErr:
+		_ = s.Close()
+		return err
+	}
+}

--- a/cmd/identity_signer_test.go
+++ b/cmd/identity_signer_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -63,8 +64,10 @@ func TestRunIdentitySignerRoundTripAndGracefulShutdown(t *testing.T) {
 	sockPath := filepath.Join(sockDir, "s.sock")
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // no goroutine leak if an assertion below fails before the explicit cancel
 	done := make(chan error, 1)
-	go func() { done <- runIdentitySigner(ctx, io.Discard, keyPath, sockPath) }()
+	var out bytes.Buffer
+	go func() { done <- runIdentitySigner(ctx, &out, keyPath, sockPath) }()
 
 	waitForSocket(t, sockPath)
 
@@ -89,6 +92,21 @@ func TestRunIdentitySignerRoundTripAndGracefulShutdown(t *testing.T) {
 	}
 	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
 		t.Fatalf("socket not removed on shutdown: stat err = %v", err)
+	}
+
+	// 'Prints only non-secret lines': the socket path appears; the raw key bytes
+	// never do. Safe to read out after <-done (the goroutine's writes happen-before
+	// the send on done).
+	logged := out.String()
+	if !strings.Contains(logged, sockPath) {
+		t.Fatalf("startup line should name the socket path; got %q", logged)
+	}
+	keyBytes, rerr := os.ReadFile(keyPath)
+	if rerr != nil {
+		t.Fatalf("read key file: %v", rerr)
+	}
+	if bytes.Contains(out.Bytes(), keyBytes) {
+		t.Fatal("daemon output leaked raw key bytes")
 	}
 }
 

--- a/cmd/identity_signer_test.go
+++ b/cmd/identity_signer_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/signer"
+)
+
+// signerTestKey mints an ed25519 keypair and seals the private key to a 0600
+// file under a SHORT temp dir, returning the key path and the public key. Short
+// dirs keep the sibling socket path under the ~104-char darwin UDS limit.
+func signerTestKey(t *testing.T) (keyPath string, pub ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	dir, err := os.MkdirTemp("", "vmsgn")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	keyPath = filepath.Join(dir, "k.key")
+	if err := signer.SealPrivateKey(keyPath, priv); err != nil {
+		t.Fatalf("SealPrivateKey: %v", err)
+	}
+	return keyPath, pub
+}
+
+// waitForSocket polls until path exists or the deadline passes; it lets a test
+// wait for runIdentitySigner's goroutine to bind before dialing.
+func waitForSocket(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("socket %q was not bound within deadline", path)
+}
+
+// TestRunIdentitySignerRoundTripAndGracefulShutdown starts runIdentitySigner in
+// a goroutine, proves a keyless client round-trip signature VERIFIES, then
+// cancels the context and asserts the socket file is removed (graceful Close).
+func TestRunIdentitySignerRoundTripAndGracefulShutdown(t *testing.T) {
+	keyPath, pub := signerTestKey(t)
+	sockDir, err := os.MkdirTemp("", "vmsgs")
+	if err != nil {
+		t.Fatalf("MkdirTemp sock: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sockPath := filepath.Join(sockDir, "s.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runIdentitySigner(ctx, io.Discard, keyPath, sockPath) }()
+
+	waitForSocket(t, sockPath)
+
+	const entry = `{"agent":"mira","epoch":1}`
+	canonical, err := identity.Canonicalize([]byte(entry))
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	client := &signer.Client{SocketPath: sockPath}
+	sig, err := client.Sign(canonical.Bytes())
+	if err != nil {
+		t.Fatalf("client.Sign: %v", err)
+	}
+	ok, err := identity.VerifyCanonical(pub, canonical, sig)
+	if err != nil || !ok {
+		t.Fatalf("signer signature did not verify: ok=%v err=%v", ok, err)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("runIdentitySigner returned error on graceful shutdown: %v", err)
+	}
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Fatalf("socket not removed on shutdown: stat err = %v", err)
+	}
+}
+
+// TestRunIdentitySignerMissingKeyFailsClosed asserts a missing key file makes
+// runIdentitySigner return an error and leave no socket behind.
+func TestRunIdentitySignerMissingKeyFailsClosed(t *testing.T) {
+	dir, err := os.MkdirTemp("", "vmsgnmk")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	keyPath := filepath.Join(dir, "missing.key")
+	sockPath := filepath.Join(dir, "s.sock")
+
+	err = runIdentitySigner(context.Background(), io.Discard, keyPath, sockPath)
+	if err == nil {
+		t.Fatal("expected fail-closed error for missing key file, got nil")
+	}
+	if _, statErr := os.Stat(sockPath); !os.IsNotExist(statErr) {
+		t.Fatalf("missing-key path must not bind a socket: stat err = %v", statErr)
+	}
+}
+
+// TestRunIdentitySignerEmptyAllowlistRefuses asserts the empty-allowlist guard
+// fails closed: an empty uid allowlist must refuse to start (never deny-all
+// silently). It drives the low-level builder so the guard is exercised directly.
+func TestRunIdentitySignerEmptyAllowlistRefuses(t *testing.T) {
+	keyPath, _ := signerTestKey(t)
+	sockDir, err := os.MkdirTemp("", "vmsgea")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sockPath := filepath.Join(sockDir, "s.sock")
+
+	err = serveIdentitySigner(context.Background(), io.Discard, signer.Config{
+		KeyPath:     keyPath,
+		SocketPath:  sockPath,
+		AllowedUIDs: nil,
+	})
+	if err == nil {
+		t.Fatal("expected refusal for empty uid allowlist, got nil")
+	}
+	if _, statErr := os.Stat(sockPath); !os.IsNotExist(statErr) {
+		t.Fatalf("empty-allowlist path must not bind a socket: stat err = %v", statErr)
+	}
+}
+
+// TestIdentitySignerCommandFailsClosedOnMissingKey drives the cobra entrypoint
+// through RootCmd with explicit flags pointed at a MISSING key. This exercises
+// runIdentitySignerCmd + resolveSignerPaths + the signal-context wiring while
+// failing closed BEFORE Serve blocks (a missing key cannot bind), so the test
+// returns promptly and leaves no socket behind.
+func TestIdentitySignerCommandFailsClosedOnMissingKey(t *testing.T) {
+	dir, err := os.MkdirTemp("", "vmsgncmd")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	keyPath := filepath.Join(dir, "missing.key")
+	sockPath := filepath.Join(dir, "s.sock")
+
+	_, _, err = runRootCmd(t, "identity", "signer",
+		"--signer-key", keyPath, "--signer-socket", sockPath)
+	if err == nil {
+		t.Fatal("expected fail-closed error for missing key, got nil")
+	}
+	if _, statErr := os.Stat(sockPath); !os.IsNotExist(statErr) {
+		t.Fatalf("fail-closed path must not bind a socket: stat err = %v", statErr)
+	}
+}
+
+// errWriter is an io.Writer that always fails, used to drive the startup-line
+// write-error fail-closed path in serveIdentitySigner.
+type errWriter struct{}
+
+func (errWriter) Write(_ []byte) (int, error) { return 0, errAlwaysFails }
+
+var errAlwaysFails = io.ErrClosedPipe
+
+// TestResolveSignerPathsFallsBackToXDGDefaults drives resolveSignerPaths with no
+// flags set so both empty-path branches resolve the XDG defaults — the default
+// resolution branches the flagged command tests skip.
+func TestResolveSignerPathsFallsBackToXDGDefaults(t *testing.T) {
+	resetFlagsRecursive(identitySignerCmd)
+
+	keyPath, sockPath, err := resolveSignerPaths(identitySignerCmd)
+	if err != nil {
+		t.Fatalf("resolveSignerPaths: %v", err)
+	}
+	if !strings.HasSuffix(keyPath, signerKeyFilename) {
+		t.Fatalf("key path %q does not end in %q", keyPath, signerKeyFilename)
+	}
+	if !strings.HasSuffix(sockPath, signerSocketFilename) {
+		t.Fatalf("socket path %q does not end in %q", sockPath, signerSocketFilename)
+	}
+}
+
+// TestServeIdentitySignerStartupWriteErrorFailsClosed proves a failing output
+// writer on the startup line makes serveIdentitySigner FAIL CLOSED (return an
+// error and Close — socket removed), never leaving a half-started daemon.
+func TestServeIdentitySignerStartupWriteErrorFailsClosed(t *testing.T) {
+	keyPath, _ := signerTestKey(t)
+	sockDir, err := os.MkdirTemp("", "vmsgsw")
+	if err != nil {
+		t.Fatalf("MkdirTemp sock: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sockPath := filepath.Join(sockDir, "s.sock")
+
+	err = serveIdentitySigner(context.Background(), errWriter{}, signer.Config{
+		KeyPath:     keyPath,
+		SocketPath:  sockPath,
+		AllowedUIDs: []uint32{uint32(os.Getuid())},
+	})
+	if err == nil {
+		t.Fatal("expected fail-closed error on startup-line write failure, got nil")
+	}
+	if _, statErr := os.Stat(sockPath); !os.IsNotExist(statErr) {
+		t.Fatalf("startup-write-error path must remove the socket: stat err = %v", statErr)
+	}
+}
+
+// TestIdentitySignerCommandRegistered is a thin smoke test: `identity signer
+// --help` succeeds and shows both flags, mirroring the sign-* command tests.
+func TestIdentitySignerCommandRegistered(t *testing.T) {
+	out, _, err := runRootCmd(t, "identity", "signer", "--help")
+	if err != nil {
+		t.Fatalf("identity signer --help: %v", err)
+	}
+	help := out.String()
+	for _, want := range []string{"signer", "--signer-key", "--signer-socket"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("identity signer --help missing %q\n%s", want, help)
+		}
+	}
+}

--- a/cmd/zz_catalog.go
+++ b/cmd/zz_catalog.go
@@ -274,6 +274,11 @@ var commandCatalog = map[string]catalogEntry{
 		when:  "you have a trust-root registry to sign so consumers can verify the root signature, anti-rollback epoch, and freshness at load.",
 		short: "Sign a trust-root registry via the keyless signer (Contract-B)",
 	},
+	"vaultmind identity signer": {
+		group: groupLifecycle,
+		when:  "you need to RUN the keyless custody signer daemon so the sign-* commands have a process to connect to.",
+		short: "Run the keyless custody signer daemon (Contract-B)",
+	},
 	"vaultmind hooks": {
 		group: groupLifecycle,
 		when:  "you need to install, remove, or check VaultMind's Claude Code hook scripts.",

--- a/internal/config/commands/identity_signer_config.go
+++ b/internal/config/commands/identity_signer_config.go
@@ -1,0 +1,42 @@
+package commands
+
+import "github.com/peiman/vaultmind/.ckeletin/pkg/config"
+
+// IdentitySignerMetadata defines metadata for the `identity signer` command —
+// the keyless custody-signer DAEMON that the sign-* commands connect to.
+var IdentitySignerMetadata = config.CommandMetadata{
+	Use:   "signer",
+	Short: "Run the keyless custody signer daemon (Contract-B)",
+	Long: `Run the keyless custody signer in the FOREGROUND. The signer holds the agent's
+ed25519 private key in memory and serves signatures over a 0600 Unix-domain
+socket, gated by LOCAL_PEERCRED to the current user's uid (the documented
+DEV-INTERIM posture). The private key NEVER leaves this process; the sign-*
+CLIs are KEYLESS and reach it only over the socket.
+
+This is a long-running process: it serves until it receives SIGINT/SIGTERM,
+then removes the socket and exits. Background it (or wire it under launchd)
+yourself. It FAILS CLOSED: a missing/unreadable key, a bind failure, or an
+empty uid allowlist refuses to start with a non-zero exit and prints nothing
+sensitive.
+
+DEV-INTERIM: the signer runs as the SAME uid as the CLI today. This is the
+custody ARCHITECTURE, not real isolation — that needs a dedicated service uid +
+launchd + sandbox + Secure-Enclave key wrap (deferred).`,
+	ConfigPrefix: "app.identitysigner",
+	FlagOverrides: map[string]string{
+		"app.identitysigner.signer_key":    "signer-key",
+		"app.identitysigner.signer_socket": "signer-socket",
+	},
+}
+
+// IdentitySignerOptions returns config options for `identity signer`.
+func IdentitySignerOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.identitysigner.signer_key", DefaultValue: "", Description: "Sealed signer key path (default: XDG data dir)", Type: "string"},
+		{Key: "app.identitysigner.signer_socket", DefaultValue: "", Description: "Signer socket path (default: XDG state dir)", Type: "string"},
+	}
+}
+
+func init() {
+	config.RegisterOptionsProvider(IdentitySignerOptions)
+}

--- a/internal/identity/signer/signer.go
+++ b/internal/identity/signer/signer.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/peiman/vaultmind/internal/identity"
 )
@@ -65,6 +66,22 @@ const (
 	// which is a fail-open-looking deny-all misconfiguration: the signer would
 	// run and bind but sign nothing. Fail closed at construction instead.
 	errEmptyAllowlist = "signer: AllowedUIDs must list at least one uid (refusing deny-all)"
+	// errSignerAlreadyRunning is returned by Listen when a LIVE signer is already
+	// answering on the socket path — refusing to start prevents silently
+	// hijacking a running signer's socket (which would leave the first daemon
+	// alive-but-blind and clients reaching an unexpected key).
+	errSignerAlreadyRunning = "signer: already running at socket (refusing to start)"
+	// errSocketPathNotSocket is returned by Listen when the socket path exists but
+	// is NOT a socket — we never blind-delete an arbitrary file at a typo'd path.
+	errSocketPathNotSocket = "signer: path exists and is not a socket (refusing to remove)"
+	// errKeyFilePermissive is returned by loadPrivateKey when the key file is
+	// group/world-accessible — a custody key whose whole point is confinement must
+	// be 0600 (sshd-style strict modes); fail closed so a leaked-perm key is noticed.
+	errKeyFilePermissive = "signer: key file is group/world-accessible (refusing to load)"
+
+	// socketDialProbeTimeout bounds the liveness dial-probe in Listen so a
+	// misbehaving socket can't wedge startup.
+	socketDialProbeTimeout = 1500 * time.Millisecond
 )
 
 // PolicyFunc inspects the canonical bytes a caller asked to sign and returns a
@@ -131,13 +148,44 @@ func New(cfg Config) (*Signer, error) {
 	return &Signer{priv: priv, cfg: cfg, allowed: allowed}, nil
 }
 
-// Listen binds the 0600 Unix-domain socket. Any stale socket file at the path
-// is removed first. The socket is chmod'd to 0600 so only the owning uid can
-// connect (the same-uid dev-interim boundary; see package doc).
-func (s *Signer) Listen() error {
-	// Remove a stale socket left by a prior crashed run.
-	if err := os.Remove(s.cfg.SocketPath); err != nil && !os.IsNotExist(err) {
+// reapStaleSocket makes SocketPath safe to bind. It FAILS CLOSED rather than
+// blindly unlinking: if a LIVE signer is already answering there (dial-probe
+// succeeds) it refuses to start (no silent socket hijack / alive-but-blind
+// first daemon); if the path is a non-socket file it refuses (never deletes an
+// arbitrary file at a typo'd --signer-socket); it removes ONLY a genuinely-dead
+// socket left by a prior crash.
+func reapStaleSocket(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil // nothing there — free to bind
+	}
+	if err != nil {
+		return fmt.Errorf("signer: stat socket path: %w", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("%s: %q", errSocketPathNotSocket, path)
+	}
+	// It IS a socket — is a live signer answering? A successful dial means yes.
+	if conn, derr := net.DialTimeout(network, path, socketDialProbeTimeout); derr == nil {
+		_ = conn.Close()
+		return fmt.Errorf("%s: %q", errSignerAlreadyRunning, path)
+	}
+	// Dead socket (no listener / connection refused) — safe to reap.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("signer: remove stale socket: %w", err)
+	}
+	return nil
+}
+
+// Listen binds the 0600 Unix-domain socket after reaping only a genuinely-dead
+// stale socket (see reapStaleSocket — a live signer at the path makes Listen
+// fail closed). The socket is chmod'd to 0600 so only the owning uid can connect
+// (the same-uid dev-interim boundary; see package doc).
+func (s *Signer) Listen() error {
+	// Reap only a genuinely-dead socket; refuse if a LIVE signer is already
+	// listening, and never delete a non-socket file at a typo'd path.
+	if err := reapStaleSocket(s.cfg.SocketPath); err != nil {
+		return err
 	}
 	addr, err := net.ResolveUnixAddr(network, s.cfg.SocketPath)
 	if err != nil {
@@ -199,13 +247,13 @@ func (s *Signer) Close() error {
 	ln := s.ln
 	s.ln = nil
 	s.mu.Unlock()
-	if ln != nil {
-		_ = ln.Close()
+	if ln == nil {
+		return nil
 	}
-	if err := os.Remove(s.cfg.SocketPath); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
+	// Go's net.UnixListener (created via ListenUnix) unlinks the socket file IT
+	// created on Close. We rely on that and DO NOT blind-remove by path, which
+	// could unlink a successor's live socket (and would mask this Close's error).
+	return ln.Close()
 }
 
 // handle services one connection: authenticate the peer UID, read the request,
@@ -263,6 +311,16 @@ func (s *Signer) handle(conn *net.UnixConn) {
 // loadPrivateKey reads the sealed key file and returns the ed25519 private key.
 // It enforces the exact key length so a truncated/corrupt file fails closed.
 func loadPrivateKey(path string) (ed25519.PrivateKey, error) {
+	// Strict modes (sshd-style): refuse a group/world-accessible key file. The
+	// custody key's whole point is confinement; loading a 0644 key silently would
+	// contradict that. The message names the path + mode only, never contents.
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("signer: stat key file: %w", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("%s: %q has mode %#o", errKeyFilePermissive, path, info.Mode().Perm())
+	}
 	b, err := os.ReadFile(path) // #nosec G304 -- operator-configured sealed signer key path (signer Config), not runtime user input
 	if err != nil {
 		return nil, fmt.Errorf("signer: read key file: %w", err)

--- a/internal/identity/signer/signer.go
+++ b/internal/identity/signer/signer.go
@@ -60,6 +60,11 @@ const (
 	errPolicyRefused = "signer: policy refused"
 	// errNotListening is returned when Serve is called before Listen.
 	errNotListening = "signer: not listening (call Listen first)"
+	// errEmptyAllowlist is returned when AllowedUIDs is empty. An empty allowlist
+	// would deny EVERY caller silently (every request answered errUIDNotAllowed),
+	// which is a fail-open-looking deny-all misconfiguration: the signer would
+	// run and bind but sign nothing. Fail closed at construction instead.
+	errEmptyAllowlist = "signer: AllowedUIDs must list at least one uid (refusing deny-all)"
 )
 
 // PolicyFunc inspects the canonical bytes a caller asked to sign and returns a
@@ -111,6 +116,9 @@ func New(cfg Config) (*Signer, error) {
 	}
 	if cfg.SocketPath == "" {
 		return nil, errors.New("signer: SocketPath is required")
+	}
+	if len(cfg.AllowedUIDs) == 0 {
+		return nil, errors.New(errEmptyAllowlist)
 	}
 	priv, err := loadPrivateKey(cfg.KeyPath)
 	if err != nil {

--- a/internal/identity/signer/signer_test.go
+++ b/internal/identity/signer/signer_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/peiman/vaultmind/internal/identity"
@@ -233,15 +234,142 @@ func TestNewRejectsBadKeyFile(t *testing.T) {
 	if err := os.WriteFile(bad, []byte("not-a-key"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if _, err := New(Config{KeyPath: bad, SocketPath: filepath.Join(dir, "s.sock")}); err == nil {
+	// AllowedUIDs is non-empty so New reaches loadPrivateKey (the empty-allowlist
+	// guard runs FIRST and would otherwise mask the wrong-size-key check).
+	_, err := New(Config{KeyPath: bad, SocketPath: filepath.Join(dir, "s.sock"), AllowedUIDs: []uint32{1000}})
+	if err == nil {
 		t.Fatal("expected error for wrong-size key file")
+	}
+	if err.Error() != errLoadKeyLen {
+		t.Fatalf("expected errLoadKeyLen, got %v", err)
 	}
 }
 
 func TestNewRejectsMissingKeyFile(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := New(Config{KeyPath: filepath.Join(dir, "nope.key"), SocketPath: filepath.Join(dir, "s.sock")}); err == nil {
+	// Non-empty allowlist so we exercise the missing-key path, not the allowlist guard.
+	_, err := New(Config{KeyPath: filepath.Join(dir, "nope.key"), SocketPath: filepath.Join(dir, "s.sock"), AllowedUIDs: []uint32{1000}})
+	if err == nil {
 		t.Fatal("expected error for missing key file")
+	}
+}
+
+func TestNewRejectsEmptyAllowlist(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	// Valid key + socket, but no AllowedUIDs → the deny-all guard must fail closed
+	// at construction (covers the signer.New guard directly, not via the cmd guard).
+	_, err := New(Config{KeyPath: keyPath, SocketPath: filepath.Join(t.TempDir(), "s.sock")})
+	if err == nil {
+		t.Fatal("expected error for empty AllowedUIDs")
+	}
+	if err.Error() != errEmptyAllowlist {
+		t.Fatalf("expected errEmptyAllowlist, got %v", err)
+	}
+}
+
+func TestNewRejectsPermissiveKeyFile(t *testing.T) {
+	// A valid-length ed25519 key written group/world-readable (0644) must be
+	// refused — a custody key must be 0600 (sshd-style strict modes).
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	dir := t.TempDir()
+	loose := filepath.Join(dir, "loose.key")
+	if err := os.WriteFile(loose, priv, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err = New(Config{KeyPath: loose, SocketPath: filepath.Join(dir, "s.sock"), AllowedUIDs: []uint32{1000}})
+	if err == nil {
+		t.Fatal("expected refusal for group/world-readable key file")
+	}
+	if !strings.Contains(err.Error(), errKeyFilePermissive) {
+		t.Fatalf("expected errKeyFilePermissive, got %v", err)
+	}
+}
+
+func TestListenRefusesWhenLiveSignerPresent(t *testing.T) {
+	keyPath, pub := newKeyFile(t)
+	// First signer is LIVE (startSigner registers cleanup + returns a client).
+	client, sockPath := startSigner(t, keyPath, []uint32{uint32(os.Getuid())})
+
+	// A second signer on the same socket must REFUSE — no silent hijack of a
+	// running signer (which would leave the first alive-but-blind).
+	s2, err := New(Config{KeyPath: keyPath, SocketPath: sockPath, AllowedUIDs: []uint32{uint32(os.Getuid())}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s2.Listen(); err == nil {
+		_ = s2.Close()
+		t.Fatal("second Listen must refuse a live signer's socket")
+	} else if !strings.Contains(err.Error(), errSignerAlreadyRunning) {
+		t.Fatalf("expected errSignerAlreadyRunning, got %v", err)
+	}
+
+	// The first signer must still sign — it was not hijacked.
+	canonical, err := identity.Canonicalize([]byte(canonicalEntry))
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	sig, err := client.Sign(canonical.Bytes())
+	if err != nil {
+		t.Fatalf("first signer should still sign after the refused second start: %v", err)
+	}
+	if ok, verr := identity.VerifyCanonical(pub, canonical, sig); !ok || verr != nil {
+		t.Fatalf("first signer's signature did not verify: ok=%v err=%v", ok, verr)
+	}
+}
+
+func TestListenReapsDeadSocket(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	sockPath := shortSocketPath(t)
+	// Leave a DEAD socket file (file exists, type socket, no listener) by binding
+	// then closing with unlink disabled — simulates a prior crashed run.
+	addr, err := net.ResolveUnixAddr(network, sockPath)
+	if err != nil {
+		t.Fatalf("ResolveUnixAddr: %v", err)
+	}
+	ln, err := net.ListenUnix(network, addr)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	ln.SetUnlinkOnClose(false)
+	_ = ln.Close()
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("expected a leftover dead socket file: %v", err)
+	}
+
+	// Listen should dial-probe (dead → no listener), reap it, and bind cleanly.
+	s, err := New(Config{KeyPath: keyPath, SocketPath: sockPath, AllowedUIDs: []uint32{uint32(os.Getuid())}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.Listen(); err != nil {
+		t.Fatalf("Listen should reap a dead socket and bind: %v", err)
+	}
+	_ = s.Close()
+}
+
+func TestListenRefusesNonSocketFile(t *testing.T) {
+	keyPath, _ := newKeyFile(t)
+	dir := t.TempDir()
+	notSock := filepath.Join(dir, "regular.file")
+	if err := os.WriteFile(notSock, []byte("important operator data"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	s, err := New(Config{KeyPath: keyPath, SocketPath: notSock, AllowedUIDs: []uint32{uint32(os.Getuid())}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.Listen(); err == nil {
+		_ = s.Close()
+		t.Fatal("Listen must refuse a non-socket file path (never blind-delete it)")
+	} else if !strings.Contains(err.Error(), errSocketPathNotSocket) {
+		t.Fatalf("expected errSocketPathNotSocket, got %v", err)
+	}
+	// The operator's file must NOT have been deleted.
+	if _, statErr := os.Stat(notSock); statErr != nil {
+		t.Fatalf("non-socket file must be preserved, not deleted: %v", statErr)
 	}
 }
 

--- a/internal/onboard/COMMANDS.md
+++ b/internal/onboard/COMMANDS.md
@@ -60,6 +60,7 @@ Generated from the command tree — do not edit by hand (run `task generate:docs
 | `vaultmind identity sign` | Validate, canonicalize, and sign an entry via the keyless signer | you have a Contract-B entry to sign and want it validated, canonicalized, and signed by the keyless signer. |
 | `vaultmind identity sign-envelope` | Sign a chat message envelope via the keyless signer (Contract-B slice 5) | you have a chat MESSAGE envelope to sign so a receiving daemon can verify the signature and the signer's registry binding. |
 | `vaultmind identity sign-registry` | Sign a trust-root registry via the keyless signer (Contract-B) | you have a trust-root registry to sign so consumers can verify the root signature, anti-rollback epoch, and freshness at load. |
+| `vaultmind identity signer` | Run the keyless custody signer daemon (Contract-B) | you need to RUN the keyless custody signer daemon so the sign-* commands have a process to connect to. |
 | `vaultmind init` | Scaffold a fresh persona-shaped vault, ready for you and your agent | you are starting fresh and need to scaffold a new persona-shaped vault. |
 
 ## Setup & introspection:


### PR DESCRIPTION
The missing custody-signer **daemon** — slice 2 shipped the signer library + keyless clients, but nothing *ran* the signer, so `identity sign-envelope`/`sign-registry` had nothing to connect to. This is the foreground daemon (single-uid LOCAL_PEERCRED, dev-interim posture) members run.

## Commits
- `5007456` — the command (`runIdentitySigner(ctx,…)` serving until SIGINT/SIGTERM; fail-closed on empty allowlist / missing key / bind failure; key never printed) + `signer.New` empty-allowlist guard + ADR-005 metadata + 7 tests.
- `93dc92c` — **pr-review hardening** (multi-lens review, adversarially verified):
  - **HIGH** socket-hijack: `Listen()` now dial-probes (refuse a *live* signer, refuse a non-socket file, reap only a dead socket) instead of blind-unlinking — closes the alive-but-blind double-start class. +3 tests.
  - **HIGH** test integrity: restored two key-fail-closed tests the allowlist guard had vacated + added a direct empty-allowlist test.
  - **MEDIUM** key-file perms: `loadPrivateKey` enforces sshd-style strict modes (reject group/world-readable) + test.
  - **MEDIUM** `Close()`: relies on the listener's unlink (can't remove a successor's socket) + surfaces the error.
  - **LOW**: Close-before-print (SIGPIPE), `errors.Join` on swallowed-Close paths + serve-error drain, `defer cancel()`, output-never-leaks-key-bytes assertion.

Deferred (documented dev-interim residuals): per-connection deadline, inherited slice-2 `writeOK/writeErr` swallow, serve-error-after-startup test seam.

`task check` green (23/23, coverage 87.0%); all signer + cmd tests pass.