### PR TITLE
fix(heal): rewrite id-form wikilinks doctor flags as Obsidian-incompatible

### DIFF
--- a/cmd/doctor_heal_test.go
+++ b/cmd/doctor_heal_test.go
@@ -184,9 +184,10 @@ func TestDoctorHeal_DryRunDoesNotWarnStaleIndex(t *testing.T) {
 // A heal that changed zero files (already-clean vault) must NOT warn about a
 // stale index (M2).
 func TestDoctorHeal_NoWarnWhenZeroChanges(t *testing.T) {
-	// buildIndexedTestVault's links are already filename/alias form, so heal
-	// finds nothing to fix → zero files changed.
-	vault := buildIndexedTestVault(t)
+	// This vault's only link is already filename-stem form ([[beta]] → beta.md),
+	// so heal finds nothing to fix → zero files changed. (The shared
+	// buildIndexedTestVault deliberately carries id-form links heal now fixes.)
+	vault := buildCleanIndexedTestVault(t)
 	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault, "--json")
 	require.NoError(t, err)
 

--- a/cmd/memory_coverage_test.go
+++ b/cmd/memory_coverage_test.go
@@ -280,7 +280,7 @@ func TestFormatContextPack_WithTarget(t *testing.T) {
 // nothing was written. This pins the "zero changes" branch of runWikilinkFix
 // human output.
 func TestDoctorHeal_ZeroChangesHumanOutputNoStaleWarning(t *testing.T) {
-	vault := buildIndexedTestVault(t)
+	vault := buildCleanIndexedTestVault(t)
 	out, _, err := runRootCmd(t, "doctor", "heal", "--vault", vault)
 	require.NoError(t, err)
 

--- a/cmd/remaining_runners_test.go
+++ b/cmd/remaining_runners_test.go
@@ -227,9 +227,13 @@ func TestParseFieldSlice(t *testing.T) {
 	assert.Equal(t, map[string]string{"k": "v=w"}, parseFieldSlice([]string{"k=v=w"}))
 }
 
-// lint fix-links on a clean vault reports zero changes. Regression: a false
-// positive here would make every "lint" run claim it fixed something.
-func TestLintFixLinks_CleanVaultReportsNoChanges(t *testing.T) {
+// lint fix-links reconciles with doctor: every link doctor flags as
+// Obsidian-incompatible must be fixable by the healer. The shared fixture
+// vault carries two id-form links doctor flags — concepts/alpha.md's
+// [[proj-beta|Beta]] and projects/beta.md's [[concept-alpha]] — so a dry-run
+// must report exactly those (FilesScanned>0 to prove the scan ran). Before the
+// id-form fix this reported 0, the doctor/heal contradiction in the bug report.
+func TestLintFixLinks_FlaggedIDLinksAreFixable(t *testing.T) {
 	vault := buildIndexedTestVault(t)
 	out, _, err := runRootCmd(t, "lint", "fix-links", "--vault", vault, "--json")
 	require.NoError(t, err)
@@ -243,8 +247,8 @@ func TestLintFixLinks_CleanVaultReportsNoChanges(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
 	assert.Greater(t, env.Result.FilesScanned, 0)
-	assert.Equal(t, 0, env.Result.FilesChanged)
-	assert.Equal(t, 0, env.Result.LinksFixed)
+	assert.Equal(t, 2, env.Result.FilesChanged)
+	assert.Equal(t, 2, env.Result.LinksFixed)
 }
 
 // lint fix-links human output (non-JSON mode) surfaces the mode tag and the

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -90,6 +90,52 @@ func writeTestNote(t *testing.T, vaultRoot, relPath, content string) {
 	require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
 }
 
+// buildCleanIndexedTestVault creates an indexed vault whose only wikilink is
+// already Obsidian-compatible (the link target equals the target note's
+// filename stem), so the wikilink healer makes zero changes. Tests that pin
+// the "zero changes" heal branch need this — the shared buildIndexedTestVault
+// deliberately carries id-form links that doctor flags and heal now fixes.
+func buildCleanIndexedTestVault(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".vaultmind"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".vaultmind", "config.yaml"), []byte(`
+types:
+  concept:
+    required: [title]
+    optional: [tags, related_ids]
+`), 0o644))
+
+	// Target note: filename stem "beta" equals the link target below.
+	writeTestNote(t, dir, "concepts/beta.md", `---
+id: concept-beta
+type: concept
+title: Beta Concept
+---
+Beta body, no links.
+`)
+	// Source note links by filename stem [[beta]] — already compatible.
+	writeTestNote(t, dir, "concepts/alpha.md", `---
+id: concept-alpha
+type: concept
+title: Alpha Concept
+---
+Alpha body. See [[beta]] for context.
+`)
+
+	cfg, err := vault.LoadConfig(dir)
+	require.NoError(t, err)
+	dbPath := filepath.Join(dir, cfg.Index.DBPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+
+	idxr := index.NewIndexer(dir, dbPath, cfg)
+	_, err = idxr.Rebuild()
+	require.NoError(t, err, "indexer rebuild failed")
+
+	return dir
+}
+
 // copyBaselineVaultToTemp copies the committed baseline fixture vault into
 // a tempdir so tests can index it without mutating the source tree. The
 // committed fixture has no index.db (SQLite files aren't committed); tests

--- a/internal/mutation/lint.go
+++ b/internal/mutation/lint.go
@@ -25,13 +25,19 @@ type LinkFixDetail struct {
 	NewLink string `json:"new_link"`
 }
 
-// wikilinkRe matches [[Target]] but not [[file|display]] (no | inside).
-var wikilinkRe = regexp.MustCompile(`\[\[([^\]|]+)\]\]`)
+// wikilinkRe matches [[Target]] and [[Target|Display]]. Group 1 is the link
+// target (the part before any |); group 2 (optional) wraps |Display and group
+// 3 is the display text. Both forms are matched because doctor flags an
+// id-form link as Obsidian-incompatible whether or not it carries a |display,
+// so the healer must rewrite both to fix exactly what doctor flags. The #
+// exclusion leaves heading/block-anchor links ([[Target#Heading]]) untouched.
+var wikilinkRe = regexp.MustCompile(`\[\[([^\]|#]+?)(\|([^\]]*))?\]\]`)
 
-// FixWikilinks scans all .md files in vaultPath and rewrites [[Title]] to
-// [[filename|Title]] wherever Title resolves to a note whose filename stem
-// differs from the link target. When fix is false the function performs a
-// dry-run: it counts and records changes but does not write any files.
+// FixWikilinks scans all .md files in vaultPath and rewrites [[Target]] to
+// [[filename|Target]] (and [[Target|Display]] to [[filename|Display]])
+// wherever Target resolves to a note whose filename stem differs from the link
+// target. When fix is false the function performs a dry-run: it counts and
+// records changes but does not write any files.
 func FixWikilinks(db *index.DB, vaultPath string, fix bool) (*FixWikilinksResult, error) {
 	titleToStem, err := buildTitleStemMap(db)
 	if err != nil {
@@ -91,8 +97,13 @@ func FixWikilinks(db *index.DB, vaultPath string, fix bool) (*FixWikilinksResult
 	return result, nil
 }
 
-// buildTitleStemMap queries the index and returns a map from title/alias to
-// the filename stem (basename without .md extension) of the note's file.
+// buildTitleStemMap queries the index and returns a map from any wikilink
+// target form — note id, title, or alias — to the filename stem (basename
+// without .md extension) of the note's file. ids are included so the healer
+// rewrites the id-form links ([[reference-foo]]) that doctor flags as
+// Obsidian-incompatible; without them the two disagreed and heal fixed 0.
+// ids take precedence over titles/aliases on collision (Obsidian resolves a
+// bare [[id]] to that note's file).
 func buildTitleStemMap(db *index.DB) (map[string]string, error) {
 	m := make(map[string]string)
 
@@ -137,7 +148,34 @@ func buildTitleStemMap(db *index.DB) (map[string]string, error) {
 		return nil, fmt.Errorf("iterating aliases: %w", err)
 	}
 
+	if err := addIDStems(db, m); err != nil {
+		return nil, err
+	}
+
 	return m, nil
+}
+
+// addIDStems maps every note id to its filename stem, overwriting any
+// title/alias entry that collides. Obsidian resolves a bare [[id]] against the
+// note's file, so the id form is authoritative — this is what reconciles the
+// healer with doctor's incompatible-link flag (both key on the link target).
+func addIDStems(db *index.DB, m map[string]string) error {
+	idRows, err := db.Query("SELECT id, path FROM notes")
+	if err != nil {
+		return fmt.Errorf("querying note ids: %w", err)
+	}
+	defer func() { _ = idRows.Close() }()
+	for idRows.Next() {
+		var id, path string
+		if err := idRows.Scan(&id, &path); err != nil {
+			return fmt.Errorf("scanning note id: %w", err)
+		}
+		m[id] = strings.TrimSuffix(filepath.Base(path), ".md")
+	}
+	if err := idRows.Err(); err != nil {
+		return fmt.Errorf("iterating note ids: %w", err)
+	}
+	return nil
 }
 
 // splitBody splits raw file content into the frontmatter prefix and the body.
@@ -167,23 +205,31 @@ func splitBody(raw []byte) (body []byte, bodyStart int) {
 	return []byte(s[bodyStart:]), bodyStart
 }
 
-// rewriteLinks rewrites [[Target]] → [[stem|Target]] in body text when Target
-// is in the title/alias map and stem != Target. Returns the modified body and
-// a slice of details (one per rewrite).
+// rewriteLinks rewrites incompatible wikilinks in body text. A bare
+// [[Target]] becomes [[stem|Target]]; an aliased [[Target|Display]] becomes
+// [[stem|Display]], preserving the display text (per the wikilink convention
+// [[filename|Display Text]]). A link is rewritten only when Target resolves
+// via the id/title/alias map to a note whose filename stem differs from
+// Target. Returns the modified body and one detail per rewrite.
 func rewriteLinks(body []byte, titleToStem map[string]string) ([]byte, []LinkFixDetail) {
 	var details []LinkFixDetail
 
 	result := wikilinkRe.ReplaceAllFunc(body, func(match []byte) []byte {
-		// Extract inner target (the regex guarantees group 1 exists)
-		inner := string(match[2 : len(match)-2]) // strip [[ and ]]
-		stem, ok := titleToStem[inner]
-		if !ok {
-			return match // unknown — leave as-is
+		// Re-match to recover the target (group 1) and optional display alias
+		// (group 3). match is a single full match, so this always succeeds.
+		groups := wikilinkRe.FindSubmatch(match)
+		target := string(groups[1])
+		stem, ok := titleToStem[target]
+		if !ok || stem == target {
+			return match // unknown or already compatible — leave as-is
 		}
-		if stem == inner {
-			return match // already compatible
+		// Preserve an explicit display alias; otherwise fall back to the
+		// original target text as the display (keeps the link readable).
+		display := target
+		if groups[2] != nil {
+			display = string(groups[3])
 		}
-		newLink := "[[" + stem + "|" + inner + "]]"
+		newLink := "[[" + stem + "|" + display + "]]"
 		details = append(details, LinkFixDetail{
 			OldLink: string(match),
 			NewLink: newLink,

--- a/internal/mutation/lint_test.go
+++ b/internal/mutation/lint_test.go
@@ -240,6 +240,47 @@ func TestFixWikilinks_PopulatesDetails(t *testing.T) {
 	assert.Equal(t, "[[eta|Eta Note]]", result.Details[0].NewLink)
 }
 
+// TestFixWikilinks_RewritesIDFormLinks reproduces the doctor/heal
+// contradiction: doctor flags [[reference-foo]] (id-form) links as
+// Obsidian-incompatible (the link target is the note's id but its filename
+// stem differs), yet heal rewrites 0 of them. The healer must rewrite BOTH the
+// bare id-link and the ALIASED id-link [[reference-foo|Pattern 2c]], and the
+// aliased one must KEEP its display text (per [[wikilink_convention]]:
+// [[filename|Display Text]]).
+func TestFixWikilinks_RewritesIDFormLinks(t *testing.T) {
+	db, dir := buildLintTestDB(t)
+
+	vaultDir := filepath.Join(dir, "vault")
+	require.NoError(t, os.MkdirAll(filepath.Join(vaultDir, "references"), 0o755))
+
+	// Target note: id "reference-foo" lives at references/foo.md → stem "foo"
+	// differs from the id, so [[reference-foo]] is Obsidian-incompatible.
+	_, err := db.Exec(
+		"INSERT INTO notes (id, path, title, hash, mtime, is_domain) VALUES (?, ?, ?, ?, ?, ?)",
+		"reference-foo", "references/foo.md", "Foo Reference", "idform1", 0, true,
+	)
+	require.NoError(t, err)
+
+	// Source note: (a) bare id-link, (b) aliased id-link with a display alias.
+	noteContent := "---\nid: concept-idsrc\ntype: concept\ntitle: IDSrc\n---\n\n" +
+		"Bare: [[reference-foo]] and aliased: [[reference-foo|Pattern 2c]].\n"
+	notePath := filepath.Join(vaultDir, "references", "idsrc.md")
+	require.NoError(t, os.WriteFile(notePath, []byte(noteContent), 0o644))
+
+	result, err := mutation.FixWikilinks(db, vaultDir, true)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, result.LinksFixed, 2, "both id-form links must be rewritten")
+
+	content, err := os.ReadFile(notePath)
+	require.NoError(t, err)
+	// Bare id-link: display falls back to the original target.
+	assert.Contains(t, string(content), "[[foo|reference-foo]]")
+	// Aliased id-link: display alias "Pattern 2c" MUST be preserved.
+	assert.Contains(t, string(content), "[[foo|Pattern 2c]]")
+	assert.NotContains(t, string(content), "[[reference-foo]]")
+	assert.NotContains(t, string(content), "[[reference-foo|Pattern 2c]]")
+}
+
 func TestFixWikilinks_EmptyVault(t *testing.T) {
 	db, dir := buildLintTestDB(t)
 


### PR DESCRIPTION
MEDIUM dogfood bug (workhorse): `doctor heal wikilinks` fixed 0 of the `[[note-id]]`-form links doctor itself flags (healer only matched `[[Title]]`-form), and dropped the display alias on aliased id-links. Fix reconciles heal with doctor (both key on the link target): buildTitleStemMap also maps id→stem (ids win), wikilinkRe matches `[[Target]]` and `[[Target|Display]]` preserving the alias (`[[reference-foo|Pattern 2c]]`→`[[foo|Pattern 2c]]`), heading/block links untouched. Two cmd tests that encoded the bug repurposed + a clean fixture added. task check green, reviewed (cmd-test changes legit).