### PR TITLE
fix(doctor): text rollup counts the surfaced issue set, not the validation aggregate

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -243,15 +243,15 @@ func writeDoctorHuman(w io.Writer, result *query.DoctorResult, summaryOnly bool)
 	if err := writeStaleIndex(w, &result.Issues, summaryOnly); err != nil {
 		return err
 	}
-	// Errors/warnings rollup — the cold-start signal `vault status` used to
-	// emit. Always printed so the operator gets the validation bottom line
-	// from a single `doctor` run. runDoctorCore always sets IssuesSummary, but
-	// read nil-safely (0/0) so a future raw-result caller can't panic here.
-	var errCount, warnCount int
-	if result.IssuesSummary != nil {
-		errCount = result.IssuesSummary.Errors
-		warnCount = result.IssuesSummary.Warnings
-	}
+	// Errors/warnings rollup — the cold-start bottom line. Counts come from
+	// query.SurfacedIssueCounts (SSOT) over the SURFACED result.Issues set, so
+	// the text rollup always agrees with --json. It deliberately does NOT read
+	// result.IssuesSummary: that schema-validation AGGREGATE counts findings
+	// doctor never renders as text lines (and which the --json envelope's
+	// surfaced warnings/errors arrays do not count), which previously
+	// overstated warnings (e.g. "0 errors, 96 warnings") against a --json that
+	// surfaced none. result.issues_summary stays in --json untouched.
+	errCount, warnCount := query.SurfacedIssueCounts(result.Issues)
 	if _, err := fmt.Fprintf(w, "Issues: %d errors, %d warnings\n", errCount, warnCount); err != nil {
 		return err
 	}

--- a/cmd/doctor_rollup_count_test.go
+++ b/cmd/doctor_rollup_count_test.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/index"
+	"github.com/peiman/vaultmind/internal/vault"
+	"github.com/stretchr/testify/require"
+)
+
+// issuesLineRE captures the two counts the TEXT rollup prints:
+// "Issues: <errors> errors, <warnings> warnings".
+var issuesLineRE = regexp.MustCompile(`Issues: (\d+) errors, (\d+) warnings`)
+
+// jsonSurfacedIssues mirrors the result.issues block of the doctor --json
+// envelope — the surfaced-issue set that is the source of truth for the text
+// rollup. Only the count fields that SurfacedIssueCounts reads are decoded.
+type jsonSurfacedIssues struct {
+	Result struct {
+		Issues struct {
+			DuplicateIDs              int  `json:"duplicate_ids"`
+			BrokenReferences          int  `json:"broken_references"`
+			MissingRequiredFields     int  `json:"missing_required_fields"`
+			MalformedMarkers          int  `json:"malformed_markers"`
+			UnresolvedLinks           int  `json:"unresolved_links"`
+			NotesMissingIDOrType      int  `json:"notes_missing_id_or_type"`
+			ObsidianIncompatibleLinks int  `json:"obsidian_incompatible_links"`
+			PathPseudoIDLinks         int  `json:"path_pseudo_id_links"`
+			StaleIndex                int  `json:"stale_index"`
+			HookDrift                 int  `json:"hook_drift"`
+			LegacyHooksJSON           bool `json:"legacy_hooks_json"`
+		} `json:"issues"`
+		IssuesSummary struct {
+			Warnings int `json:"warnings"`
+		} `json:"issues_summary"`
+	} `json:"result"`
+}
+
+// surfacedErrWarn classifies the --json result.issues block the same way the
+// SSOT helper does, so the test asserts against an INDEPENDENTLY computed count
+// rather than re-using the production helper's arithmetic.
+func (j jsonSurfacedIssues) surfacedErrWarn() (errs, warns int) {
+	i := j.Result.Issues
+	errs = i.DuplicateIDs + i.MissingRequiredFields + i.MalformedMarkers +
+		i.NotesMissingIDOrType + i.PathPseudoIDLinks
+	warns = i.UnresolvedLinks + i.BrokenReferences + i.ObsidianIncompatibleLinks +
+		i.StaleIndex + i.HookDrift
+	if i.LegacyHooksJSON {
+		warns++
+	}
+	return errs, warns
+}
+
+// chdirToTemp moves the test process into a fresh tempdir with no .claude/
+// ancestor, so doctor's project-root hook-drift detection cannot fire and the
+// surfaced-issue set is determined solely by vault content. Restores CWD on
+// cleanup. Not parallel-safe — these tests must not call t.Parallel().
+func chdirToTemp(t *testing.T) {
+	t.Helper()
+	old, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(t.TempDir()))
+	t.Cleanup(func() { _ = os.Chdir(old) })
+}
+
+// buildValidationWarningVault creates a vault whose ONLY health findings are
+// schema-validation warnings (unknown_type) — findings the doctor TEXT renderer
+// does NOT surface as per-item lines. This is the exact shape that produced the
+// reported divergence: TEXT "Issues: 0 errors, N warnings" while --json's
+// surfaced result.issues block is all zero (the validation warnings live only
+// in the nested result.issues_summary aggregate).
+func buildValidationWarningVault(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".vaultmind"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".vaultmind", "config.yaml"), []byte(`
+types:
+  concept:
+    required: [title]
+`), 0o644))
+	for i, name := range []string{"a", "b", "c"} {
+		writeTestNote(t, dir, fmt.Sprintf("%s.md", name), fmt.Sprintf(
+			"---\nid: note-%s\ntype: mystery-%d\ntitle: Note %s\n---\nbody\n", name, i, name))
+	}
+
+	cfg, err := vault.LoadConfig(dir)
+	require.NoError(t, err)
+	dbPath := filepath.Join(dir, cfg.Index.DBPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	_, err = index.NewIndexer(dir, dbPath, cfg).Rebuild()
+	require.NoError(t, err)
+	return dir
+}
+
+func readTextIssueCounts(t *testing.T, vault string) (errs, warns int, raw string) {
+	t.Helper()
+	textOut, _, err := runRootCmd(t, "doctor", "--vault", vault)
+	require.NoError(t, err)
+	raw = textOut.String()
+	m := issuesLineRE.FindStringSubmatch(raw)
+	require.NotNil(t, m, "TEXT rollup must print an Issues: line; got:\n%s", raw)
+	errs, _ = strconv.Atoi(m[1])
+	warns, _ = strconv.Atoi(m[2])
+	return errs, warns, raw
+}
+
+func readJSONSurfaced(t *testing.T, vault string) jsonSurfacedIssues {
+	t.Helper()
+	jsonOut, _, err := runRootCmd(t, "doctor", "--vault", vault, "--json")
+	require.NoError(t, err)
+	var j jsonSurfacedIssues
+	require.NoError(t, json.Unmarshal(jsonOut.Bytes(), &j))
+	return j
+}
+
+// TestDoctor_TextRollupCounts_MatchJSONSurfacedSet asserts the TEXT rollup's
+// "Issues:" counts equal the --json source of truth (the surfaced result.issues
+// block), for a vault whose only findings are schema-validation warnings the
+// TEXT renderer never surfaces as lines.
+//
+// Before the fix the TEXT rollup read result.issues_summary (the validation
+// AGGREGATE: 3 unknown_type warnings) while the surfaced result.issues block
+// was all zero, so the TEXT count OVERSTATED warnings no text line backed —
+// and the aggregate stayed visible in --json's result.issues_summary, proving
+// the two counts came from different sets.
+func TestDoctor_TextRollupCounts_MatchJSONSurfacedSet(t *testing.T) {
+	chdirToTemp(t)
+	vault := buildValidationWarningVault(t)
+
+	textErrors, textWarnings, _ := readTextIssueCounts(t, vault)
+	j := readJSONSurfaced(t, vault)
+	jsonErrors, jsonWarnings := j.surfacedErrWarn()
+
+	require.Equal(t, jsonErrors, textErrors,
+		"TEXT error count must equal --json surfaced result.issues errors")
+	require.Equal(t, jsonWarnings, textWarnings,
+		"TEXT warning count must equal --json surfaced result.issues warnings")
+
+	// Document the divergence the fix closes: the validation aggregate is
+	// non-zero in --json yet the surfaced counts (and now the text) are zero.
+	require.Equal(t, 3, j.Result.IssuesSummary.Warnings,
+		"validation aggregate still reports 3 warnings in --json")
+	require.Equal(t, 0, textWarnings,
+		"text must report the surfaced count (0), not the validation aggregate (3)")
+	require.Equal(t, 0, textErrors, "no surfaced errors")
+}
+
+// TestDoctor_TextRollupCounts_ReflectSurfacedItems proves the rollup tracks
+// REAL surfaced issues: a stale-index drift is surfaced both as a text line and
+// counted as a warning, and the text count equals the --json surfaced count.
+// This guards against a fix that simply hard-codes 0/0.
+func TestDoctor_TextRollupCounts_ReflectSurfacedItems(t *testing.T) {
+	chdirToTemp(t)
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".vaultmind"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".vaultmind", "config.yaml"), []byte(`
+types:
+  concept:
+    required: [title]
+`), 0o644))
+	notePath := filepath.Join(dir, "a.md")
+	writeTestNote(t, dir, "a.md", "---\nid: note-a\ntype: concept\ntitle: A\n---\noriginal body\n")
+
+	cfg, err := vault.LoadConfig(dir)
+	require.NoError(t, err)
+	dbPath := filepath.Join(dir, cfg.Index.DBPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+	_, err = index.NewIndexer(dir, dbPath, cfg).Rebuild()
+	require.NoError(t, err)
+
+	// Edit the note AFTER indexing so its content hash drifts from the stored
+	// hash => a surfaced stale-index warning the text report renders as a line.
+	require.NoError(t, os.WriteFile(notePath,
+		[]byte("---\nid: note-a\ntype: concept\ntitle: A\n---\nEDITED body, hash now differs\n"), 0o644))
+
+	textErrors, textWarnings, raw := readTextIssueCounts(t, dir)
+	j := readJSONSurfaced(t, dir)
+	jsonErrors, jsonWarnings := j.surfacedErrWarn()
+
+	require.Equal(t, jsonErrors, textErrors, "TEXT errors must equal --json surfaced errors")
+	require.Equal(t, jsonWarnings, textWarnings, "TEXT warnings must equal --json surfaced warnings")
+	require.Greater(t, jsonErrors+jsonWarnings, 0,
+		"this vault must surface at least one issue so the test is non-vacuous")
+	require.Contains(t, raw, "Stale index:",
+		"the surfaced stale-index drift must also appear as a text detail line")
+}

--- a/internal/query/doctor.go
+++ b/internal/query/doctor.go
@@ -123,6 +123,44 @@ type DoctorIssues struct {
 	LegacyHooksJSON bool `json:"legacy_hooks_json"`
 }
 
+// SurfacedIssueCounts returns the error and warning counts for the issues a
+// doctor run actually SURFACES — the items in DoctorIssues that the human
+// report renders as detail lines and that the --json envelope represents. It
+// is the single source of truth for the "Issues: E errors, W warnings" text
+// rollup so that count can never again disagree with --json.
+//
+// It deliberately does NOT fold in DoctorResult.IssuesSummary (the schema
+// VALIDATION aggregate from SummarizeValidationIssues). That aggregate counts
+// findings — unknown_type, invalid_status, broken_reference — that doctor
+// surfaces only in the nested result.issues_summary JSON field, never as a
+// per-item line in the text report. Counting it in the text rollup overstated
+// warnings (e.g. "0 errors, 96 warnings") against a --json envelope that
+// surfaced none. result.issues_summary stays in --json unchanged; this helper
+// only governs the surfaced-set rollup.
+//
+// Severity follows the doctor renderer's own framing: integrity violations
+// that mean data is wrong are errors; advisories that mean the vault is
+// degraded-but-usable are warnings.
+func SurfacedIssueCounts(issues DoctorIssues) (errors, warnings int) {
+	// Errors — hard integrity violations.
+	errors = issues.DuplicateIDs +
+		issues.MissingRequiredFields +
+		issues.MalformedMarkers +
+		issues.NotesMissingIDOrType +
+		issues.PathPseudoIDLinks // dead links: target file does not exist
+
+	// Warnings — surfaced advisories the vault still functions despite.
+	warnings = issues.UnresolvedLinks +
+		issues.BrokenReferences +
+		issues.ObsidianIncompatibleLinks +
+		issues.StaleIndex +
+		issues.HookDrift
+	if issues.LegacyHooksJSON {
+		warnings++
+	}
+	return errors, warnings
+}
+
 // ContentDrift describes one note whose current file content hash
 // differs from the indexer's stored hash.
 type ContentDrift struct {

--- a/internal/query/doctor_surfaced_counts_test.go
+++ b/internal/query/doctor_surfaced_counts_test.go
@@ -1,0 +1,67 @@
+package query
+
+import "testing"
+
+// TestSurfacedIssueCounts pins the severity classification of the SURFACED
+// doctor issue set — the single source of truth for the "Issues: E errors, W
+// warnings" text rollup. It must count the items doctor actually renders, never
+// the schema-validation aggregate (which the text report does not surface).
+func TestSurfacedIssueCounts(t *testing.T) {
+	tests := []struct {
+		name         string
+		issues       DoctorIssues
+		wantErrors   int
+		wantWarnings int
+	}{
+		{
+			name:         "empty => zero",
+			issues:       DoctorIssues{},
+			wantErrors:   0,
+			wantWarnings: 0,
+		},
+		{
+			name: "integrity violations count as errors",
+			issues: DoctorIssues{
+				DuplicateIDs:          1,
+				MissingRequiredFields: 2,
+				MalformedMarkers:      3,
+				NotesMissingIDOrType:  4,
+				PathPseudoIDLinks:     5,
+			},
+			wantErrors:   15,
+			wantWarnings: 0,
+		},
+		{
+			name: "advisories count as warnings",
+			issues: DoctorIssues{
+				UnresolvedLinks:           1,
+				BrokenReferences:          2,
+				ObsidianIncompatibleLinks: 3,
+				StaleIndex:                4,
+				HookDrift:                 5,
+				LegacyHooksJSON:           true,
+			},
+			wantErrors:   0,
+			wantWarnings: 16,
+		},
+		{
+			name: "legacy hooks json adds exactly one warning",
+			issues: DoctorIssues{
+				LegacyHooksJSON: true,
+			},
+			wantErrors:   0,
+			wantWarnings: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErrors, gotWarnings := SurfacedIssueCounts(tc.issues)
+			if gotErrors != tc.wantErrors {
+				t.Errorf("errors = %d, want %d", gotErrors, tc.wantErrors)
+			}
+			if gotWarnings != tc.wantWarnings {
+				t.Errorf("warnings = %d, want %d", gotWarnings, tc.wantWarnings)
+			}
+		})
+	}
+}


### PR DESCRIPTION
LOW dogfood bug (workhorse): `doctor` text said e.g. '0 errors, 96 warnings' with no per-item lines while `doctor --json` said warnings:0 — the text counter counted the schema-validation aggregate, not the surfaced issues. Fix: `query.SurfacedIssueCounts(DoctorIssues)` as the single source of truth (counts the surfaced result.Issues, severity-classified); text rollup now derives counts from it, matching --json. Table-driven test pins the classification. task check green.