### PR TITLE
fix(index): migrate _path: id to frontmatter id on re-index (no silent data loss)

### DIFF
--- a/internal/index/id_migration_test.go
+++ b/internal/index/id_migration_test.go
@@ -1,0 +1,176 @@
+package index_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/index"
+	"github.com/peiman/vaultmind/internal/vault"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStoreNote_PathCollisionMigratesID is the load-bearing regression test for
+// the silent-data-loss bug: a note first indexed WITHOUT a frontmatter id is
+// stored under a path-derived `_path:` id. When the file later GAINS a real id,
+// the next index pass upserts the NEW id for the SAME path and used to hit
+// `UNIQUE constraint failed: notes.path`, skipping the note (stale `_path:` row
+// kept serving search; content never updated).
+//
+// The fix treats a path-collision-with-new-id as an id MIGRATION: the existing
+// row is re-keyed to the new id, content updates land, and note_accesses
+// (activation/recall history) is carried forward to the new id.
+func TestStoreNote_PathCollisionMigratesID(t *testing.T) {
+	db := openTestDB(t)
+	const relPath = "references/foo.md"
+	const oldID = "_path:references/foo.md"
+	const newID = "reference-foo"
+
+	// (1) First index WITHOUT an id → stored under the _path: id.
+	first := buildTestRecord(oldID, relPath)
+	first.IsDomain = false
+	first.Hash = "hash-v1"
+	first.BodyText = "Original body."
+	require.NoError(t, index.StoreNote(db, first))
+
+	// (2) Record a note_accesses row + scalar access for the _path: id.
+	require.NoError(t, index.RecordNoteAccessAs(db, oldID, index.CallerAgent))
+
+	// (3) The file GAINS `id: reference-foo`. Re-index the SAME path, new id.
+	second := buildTestRecord(newID, relPath)
+	second.Hash = "hash-v2"
+	second.BodyText = "Updated body after gaining an id."
+
+	// (4) Must NOT error on the UNIQUE(path) collision — it is an id migration.
+	require.NoError(t, index.StoreNote(db, second),
+		"path-collision with a new id must migrate, not fail with UNIQUE constraint")
+
+	// (5a) The new id resolves and content updated.
+	var gotID, gotBody string
+	require.NoError(t, db.QueryRow(
+		"SELECT id, body_text FROM notes WHERE path = ?", relPath).Scan(&gotID, &gotBody))
+	assert.Equal(t, newID, gotID, "row should be re-keyed to the new id")
+	assert.Equal(t, "Updated body after gaining an id.", gotBody, "content should update")
+
+	// (5b) The OLD _path: id no longer exists.
+	var oldCount int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM notes WHERE id = ?", oldID).Scan(&oldCount))
+	assert.Equal(t, 0, oldCount, "stale _path: id must be gone")
+
+	// (5c) note_accesses migrated to the new id (history survives).
+	var newAccesses int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM note_accesses WHERE note_id = ?", newID).Scan(&newAccesses))
+	assert.Equal(t, 1, newAccesses, "note_accesses must be carried forward to the new id")
+
+	var oldAccesses int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(*) FROM note_accesses WHERE note_id = ?", oldID).Scan(&oldAccesses))
+	assert.Equal(t, 0, oldAccesses, "no orphaned note_accesses under the old id")
+
+	// (5d) Scalar access history (access_count) carried forward on the row.
+	stats, err := index.LookupNoteAccess(db, newID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.AccessCount, "scalar access_count must survive the migration")
+}
+
+// TestStoreNote_NoMigrationWhenIDUnchanged guards the common path: a normal
+// content update (same id, same path) must NOT trigger any id-migration
+// side effects — access history stays put and the row updates in place.
+func TestStoreNote_NoMigrationWhenIDUnchanged(t *testing.T) {
+	db := openTestDB(t)
+	rec := buildTestRecord("concept-stable", "concepts/stable.md")
+	rec.Hash = "h1"
+	require.NoError(t, index.StoreNote(db, rec))
+	require.NoError(t, index.RecordNoteAccessAs(db, "concept-stable", index.CallerAgent))
+
+	rec.Hash = "h2"
+	rec.BodyText = "Edited in place."
+	require.NoError(t, index.StoreNote(db, rec))
+
+	stats, err := index.LookupNoteAccess(db, "concept-stable")
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.AccessCount, "same-id update must preserve access history")
+	var body string
+	require.NoError(t, db.QueryRow(
+		"SELECT body_text FROM notes WHERE id = ?", "concept-stable").Scan(&body))
+	assert.Equal(t, "Edited in place.", body)
+}
+
+// TestIncremental_AdoptsFrontmatterID is the end-to-end version through the
+// incremental indexer: a real file gains an id and a re-index just works.
+func TestIncremental_AdoptsFrontmatterID(t *testing.T) {
+	vaultDir := t.TempDir()
+	configDir := filepath.Join(vaultDir, ".vaultmind")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"),
+		[]byte("types:\n  reference:\n    required: [title]\n    statuses: []\n"), 0o644))
+
+	refDir := filepath.Join(vaultDir, "references")
+	require.NoError(t, os.MkdirAll(refDir, 0o755))
+	notePath := filepath.Join(refDir, "foo.md")
+
+	// First index: NO frontmatter id → stored under _path:references/foo.md.
+	require.NoError(t, os.WriteFile(notePath,
+		[]byte("# Foo\n\nOriginal reference body.\n"), 0o644))
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	cfg, err := vault.LoadConfig(vaultDir)
+	require.NoError(t, err)
+	idxr := index.NewIndexer(vaultDir, dbPath, cfg)
+
+	_, err = idxr.Rebuild()
+	require.NoError(t, err)
+
+	const oldID = "_path:references/foo.md"
+	const newID = "reference-foo"
+
+	db, err := index.Open(dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Confirm it landed under the _path: id and record an access against it.
+	var startID string
+	require.NoError(t, db.QueryRow(
+		"SELECT id FROM notes WHERE path = ?", "references/foo.md").Scan(&startID))
+	require.Equal(t, oldID, startID)
+	require.NoError(t, index.RecordNoteAccessAs(db, oldID, index.CallerAgent))
+	require.NoError(t, db.Close())
+
+	// The file GAINS an id and new content.
+	require.NoError(t, os.WriteFile(notePath,
+		[]byte("---\nid: reference-foo\ntype: reference\ntitle: Foo\n---\n# Foo\n\nUpdated reference body.\n"), 0o644))
+	futureTime := time.Now().Add(10 * time.Second)
+	require.NoError(t, os.Chtimes(notePath, futureTime, futureTime))
+
+	// Re-index: must update (not error/skip).
+	result, err := idxr.Incremental()
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Errors, "no store error on id adoption")
+	assert.Empty(t, result.ErrorDetails, "no skipped-file error details")
+	assert.Equal(t, 1, result.Updated, "the note should be updated, not skipped")
+
+	db2, err := index.Open(dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db2.Close() }()
+
+	// New id resolves with updated content; old id gone; access carried forward.
+	var gotID, gotBody string
+	require.NoError(t, db2.QueryRow(
+		"SELECT id, body_text FROM notes WHERE path = ?", "references/foo.md").Scan(&gotID, &gotBody))
+	assert.Equal(t, newID, gotID)
+	assert.Contains(t, gotBody, "Updated reference body.")
+
+	var oldCount int
+	require.NoError(t, db2.QueryRow(
+		"SELECT COUNT(*) FROM notes WHERE id = ?", oldID).Scan(&oldCount))
+	assert.Equal(t, 0, oldCount, "stale _path: id must be gone after adoption")
+
+	var newAccesses int
+	require.NoError(t, db2.QueryRow(
+		"SELECT COUNT(*) FROM note_accesses WHERE note_id = ?", newID).Scan(&newAccesses))
+	assert.Equal(t, 1, newAccesses, "access history must survive the id adoption")
+}

--- a/internal/index/id_migration_whitebox_test.go
+++ b/internal/index/id_migration_whitebox_test.go
@@ -1,0 +1,126 @@
+package index
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// whiteboxDB opens a fresh migrated DB in a temp dir for in-package tests that
+// need to reach migrateNoteID's unexported error branches.
+func whiteboxDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := Open(filepath.Join(t.TempDir(), "wb.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// seedPathRow inserts a minimal stored row for path under oldID so a subsequent
+// store under a new id triggers the migration path.
+func seedPathRow(t *testing.T, db *DB, oldID, path string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO notes (id, path, hash, mtime, is_domain) VALUES (?, ?, 'h', 1, 0)`,
+		oldID, path)
+	require.NoError(t, err)
+}
+
+// TestMigrateNoteID_StoredLookupError covers storedIDForPath's error branch:
+// when the notes table is missing, the SELECT fails and the error propagates.
+func TestMigrateNoteID_StoredLookupError(t *testing.T) {
+	db := whiteboxDB(t)
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.Exec("DROP TABLE notes")
+	require.NoError(t, err)
+
+	err = migrateNoteID(tx, "references/foo.md", "reference-foo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "looking up stored id")
+}
+
+// TestMigrateNoteID_EvictDependentError covers evictOldIDDependents' error
+// branch: with a dependent table dropped, the eviction DELETE fails mid-migration.
+func TestMigrateNoteID_EvictDependentError(t *testing.T) {
+	db := whiteboxDB(t)
+	const oldID = "_path:references/foo.md"
+	const path = "references/foo.md"
+	seedPathRow(t, db, oldID, path)
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	// Drop the first dependent table so the eviction loop fails on it.
+	_, err = tx.Exec("DROP TABLE aliases")
+	require.NoError(t, err)
+
+	err = migrateNoteID(tx, path, "reference-foo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "evicting old id from aliases")
+}
+
+// TestMigrateNoteID_EvictLinksError covers the outbound-links eviction branch:
+// with links dropped (but the FK-dependent tables intact), the DELETE fails.
+func TestMigrateNoteID_EvictLinksError(t *testing.T) {
+	db := whiteboxDB(t)
+	const oldID = "_path:references/foo.md"
+	const path = "references/foo.md"
+	seedPathRow(t, db, oldID, path)
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.Exec("DROP TABLE links")
+	require.NoError(t, err)
+
+	err = migrateNoteID(tx, path, "reference-foo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outbound links")
+}
+
+// TestMigrateNoteID_AccessForwardError covers the note_accesses re-key branch:
+// dropping note_accesses makes the UPDATE fail after dependents are evicted.
+func TestMigrateNoteID_AccessForwardError(t *testing.T) {
+	db := whiteboxDB(t)
+	const oldID = "_path:references/foo.md"
+	const path = "references/foo.md"
+	seedPathRow(t, db, oldID, path)
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.Exec("DROP TABLE note_accesses")
+	require.NoError(t, err)
+
+	err = migrateNoteID(tx, path, "reference-foo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "note_accesses")
+}
+
+// TestMigrateNoteID_NoOpGuards confirms the early-return guards: no stored row,
+// or an unchanged id, are clean no-ops. Seeding happens BEFORE Begin() — under
+// WAL SQLite a single connection is held by the open tx, so a db.Exec issued
+// while the tx is live would deadlock on the connection pool.
+func TestMigrateNoteID_NoOpGuards(t *testing.T) {
+	db := whiteboxDB(t)
+	// Stored row whose id already equals the incoming id → must be a no-op.
+	seedPathRow(t, db, "reference-foo", "references/foo.md")
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	// No stored row for this path → no-op, no error.
+	require.NoError(t, migrateNoteID(tx, "references/missing.md", "reference-missing"))
+
+	// Stored row whose id already equals the incoming id → no-op, no error.
+	require.NoError(t, migrateNoteID(tx, "references/foo.md", "reference-foo"))
+}

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -74,13 +74,34 @@ func StoreNote(d *DB, rec NoteRecord) error {
 	return tx.Commit()
 }
 
+// pathIDDependentTables are the tables whose note_id column references
+// notes(id) and that StoreNoteInTx deletes-then-reinserts on every store.
+// migrateNoteID reuses this list to evict the OLD id's dependent rows during
+// an id migration so no orphans linger after the row is re-keyed. SSOT for
+// "what hangs off a note id" — keep aligned with StoreNoteInTx's delete loop.
+var pathIDDependentTables = []string{
+	"aliases", "tags", "frontmatter_kv", "blocks", "headings", "generated_sections",
+}
+
 // StoreNoteInTx stores a note within an existing transaction.
 // Used by Rebuild for batch transactions.
 func StoreNoteInTx(tx *sql.Tx, rec NoteRecord) error {
 	noteID := rec.ID
 
+	// A note first indexed WITHOUT a frontmatter id is stored under a
+	// path-derived `_path:<relpath>` id. When the file later GAINS a real id,
+	// this store carries a NEW id for the SAME path. A plain upsert would then
+	// INSERT a fresh row and hit `UNIQUE constraint failed: notes.path`, the
+	// note would be skipped, and search would keep serving the stale `_path:`
+	// row while content never updates (silent data loss). Treat this as an id
+	// MIGRATION: re-key the existing row and carry access history forward
+	// BEFORE the rest of the store proceeds under the new id.
+	if err := migrateNoteID(tx, rec.Path, noteID); err != nil {
+		return err
+	}
+
 	// Delete dependent rows first
-	for _, table := range []string{"aliases", "tags", "frontmatter_kv", "blocks", "headings", "generated_sections"} {
+	for _, table := range pathIDDependentTables {
 		if _, err := tx.Exec(fmt.Sprintf("DELETE FROM %s WHERE note_id = ?", table), noteID); err != nil {
 			return fmt.Errorf("deleting from %s: %w", table, err)
 		}
@@ -219,6 +240,76 @@ func upsertNote(tx *sql.Tx, rec NoteRecord) error {
 	)
 	if err != nil {
 		return fmt.Errorf("upserting note %q: %w", rec.ID, err)
+	}
+	return nil
+}
+
+// migrateNoteID re-keys an existing note row when the file at `path` now
+// declares a different id than the stored row (the `_path:` → real-id adoption
+// case). It is a no-op when there is no stored row for the path, or when the
+// stored id already equals newID.
+//
+// The migration is transactional and carries note_accesses (activation/recall
+// history) forward to the new id; the scalar access columns survive implicitly
+// because the notes row is updated in place rather than replaced. The OLD id's
+// dependent rows are evicted here so the row's id can be re-keyed without
+// orphaning them — StoreNoteInTx re-inserts them fresh under the new id.
+//
+// FK enforcement is deferred to commit (defer_foreign_keys) so the parent
+// notes row and the child note_accesses rows can be re-keyed in the same
+// transaction regardless of statement order; both reference the new id by the
+// time the transaction commits.
+func migrateNoteID(tx *sql.Tx, path, newID string) error {
+	oldID, err := storedIDForPath(tx, path)
+	if err != nil || oldID == "" || oldID == newID {
+		return err
+	}
+
+	if _, err := tx.Exec("PRAGMA defer_foreign_keys=ON"); err != nil {
+		return fmt.Errorf("deferring foreign keys for id migration: %w", err)
+	}
+	if err := evictOldIDDependents(tx, oldID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec("UPDATE note_accesses SET note_id = ? WHERE note_id = ?", newID, oldID); err != nil {
+		return fmt.Errorf("carrying note_accesses forward to %q: %w", newID, err)
+	}
+	if _, err := tx.Exec("UPDATE notes SET id = ? WHERE id = ?", newID, oldID); err != nil {
+		return fmt.Errorf("re-keying note id %q -> %q: %w", oldID, newID, err)
+	}
+	return nil
+}
+
+// storedIDForPath returns the id currently stored for path, or "" when no row
+// exists for it. A missing row is not an error — it is the common new-file case.
+func storedIDForPath(tx *sql.Tx, path string) (string, error) {
+	var id string
+	err := tx.QueryRow("SELECT id FROM notes WHERE path = ?", path).Scan(&id)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("looking up stored id for path %q: %w", path, err)
+	}
+	return id, nil
+}
+
+// evictOldIDDependents removes every dependent row keyed to oldID so the note
+// row can be re-keyed without orphaning them. Outbound links and the FTS row
+// key on columns outside pathIDDependentTables, so they are deleted explicitly.
+// Inbound links (dst_note_id = oldID) belong to OTHER notes and are left for
+// ResolveLinks to re-point at the new id.
+func evictOldIDDependents(tx *sql.Tx, oldID string) error {
+	for _, table := range pathIDDependentTables {
+		if _, err := tx.Exec(fmt.Sprintf("DELETE FROM %s WHERE note_id = ?", table), oldID); err != nil {
+			return fmt.Errorf("evicting old id from %s: %w", table, err)
+		}
+	}
+	if _, err := tx.Exec("DELETE FROM links WHERE src_note_id = ?", oldID); err != nil {
+		return fmt.Errorf("evicting old id outbound links: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM fts_notes WHERE note_id = ?", oldID); err != nil {
+		return fmt.Errorf("evicting old id fts row: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
HIGH dogfood bug (workhorse): a note first indexed without a frontmatter id (stored under `_path:<relpath>`) that LATER gains an id hit `UNIQUE notes.path` on re-index → 'skipping file with store error' → silent stale retrieval, doctor blind. Fix: `migrateNoteID` as the first step of StoreNoteInTx treats a path-collision-with-new-id as an id MIGRATION — re-keys the notes row in place (scalar access cols survive), carries `note_accesses` forward, evicts old-id dependents, transactional via `defer_foreign_keys`. Black-box spec + e2e incremental + white-box error-branch tests. task check green (23/23, 86.91%), reviewed (migrateNoteID transactional logic sound).