### PR TITLE
feat(identity): enroll member-journey command (Contract-B)

### DIFF
--- a/.ckeletin/pkg/config/keys_generated.go
+++ b/.ckeletin/pkg/config/keys_generated.go
@@ -130,6 +130,14 @@ const (
 	KeyAppHooksuninstallJson                 = "app.hooksuninstall.json"                  // Output in JSON format
 	KeyAppHooksuninstallLocal                = "app.hooksuninstall.local"                 // Target .claude/settings.local.json instead of .claude/settings.json.
 	KeyAppHooksuninstallRemovescripts        = "app.hooksuninstall.removescripts"         // Also delete the installed hook scripts under .claude/scripts/ (default: leave...
+	KeyAppIdentityenrollInvite               = "app.identityenroll.invite"                // Network invite: a vmenroll1: token or enroll URL (required)
+	KeyAppIdentityenrollDisplayName          = "app.identityenroll.display_name"          // Your display name in the network (required; Unicode NFC)
+	KeyAppIdentityenrollSlug                 = "app.identityenroll.slug"                  // Your short ASCII handle/slug (required)
+	KeyAppIdentityenrollPubkey               = "app.identityenroll.pubkey"                // Your base64-std ed25519 identity pubkey from `identity init` (required)
+	KeyAppIdentityenrollTransportPubkey      = "app.identityenroll.transport_pubkey"      // Your base64-std 32-byte WireGuard pubkey from `wg pubkey` (required)
+	KeyAppIdentityenrollTransportEndpoint    = "app.identityenroll.transport_endpoint"    // Optional reachable host:port (IPv6 bracketed); omitted when empty
+	KeyAppIdentityenrollSignerSocket         = "app.identityenroll.signer_socket"         // Signer socket path (default: XDG state dir)
+	KeyAppIdentityenrollYes                  = "app.identityenroll.yes"                   // Skip the out-of-band fingerprint confirmation prompt
 	KeyAppIdentityinitSignerKey              = "app.identityinit.signer_key"              // Sealed signer key path (default: XDG data dir)
 	KeyAppIdentityinviteRootPubkey           = "app.identityinvite.root_pubkey"           // Network ROOT public key (base64-std of the 32-byte ed25519 key; required)
 	KeyAppIdentityinviteRelay                = "app.identityinvite.relay"                 // Relay base URL, e.g. https://chat.acme.com (required)

--- a/cmd/identity_enroll.go
+++ b/cmd/identity_enroll.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/identitycli"
+	"github.com/spf13/cobra"
+)
+
+var identityEnrollCmd = MustNewCommand(commands.IdentityEnrollMetadata, runIdentityEnroll)
+
+func init() {
+	identityCmd.AddCommand(identityEnrollCmd)
+	setupCommandConfig(identityEnrollCmd)
+}
+
+func runIdentityEnroll(cmd *cobra.Command, _ []string) error {
+	sockPath := getConfigValueWithFlags[string](cmd, "signer-socket", config.KeyAppIdentityenrollSignerSocket)
+	if sockPath == "" {
+		p, err := defaultSignerSocketPath()
+		if err != nil {
+			return fmt.Errorf("resolving signer socket path: %w", err)
+		}
+		sockPath = p
+	}
+	cfg := identitycli.EnrollConfig{
+		InviteTokenOrURL:   getConfigValueWithFlags[string](cmd, "invite", config.KeyAppIdentityenrollInvite),
+		DisplayName:        getConfigValueWithFlags[string](cmd, "display-name", config.KeyAppIdentityenrollDisplayName),
+		Slug:               getConfigValueWithFlags[string](cmd, "slug", config.KeyAppIdentityenrollSlug),
+		PubKeyB64:          getConfigValueWithFlags[string](cmd, "pubkey", config.KeyAppIdentityenrollPubkey),
+		TransportPubKeyB64: getConfigValueWithFlags[string](cmd, "transport-pubkey", config.KeyAppIdentityenrollTransportPubkey),
+		TransportEndpoint:  getConfigValueWithFlags[string](cmd, "transport-endpoint", config.KeyAppIdentityenrollTransportEndpoint),
+		SignerSocket:       sockPath,
+		AssumeYes:          getConfigValueWithFlags[bool](cmd, "yes", config.KeyAppIdentityenrollYes),
+	}
+	return identitycli.Enroll(cmd.OutOrStdout(), cmd.ErrOrStderr(), cmd.InOrStdin(), cfg)
+}

--- a/cmd/identity_test.go
+++ b/cmd/identity_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,9 +14,11 @@ import (
 	"time"
 
 	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/enrollment"
 	"github.com/peiman/vaultmind/internal/identity/envelope"
 	"github.com/peiman/vaultmind/internal/identity/invite"
 	"github.com/peiman/vaultmind/internal/identity/registry"
+	"github.com/peiman/vaultmind/internal/identity/relayclient"
 	"github.com/peiman/vaultmind/internal/identity/signer"
 	"github.com/peiman/vaultmind/internal/identitycli"
 )
@@ -452,5 +456,124 @@ func TestIdentityInviteCommandHelp(t *testing.T) {
 		if !strings.Contains(help, want) {
 			t.Fatalf("help missing flag %q:\n%s", want, help)
 		}
+	}
+}
+
+// TestIdentityEnrollCommandHelp is a registration smoke test: `identity enroll
+// --help` resolves the command and prints all its flags.
+func TestIdentityEnrollCommandHelp(t *testing.T) {
+	out, _, err := runRootCmd(t, "identity", "enroll", "--help")
+	if err != nil {
+		t.Fatalf("identity enroll --help: %v", err)
+	}
+	help := out.String()
+	for _, want := range []string{
+		"--invite", "--display-name", "--slug", "--pubkey",
+		"--transport-pubkey", "--transport-endpoint", "--signer-socket", "--yes",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("enroll help missing flag %q:\n%s", want, help)
+		}
+	}
+}
+
+// enrollRelayServer spins up an httptest relay serving the well-known root for
+// rootPub and returns the server plus the derived base64 root and network id.
+func enrollRelayServer(t *testing.T, rootPub ed25519.PublicKey) (srv *httptest.Server, rootB64, networkID string) {
+	t.Helper()
+	rootB64 = base64.StdEncoding.EncodeToString(rootPub)
+	networkID = registry.NetworkID(rootPub)
+	body, err := json.Marshal(relayclient.WellKnownRoot{RootPubKey: rootB64, NetworkID: networkID})
+	if err != nil {
+		t.Fatalf("marshal well-known: %v", err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc(relayclient.WellKnownRootPath, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, rootB64, networkID
+}
+
+// TestIdentityEnrollCommandHappyPath drives `identity enroll` through RootCmd
+// against a LIVE signer and an httptest relay. The signer holds the member key,
+// so the emitted wire self-verifies (proof-of-possession). This exercises the
+// production cmd wiring (no seam injection): real signer.Client + real HTTP.
+func TestIdentityEnrollCommandHappyPath(t *testing.T) {
+	sockPath, memberPub := startCmdSigner(t)
+	rootPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey root: %v", err)
+	}
+	srv, rootB64, networkID := enrollRelayServer(t, rootPub)
+
+	token, _, err := invite.Encode(invite.Invite{NetworkID: networkID, Relay: srv.URL, RootPubKey: rootB64})
+	if err != nil {
+		t.Fatalf("invite.Encode: %v", err)
+	}
+
+	out, _, err := runRootCmd(t, "identity", "enroll",
+		"--invite", token,
+		"--display-name", "Mira",
+		"--slug", "mira",
+		"--pubkey", base64.StdEncoding.EncodeToString(memberPub),
+		"--transport-pubkey", base64.StdEncoding.EncodeToString(make([]byte, 32)),
+		"--signer-socket", sockPath,
+		"--yes",
+	)
+	if err != nil {
+		t.Fatalf("identity enroll: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("emitted wire is not JSON: %v (%q)", err, out.String())
+	}
+	if got[enrollment.FieldSig] == nil {
+		t.Fatalf("emitted wire missing sig: %q", out.String())
+	}
+	if got[enrollment.FieldNetworkID] != networkID {
+		t.Fatalf("emitted network_id = %v, want %s", got[enrollment.FieldNetworkID], networkID)
+	}
+}
+
+// TestIdentityEnrollCommandFailsClosedWhenSignerUnreachable drives the command
+// with a valid invite + relay but a dead signer socket, and asserts it fails
+// closed with no request emitted.
+func TestIdentityEnrollCommandFailsClosedWhenSignerUnreachable(t *testing.T) {
+	rootPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey root: %v", err)
+	}
+	srv, rootB64, networkID := enrollRelayServer(t, rootPub)
+	token, _, err := invite.Encode(invite.Invite{NetworkID: networkID, Relay: srv.URL, RootPubKey: rootB64})
+	if err != nil {
+		t.Fatalf("invite.Encode: %v", err)
+	}
+	memberPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey member: %v", err)
+	}
+	dir, err := os.MkdirTemp("", "vmcmdenroll")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	out, _, err := runRootCmd(t, "identity", "enroll",
+		"--invite", token,
+		"--display-name", "Mira",
+		"--slug", "mira",
+		"--pubkey", base64.StdEncoding.EncodeToString(memberPub),
+		"--transport-pubkey", base64.StdEncoding.EncodeToString(make([]byte, 32)),
+		"--signer-socket", filepath.Join(dir, "nope.sock"),
+		"--yes",
+	)
+	if err == nil {
+		t.Fatal("expected fail-closed error when signer unreachable, got nil")
+	}
+	if strings.Contains(out.String(), enrollment.FieldSig) {
+		t.Fatalf("fail-closed path must not emit a request, got %q", out.String())
 	}
 }

--- a/cmd/zz_catalog.go
+++ b/cmd/zz_catalog.go
@@ -264,6 +264,11 @@ var commandCatalog = map[string]catalogEntry{
 		when:  "you are an admin and want to emit a network invite (the trust anchor plus relay, with an out-of-band fingerprint) for a member to enroll against.",
 		short: "Emit an UNSIGNED network invite carrying the trust anchor (Contract-B)",
 	},
+	"vaultmind identity enroll": {
+		group: groupLifecycle,
+		when:  "you are a member with an invite and want to enroll: cross-check the relay's root against the invite, confirm the fingerprint, and self-sign an enrollment request for your admin.",
+		short: "Enroll into a Contract-B network from an invite, then self-sign the request",
+	},
 	"vaultmind identity sign": {
 		group: groupLifecycle,
 		when:  "you have a Contract-B entry to sign and want it validated, canonicalized, and signed by the keyless signer.",

--- a/internal/config/commands/identity_enroll_config.go
+++ b/internal/config/commands/identity_enroll_config.go
@@ -1,0 +1,58 @@
+package commands
+
+import "github.com/peiman/vaultmind/.ckeletin/pkg/config"
+
+// IdentityEnrollMetadata defines metadata for the `identity enroll` command.
+var IdentityEnrollMetadata = config.CommandMetadata{
+	Use:   "enroll",
+	Short: "Enroll into a Contract-B network: consume an invite, confirm the fingerprint, self-sign a request",
+	Long: `Run the Contract-B MEMBER-onboarding journey. Consume a network INVITE (a
+` + "`vmenroll1:`" + ` token or an enroll URL), fetch the relay's
+/.well-known/vaultmind-root, CROSS-CHECK it against the invite's trust anchor,
+confirm the FINGERPRINT out of band, then assemble + self-sign an enrollment
+request via the KEYLESS signer and print the signed request JSON to stdout.
+
+The cross-checks are the security spine: the relay's advertised root MUST decode
+to a valid key, be self-consistent (network_id == NetworkID(root)), and match the
+invite's anchor (raw bytes AND network id). Any mismatch is a HARD error (wrong
+relay / MITM / misconfig) and the flow refuses to proceed.
+
+After signing, the request is SELF-VERIFIED (proof-of-possession). A self-verify
+failure means the running signer holds a DIFFERENT key than --pubkey — the flow
+fails loudly and emits NOTHING.
+
+--pubkey is your base64-std ed25519 IDENTITY pubkey from ` + "`identity init`" + `.
+--transport-pubkey is your base64-std WireGuard pubkey (` + "`wg pubkey`" + `).
+Pipe stdout to a file and hand it to your admin out of band; they run
+` + "`vaultmind identity enroll-add`" + `. This CLI is KEYLESS: it never opens the key file.`,
+	ConfigPrefix: "app.identityenroll",
+	FlagOverrides: map[string]string{
+		"app.identityenroll.invite":             "invite",
+		"app.identityenroll.display_name":       "display-name",
+		"app.identityenroll.slug":               "slug",
+		"app.identityenroll.pubkey":             "pubkey",
+		"app.identityenroll.transport_pubkey":   "transport-pubkey",
+		"app.identityenroll.transport_endpoint": "transport-endpoint",
+		"app.identityenroll.signer_socket":      "signer-socket",
+		"app.identityenroll.yes":                "yes",
+	},
+}
+
+// IdentityEnrollOptions returns config options for `identity enroll`. Every flag
+// description lives here (SSOT) — never inline in cmd/.
+func IdentityEnrollOptions() []config.ConfigOption {
+	return []config.ConfigOption{
+		{Key: "app.identityenroll.invite", DefaultValue: "", Description: "Network invite: a vmenroll1: token or enroll URL (required)", Type: "string"},
+		{Key: "app.identityenroll.display_name", DefaultValue: "", Description: "Your display name in the network (required; Unicode NFC)", Type: "string"},
+		{Key: "app.identityenroll.slug", DefaultValue: "", Description: "Your short ASCII handle/slug (required)", Type: "string"},
+		{Key: "app.identityenroll.pubkey", DefaultValue: "", Description: "Your base64-std ed25519 identity pubkey from `identity init` (required)", Type: "string"},
+		{Key: "app.identityenroll.transport_pubkey", DefaultValue: "", Description: "Your base64-std 32-byte WireGuard pubkey from `wg pubkey` (required)", Type: "string"},
+		{Key: "app.identityenroll.transport_endpoint", DefaultValue: "", Description: "Optional reachable host:port (IPv6 bracketed); omitted when empty", Type: "string"},
+		{Key: "app.identityenroll.signer_socket", DefaultValue: "", Description: "Signer socket path (default: XDG state dir)", Type: "string"},
+		{Key: "app.identityenroll.yes", DefaultValue: false, Description: "Skip the out-of-band fingerprint confirmation prompt", Type: "bool"},
+	}
+}
+
+func init() {
+	config.RegisterOptionsProvider(IdentityEnrollOptions)
+}

--- a/internal/config/commands/identity_enroll_config_test.go
+++ b/internal/config/commands/identity_enroll_config_test.go
@@ -1,0 +1,78 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIdentityEnrollMetadata_Fields pins the command metadata.
+func TestIdentityEnrollMetadata_Fields(t *testing.T) {
+	meta := commands.IdentityEnrollMetadata
+	assert.Equal(t, "enroll", meta.Use)
+	assert.NotEmpty(t, meta.Short)
+	assert.NotEmpty(t, meta.Long)
+	assert.Equal(t, "app.identityenroll", meta.ConfigPrefix)
+}
+
+// TestIdentityEnrollMetadata_FlagOverridesMapToOptions proves every flag override
+// targets an existing option key and a distinct flag name (no typos / collisions).
+func TestIdentityEnrollMetadata_FlagOverridesMapToOptions(t *testing.T) {
+	opts := commands.IdentityEnrollOptions()
+	optKeys := map[string]bool{}
+	for _, o := range opts {
+		optKeys[o.Key] = true
+	}
+
+	seenFlags := map[string]bool{}
+	for key, flag := range commands.IdentityEnrollMetadata.FlagOverrides {
+		assert.Truef(t, optKeys[key], "flag override key %q has no matching option", key)
+		assert.NotEmpty(t, flag)
+		assert.Falsef(t, seenFlags[flag], "duplicate flag name %q", flag)
+		seenFlags[flag] = true
+	}
+	// Every option must have a flag override (each is user-facing).
+	assert.Len(t, commands.IdentityEnrollMetadata.FlagOverrides, len(opts))
+}
+
+// TestIdentityEnrollOptions_ShapeAndDefaults asserts each option's key/type and
+// the required defaults, covering every option entry.
+func TestIdentityEnrollOptions_ShapeAndDefaults(t *testing.T) {
+	opts := commands.IdentityEnrollOptions()
+	require.Len(t, opts, 8)
+
+	byKey := map[string]struct {
+		def any
+		typ string
+	}{}
+	for _, o := range opts {
+		assert.NotEmpty(t, o.Description, "option %q must describe itself", o.Key)
+		byKey[o.Key] = struct {
+			def any
+			typ string
+		}{o.DefaultValue, o.Type}
+	}
+
+	wantStrings := []string{
+		"app.identityenroll.invite",
+		"app.identityenroll.display_name",
+		"app.identityenroll.slug",
+		"app.identityenroll.pubkey",
+		"app.identityenroll.transport_pubkey",
+		"app.identityenroll.transport_endpoint",
+		"app.identityenroll.signer_socket",
+	}
+	for _, k := range wantStrings {
+		got, ok := byKey[k]
+		require.Truef(t, ok, "missing option %q", k)
+		assert.Equal(t, "string", got.typ, "option %q type", k)
+		assert.Equal(t, "", got.def, "option %q default", k)
+	}
+
+	yes, ok := byKey["app.identityenroll.yes"]
+	require.True(t, ok, "missing --yes option")
+	assert.Equal(t, "bool", yes.typ)
+	assert.Equal(t, false, yes.def)
+}

--- a/internal/identity/enrollment/enrollment.go
+++ b/internal/identity/enrollment/enrollment.go
@@ -87,6 +87,9 @@ const (
 
 	// errMarshalSigned wraps a marshal failure of the signed-subset object.
 	errMarshalSigned = "enrollment: marshal signed subset"
+	// errMarshalWire wraps a marshal failure of the exported wire request (should
+	// never happen for the fixed-shape struct).
+	errMarshalWire = "enrollment: marshal wire request"
 	// errSigBadLen is returned by VerifyEnrollment when the decoded signature is
 	// not ed25519.SignatureSize bytes.
 	errSigBadLen = "enrollment: signature must be ed25519.SignatureSize bytes"
@@ -167,6 +170,57 @@ func CanonicalizeEnrollment(fields Fields) (identity.CanonicalBytes, error) {
 		return identity.CanonicalBytes{}, fmt.Errorf("%s: %w", errMarshalSigned, err)
 	}
 	return identity.Canonicalize(raw)
+}
+
+// wireEnrollmentRequest is the wire shape MarshalWire emits for a signed
+// enrollment request: the signed-subset fields PLUS the transport sig. It
+// mirrors the frozen contract's snake_case JSON tags (the same names
+// CanonicalizeEnrollment sorts over), with transport_endpoint omitempty so an
+// absent endpoint is OMITTED (absent != null). The handoff to the admin carries
+// this form out of band.
+type wireEnrollmentRequest struct {
+	AlgVersion        int64   `json:"alg_version"`
+	Created           int64   `json:"created"`
+	DisplayName       string  `json:"display_name"`
+	KeyEpoch          int64   `json:"key_epoch"`
+	NetworkID         string  `json:"network_id"`
+	Nonce             string  `json:"nonce"`
+	PubKey            string  `json:"pubkey"`
+	Slug              string  `json:"slug"`
+	TransportEndpoint *string `json:"transport_endpoint,omitempty"`
+	TransportPubKey   string  `json:"transport_pubkey"`
+	Sig               string  `json:"sig"`
+}
+
+// MarshalWire produces the wire JSON of a signed enrollment request: every
+// signed-subset field plus the base64-std transport sig. It re-runs the pre-sign
+// gates first (via CanonicalizeEnrollment) so an ungateable request can NEVER be
+// emitted, then marshals the wire struct (transport_endpoint omitted when nil).
+//
+// It deliberately does NOT touch CanonicalizeEnrollment: stripping the sig and
+// re-canonicalizing this JSON reproduces the exact canonical bytes the signature
+// covers (the admin's re-derivation matches). It FAILS CLOSED on any gate error.
+func MarshalWire(fields Fields, sigB64 string) ([]byte, error) {
+	if _, err := CanonicalizeEnrollment(fields); err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(wireEnrollmentRequest{
+		AlgVersion:        fields.AlgVersion,
+		Created:           fields.Created,
+		DisplayName:       fields.DisplayName,
+		KeyEpoch:          fields.KeyEpoch,
+		NetworkID:         fields.NetworkID,
+		Nonce:             fields.Nonce,
+		PubKey:            fields.PubKey,
+		Slug:              fields.Slug,
+		TransportEndpoint: fields.TransportEndpoint,
+		TransportPubKey:   fields.TransportPubKey,
+		Sig:               sigB64,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errMarshalWire, err)
+	}
+	return raw, nil
 }
 
 // checkGates enforces the frozen pre-sign contract. Each rule is a TYPED reject.

--- a/internal/identity/enrollment/marshal_wire_test.go
+++ b/internal/identity/enrollment/marshal_wire_test.go
@@ -1,0 +1,108 @@
+package enrollment
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lowEntropySigB64 is a deterministic, LOW-ENTROPY base64-std signature-shaped
+// value for MarshalWire tests (64 × 0xC4). MarshalWire never verifies it — it
+// only stamps it into the wire JSON — so a placeholder is sufficient and keeps
+// the gitleaks entropy scanner quiet.
+const lowEntropySigB64 = "xMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMQ=="
+
+// TestMarshalWire_RoundTrips marshals a request with transport_endpoint ABSENT,
+// re-parses it, and asserts every signed-subset field plus the sig survive, and
+// that transport_endpoint is OMITTED (absent != null).
+func TestMarshalWire_RoundTrips(t *testing.T) {
+	pub, _ := fixedEd25519(t, 0xD4)
+	f := validFields(pub)
+
+	raw, err := MarshalWire(f, lowEntropySigB64)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	assert.EqualValues(t, AlgVersion, got[FieldAlgVersion])
+	assert.EqualValues(t, f.Created, got[FieldCreated])
+	assert.Equal(t, f.DisplayName, got[FieldDisplayName])
+	assert.EqualValues(t, f.KeyEpoch, got[FieldKeyEpoch])
+	assert.Equal(t, f.NetworkID, got[FieldNetworkID])
+	assert.Equal(t, f.Nonce, got[FieldNonce])
+	assert.Equal(t, f.PubKey, got[FieldPubKey])
+	assert.Equal(t, f.Slug, got[FieldSlug])
+	assert.Equal(t, f.TransportPubKey, got[FieldTransportPubKey])
+	assert.Equal(t, lowEntropySigB64, got[FieldSig])
+
+	_, present := got[FieldTransportEndpoint]
+	assert.False(t, present, "transport_endpoint must be OMITTED when nil (absent != null)")
+}
+
+// TestMarshalWire_TransportEndpointPresent emits the optional transport_endpoint
+// when it is set.
+func TestMarshalWire_TransportEndpointPresent(t *testing.T) {
+	pub, _ := fixedEd25519(t, 0xD5)
+	f := validFields(pub)
+	f.TransportEndpoint = strptr("[2001:db8::1]:51820")
+
+	raw, err := MarshalWire(f, lowEntropySigB64)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, "[2001:db8::1]:51820", got[FieldTransportEndpoint])
+}
+
+// TestMarshalWire_StripSigRecanonicalizeEqualsCanonical is the security-critical
+// property: dropping `sig` from the wire JSON and re-canonicalizing the result
+// reproduces EXACTLY CanonicalizeEnrollment(fields). This proves MarshalWire
+// carries the signed subset faithfully (the admin re-derives the same bytes the
+// signature covers).
+func TestMarshalWire_StripSigRecanonicalizeEqualsCanonical(t *testing.T) {
+	for _, name := range []string{"endpoint-absent", "endpoint-present"} {
+		t.Run(name, func(t *testing.T) {
+			pub, _ := fixedEd25519(t, 0xD6)
+			f := validFields(pub)
+			if name == "endpoint-present" {
+				f.TransportEndpoint = strptr("relay.example:51820")
+			}
+
+			raw, err := MarshalWire(f, lowEntropySigB64)
+			require.NoError(t, err)
+
+			var obj map[string]any
+			require.NoError(t, json.Unmarshal(raw, &obj))
+			delete(obj, FieldSig)
+
+			stripped, err := json.Marshal(obj)
+			require.NoError(t, err)
+			recanon, err := identity.Canonicalize(stripped)
+			require.NoError(t, err)
+
+			want, err := CanonicalizeEnrollment(f)
+			require.NoError(t, err)
+			assert.True(t, bytes.Equal(want.Bytes(), recanon.Bytes()),
+				"strip-sig + re-canonicalize must equal CanonicalizeEnrollment\nwant=%s\ngot =%s",
+				want.Bytes(), recanon.Bytes())
+		})
+	}
+}
+
+// TestMarshalWire_GateFailurePropagates proves MarshalWire enforces the same
+// pre-emit gates: a field that CanonicalizeEnrollment rejects must fail here too
+// (never emit an ungateable request).
+func TestMarshalWire_GateFailurePropagates(t *testing.T) {
+	pub, _ := fixedEd25519(t, 0xD7)
+	f := validFields(pub)
+	f.AlgVersion = 2 // anti-downgrade gate
+
+	_, err := MarshalWire(f, lowEntropySigB64)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ErrAlgVersion)
+}

--- a/internal/identity/relayclient/relayclient.go
+++ b/internal/identity/relayclient/relayclient.go
@@ -1,0 +1,117 @@
+// Package relayclient fetches a Contract-B relay's PUBLIC trust anchor from its
+// /.well-known/vaultmind-root endpoint. It performs NO trust decisions itself —
+// the caller (the member-enroll flow) cross-checks the fetched root against the
+// out-of-band-confirmed invite. This package only does the transport: validate
+// the scheme, GET the well-known path, and decode the response.
+package relayclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// WellKnownRootPath is the canonical path a relay serves its public root anchor
+// from. SSOT so the fetch path and any docs reference one definition.
+const WellKnownRootPath = "/.well-known/vaultmind-root"
+
+// relayFetchTimeout bounds a well-known fetch when the caller passes a nil
+// client (the default client gets this timeout). When the caller supplies a
+// client, its own timeout/transport wins.
+const relayFetchTimeout = 15 * time.Second
+
+// Error strings (SSOT). Each failure mode is a distinct typed reject so the
+// enroll flow can tell a misconfigured base URL from a dead relay.
+const (
+	// errBadScheme is returned when the relay base URL is not parseable or its
+	// scheme is not http/https. The well-known fetch refuses any other scheme so
+	// a malicious invite cannot point it at file:// or similar.
+	errBadScheme = "relayclient: relay base URL must be an http(s) URL"
+	// errBuildRequest wraps a request-construction failure (should not happen for
+	// a validated URL).
+	errBuildRequest = "relayclient: build well-known request"
+	// errFetch wraps a transport failure (dial/timeout/cancelled context).
+	errFetch = "relayclient: fetch well-known root"
+	// errStatus is returned (with the status code) on a non-200 response.
+	errStatus = "relayclient: well-known root returned non-200"
+	// errDecode wraps a JSON-decode failure of the well-known body.
+	errDecode = "relayclient: decode well-known root JSON"
+)
+
+// schemeHTTP and schemeHTTPS are the only relay schemes the fetch permits.
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
+// WellKnownRoot is the relay's advertised PUBLIC trust anchor. It is UNTRUSTED
+// until the caller cross-checks it against the out-of-band-confirmed invite:
+// the relay could be a MITM, so RootPubKey/NetworkID here prove nothing on their
+// own.
+type WellKnownRoot struct {
+	// RootPubKey is base64-std (padded) of the 32-byte ed25519 ROOT public key the
+	// relay claims anchors its network.
+	RootPubKey string `json:"root_pubkey"`
+	// NetworkID is the relay's claimed "vmnet1:…" id. The caller re-derives
+	// NetworkID(root_pubkey) and rejects a mismatch.
+	NetworkID string `json:"network_id"`
+	// RootKeyEpoch is the relay's advertised root-key rotation epoch (optional;
+	// 0 when absent). It is informational here — the trust decision is the
+	// pubkey/network-id cross-check, not the epoch.
+	RootKeyEpoch int64 `json:"root_key_epoch,omitempty"`
+}
+
+// FetchRoot GETs {relayBaseURL}/.well-known/vaultmind-root and decodes the
+// WellKnownRoot. It validates the base URL scheme (http/https only) BEFORE
+// dialing, uses a context-bound request, and FAILS CLOSED on a non-200 status
+// or a malformed body. It deliberately does NOT DisallowUnknownFields so the
+// relay can add forward-compatible fields without breaking older members.
+//
+// client may be nil; a timeout-bounded default client is used in that case. The
+// returned WellKnownRoot is UNTRUSTED — the caller must cross-check it against
+// the invite before relying on it.
+func FetchRoot(ctx context.Context, client *http.Client, relayBaseURL string) (WellKnownRoot, error) {
+	endpoint, err := wellKnownURL(relayBaseURL)
+	if err != nil {
+		return WellKnownRoot{}, err
+	}
+	if client == nil {
+		client = &http.Client{Timeout: relayFetchTimeout}
+	}
+
+	//nolint:gosec // relay base URL is operator-provided via the signed invite; scheme validated above
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return WellKnownRoot{}, fmt.Errorf("%s: %w", errBuildRequest, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return WellKnownRoot{}, fmt.Errorf("%s: %w", errFetch, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return WellKnownRoot{}, fmt.Errorf("%s: %d", errStatus, resp.StatusCode)
+	}
+
+	var root WellKnownRoot
+	if err := json.NewDecoder(resp.Body).Decode(&root); err != nil {
+		return WellKnownRoot{}, fmt.Errorf("%s: %w", errDecode, err)
+	}
+	return root, nil
+}
+
+// wellKnownURL validates the relay base URL scheme and joins the well-known
+// path onto it. It rejects any non-http(s) scheme (and unparseable input) so the
+// fetch can never be redirected to a non-HTTP scheme by a hostile invite.
+func wellKnownURL(relayBaseURL string) (string, error) {
+	u, err := url.Parse(relayBaseURL)
+	if err != nil || (u.Scheme != schemeHTTP && u.Scheme != schemeHTTPS) || u.Host == "" {
+		return "", fmt.Errorf("%s", errBadScheme)
+	}
+	return u.JoinPath(WellKnownRootPath).String(), nil
+}

--- a/internal/identity/relayclient/relayclient_test.go
+++ b/internal/identity/relayclient/relayclient_test.go
@@ -1,0 +1,142 @@
+package relayclient_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity/relayclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lowEntropyRootB64 is a deterministic, LOW-ENTROPY base64-std pubkey-shaped
+// value used in fixtures so the gitleaks entropy scanner does not trip. It is
+// NOT a real key — these tests never verify against it.
+const lowEntropyRootB64 = "oaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaE=" // base64-std of 32 × 0xA1
+
+const wellKnownBody = `{"root_pubkey":"` + lowEntropyRootB64 +
+	`","network_id":"vmnet1:deadbeefdeadbeefdeadbeefdeadbeef","root_key_epoch":3}`
+
+// newRelay spins up an httptest server that serves the well-known root at the
+// canonical path and 404s everything else. handler lets a test override the
+// well-known response.
+func newRelay(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(relayclient.WellKnownRootPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestFetchRootHappy fetches a well-formed well-known root and decodes every
+// field, including the optional root_key_epoch.
+func TestFetchRootHappy(t *testing.T) {
+	srv := newRelay(t, http.StatusOK, wellKnownBody)
+
+	got, err := relayclient.FetchRoot(context.Background(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, lowEntropyRootB64, got.RootPubKey)
+	assert.Equal(t, "vmnet1:deadbeefdeadbeefdeadbeefdeadbeef", got.NetworkID)
+	assert.Equal(t, int64(3), got.RootKeyEpoch)
+}
+
+// TestFetchRootForwardCompatible proves UNKNOWN fields in the relay response are
+// tolerated (the relay may add fields without breaking older members).
+func TestFetchRootForwardCompatible(t *testing.T) {
+	body := `{"root_pubkey":"` + lowEntropyRootB64 +
+		`","network_id":"vmnet1:deadbeefdeadbeefdeadbeefdeadbeef","future_field":"ignored"}`
+	srv := newRelay(t, http.StatusOK, body)
+
+	got, err := relayclient.FetchRoot(context.Background(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, lowEntropyRootB64, got.RootPubKey)
+}
+
+// TestFetchRootNon200 maps a non-200 status to an error that names the status.
+func TestFetchRootNon200(t *testing.T) {
+	srv := newRelay(t, http.StatusInternalServerError, "boom")
+
+	_, err := relayclient.FetchRoot(context.Background(), srv.Client(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestFetchRootMalformedJSON rejects a body that is not a JSON object.
+func TestFetchRootMalformedJSON(t *testing.T) {
+	srv := newRelay(t, http.StatusOK, "{not json")
+
+	_, err := relayclient.FetchRoot(context.Background(), srv.Client(), srv.URL)
+	require.Error(t, err)
+}
+
+// TestFetchRootWrongPath404 hits a relay whose well-known path is unmapped; the
+// default mux returns 404, which must surface as a non-200 error.
+func TestFetchRootWrongPath404(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(srv.Close)
+
+	_, err := relayclient.FetchRoot(context.Background(), srv.Client(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+// TestFetchRootBadScheme rejects a relay base URL whose scheme is not http(s)
+// BEFORE dialing.
+func TestFetchRootBadScheme(t *testing.T) {
+	for _, base := range []string{"ftp://relay.example", "file:///etc/passwd", "://no-scheme", "not a url at all"} {
+		_, err := relayclient.FetchRoot(context.Background(), http.DefaultClient, base)
+		require.Error(t, err, "base %q must be rejected", base)
+	}
+}
+
+// TestFetchRootContextTimeout proves a cancelled/expired context aborts the
+// fetch (the per-request deadline is honored).
+func TestFetchRootContextTimeout(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(relayclient.WellKnownRootPath, func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte(wellKnownBody))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := relayclient.FetchRoot(ctx, srv.Client(), srv.URL)
+	require.Error(t, err)
+}
+
+// TestFetchRootNilClientUsesDefault proves a nil *http.Client is tolerated (the
+// fetch falls back to a timeout-bounded default client).
+func TestFetchRootNilClientUsesDefault(t *testing.T) {
+	srv := newRelay(t, http.StatusOK, wellKnownBody)
+
+	got, err := relayclient.FetchRoot(context.Background(), nil, srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, lowEntropyRootB64, got.RootPubKey)
+}
+
+// TestFetchRootDecodesTestdataFixture serves the committed testdata fixture and
+// asserts it decodes to the same fields the inline body uses, pinning the
+// on-disk well-known shape to the struct.
+func TestFetchRootDecodesTestdataFixture(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "well_known_root.json"))
+	require.NoError(t, err)
+	srv := newRelay(t, http.StatusOK, string(raw))
+
+	got, err := relayclient.FetchRoot(context.Background(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, lowEntropyRootB64, got.RootPubKey)
+	assert.Equal(t, "vmnet1:deadbeefdeadbeefdeadbeefdeadbeef", got.NetworkID)
+	assert.Equal(t, int64(3), got.RootKeyEpoch)
+}

--- a/internal/identity/relayclient/testdata/well_known_root.json
+++ b/internal/identity/relayclient/testdata/well_known_root.json
@@ -1,0 +1,5 @@
+{
+  "root_pubkey": "oaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaE=",
+  "network_id": "vmnet1:deadbeefdeadbeefdeadbeefdeadbeef",
+  "root_key_epoch": 3
+}

--- a/internal/identitycli/enroll.go
+++ b/internal/identitycli/enroll.go
@@ -1,0 +1,354 @@
+package identitycli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity/enrollment"
+	"github.com/peiman/vaultmind/internal/identity/invite"
+	"github.com/peiman/vaultmind/internal/identity/registry"
+	"github.com/peiman/vaultmind/internal/identity/relayclient"
+	"github.com/peiman/vaultmind/internal/identity/signer"
+)
+
+// Enroll output-label / prompt constants (SSOT) — every printed string the
+// member-enroll flow emits is a named constant here, never an inline literal.
+const (
+	// enrollNonceLen is the number of random bytes the enrollment nonce carries
+	// (base64-std encoded into the request). 16 bytes = 128 bits of anti-replay
+	// entropy.
+	enrollNonceLen = 16
+
+	// enrollFirstKeyEpoch is the key_epoch of a FIRST enrollment. Rotation (a
+	// later epoch) is a future path — first enrollment is always epoch 1, so this
+	// is hardcoded and intentionally NOT a flag.
+	enrollFirstKeyEpoch = 1
+
+	// EnrollConfirmPrompt is shown on errOut to ask the member to confirm the
+	// fingerprint matches the one the admin gave them out of band.
+	EnrollConfirmPrompt = "Confirm this matches the fingerprint your admin gave you out-of-band [y/N]: "
+	// EnrollAutoConfirmedNote is printed instead of the prompt when --yes is set.
+	EnrollAutoConfirmedNote = "auto-confirmed via --yes"
+	// EnrollConfirmedNote is the interactive-confirm result word shown in the
+	// summary when the member accepted the OOB fingerprint prompt.
+	EnrollConfirmedNote = "confirmed"
+	// EnrollNetworkLabel prefixes the printed network id.
+	EnrollNetworkLabel = "network: "
+	// EnrollRelayLabel prefixes the printed relay base URL.
+	EnrollRelayLabel = "relay: "
+	// EnrollFingerprintLabel prefixes the printed fingerprint (= network id).
+	EnrollFingerprintLabel = "fingerprint: "
+	// EnrollSignedNote confirms the request signed AND self-verified
+	// (proof-of-possession passed).
+	EnrollSignedNote = "✓ signed & self-verified"
+	// EnrollNextStepNote tells the member to hand the emitted request to the admin.
+	EnrollNextStepNote = "hand this to your admin out-of-band; they run `vaultmind identity enroll-add`."
+)
+
+// Enroll error strings (SSOT). Each failure mode is a distinct typed reject so
+// the member can tell a transport/cross-check/proof failure apart.
+const (
+	// ErrEnrollEmptyInvite is returned when --invite is empty.
+	ErrEnrollEmptyInvite = "identitycli: --invite is required (a vmenroll1: token or enroll URL)"
+	// ErrEnrollEmptyDisplayName is returned when --display-name is empty.
+	ErrEnrollEmptyDisplayName = "identitycli: --display-name is required"
+	// ErrEnrollEmptySlug is returned when --slug is empty.
+	ErrEnrollEmptySlug = "identitycli: --slug is required"
+	// ErrEnrollEmptyPubKey is returned when --pubkey is empty.
+	ErrEnrollEmptyPubKey = "identitycli: --pubkey is required (your base64-std ed25519 identity pubkey)"
+	// ErrEnrollEmptyTransportPubKey is returned when --transport-pubkey is empty.
+	ErrEnrollEmptyTransportPubKey = "identitycli: --transport-pubkey is required (your base64-std WireGuard pubkey)"
+
+	// errEnrollDecodeInvite wraps an invite.Decode failure (bad prefix/base64/json
+	// or network-id mismatch).
+	errEnrollDecodeInvite = "identitycli: decode invite"
+	// errEnrollFetchRoot wraps a well-known root fetch failure.
+	errEnrollFetchRoot = "identitycli: fetch relay well-known root"
+	// errEnrollRelayRootDecode is returned when the relay's advertised root pubkey
+	// is not base64-std of a valid ed25519 key (bad base64 / wrong length /
+	// small-order).
+	errEnrollRelayRootDecode = "identitycli: relay root pubkey is not a valid ed25519 public key"
+	// errEnrollRelaySelfInconsistent is returned when the relay's advertised
+	// network_id != NetworkID(its advertised root pubkey) — the relay contradicts
+	// itself (misconfig / MITM).
+	errEnrollRelaySelfInconsistent = "identitycli: relay network_id does not match NetworkID(relay root pubkey) — relay is self-inconsistent (misconfig or MITM)"
+	// errEnrollRootMismatch is returned when the relay's root pubkey != the
+	// invite's root pubkey (the trust anchors disagree — wrong relay or MITM).
+	errEnrollRootMismatch = "identitycli: relay root pubkey does not match the invite root pubkey — wrong relay or MITM, refusing to enroll"
+	// errEnrollNetworkIDMismatch is returned when the relay network_id != the
+	// invite network_id.
+	errEnrollNetworkIDMismatch = "identitycli: relay network_id does not match the invite network_id — wrong relay or MITM, refusing to enroll"
+	// errEnrollInviteRootDecode is returned when the invite root pubkey cannot be
+	// base64-decoded (should not happen — invite.Decode already validated it).
+	errEnrollInviteRootDecode = "identitycli: decode invite root pubkey"
+	// errEnrollAborted is returned when the member declines the fingerprint
+	// confirmation prompt.
+	errEnrollAborted = "enrollment aborted: fingerprint not confirmed"
+	// errEnrollNonce wraps a crypto/rand read failure for the nonce.
+	errEnrollNonce = "identitycli: read enrollment nonce"
+	// errEnrollSign wraps a signer failure with guidance.
+	errEnrollSign = "identitycli: sign enrollment via signer (is `vaultmind identity signer` running?)"
+	// errEnrollSelfVerifyDecode wraps a base64 decode failure of the returned sig.
+	errEnrollSelfVerifyDecode = "identitycli: decode enrollment signature"
+	// ErrEnrollSelfVerify is returned when proof-of-possession self-verification
+	// fails: the running signer holds a DIFFERENT key than --pubkey.
+	ErrEnrollSelfVerify = "self-signature failed to verify: the running signer's identity key does not match --pubkey (run `identity signer` with the key whose public half you passed to --pubkey)"
+)
+
+// EnrollConfig carries everything the member-enroll flow needs, with injectable
+// seams so tests need no real daemon, network, or clock. Every seam defaults to
+// the production implementation when nil/zero.
+type EnrollConfig struct {
+	InviteTokenOrURL   string // --invite (a vmenroll1: token OR an enroll URL)
+	DisplayName        string // --display-name
+	Slug               string // --slug
+	PubKeyB64          string // --pubkey (base64-std ed25519 identity pubkey)
+	TransportPubKeyB64 string // --transport-pubkey (base64-std WireGuard pubkey)
+	TransportEndpoint  string // --transport-endpoint (optional host:port; "" => omitted)
+	SignerSocket       string // --signer-socket
+
+	AssumeYes bool // --yes (skip the OOB fingerprint confirmation prompt)
+
+	// Seams (nil => production default).
+	HTTPClient *http.Client            // well-known fetch client
+	Signer     enrollment.SignerClient // keyless signer (default: &signer.Client{SocketPath})
+	Now        func() time.Time        // created timestamp source (default: time.Now)
+	RandReader io.Reader               // nonce entropy source (default: crypto/rand.Reader)
+}
+
+func (c EnrollConfig) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+func (c EnrollConfig) rand() io.Reader {
+	if c.RandReader != nil {
+		return c.RandReader
+	}
+	return rand.Reader
+}
+
+func (c EnrollConfig) signer() enrollment.SignerClient {
+	if c.Signer != nil {
+		return c.Signer
+	}
+	return &signer.Client{SocketPath: c.SignerSocket}
+}
+
+func (c EnrollConfig) httpClient() *http.Client {
+	return c.HTTPClient // nil is fine — relayclient.FetchRoot defaults it
+}
+
+// Enroll runs the Contract-B member-onboarding flow: decode the invite, fetch
+// the relay's well-known root, CROSS-CHECK it against the invite (the security
+// spine), confirm the fingerprint out of band, assemble + gate + sign the
+// enrollment request via the keyless signer, self-verify proof-of-possession,
+// and emit the signed wire JSON on out (human guidance goes to errOut). It FAILS
+// CLOSED: any cross-check, gate, sign, or self-verify failure returns non-nil
+// and emits NO request.
+func Enroll(out, errOut io.Writer, in io.Reader, cfg EnrollConfig) error {
+	if err := validateEnrollConfig(cfg); err != nil {
+		return err
+	}
+
+	inv, err := invite.Decode(cfg.InviteTokenOrURL)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errEnrollDecodeInvite, err)
+	}
+
+	root, err := relayclient.FetchRoot(context.Background(), cfg.httpClient(), inv.Relay)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errEnrollFetchRoot, err)
+	}
+
+	if err := crossCheckRoot(inv, root); err != nil {
+		return err
+	}
+
+	fp := invite.Fingerprint(inv)
+	if err := confirmFingerprint(errOut, in, fp, cfg.AssumeYes); err != nil {
+		return err
+	}
+
+	fields, err := assembleFields(cfg, inv)
+	if err != nil {
+		return err
+	}
+
+	// Fail-fast: surface gate errors with the exact enrollment.Err* message
+	// BEFORE dialing the signer.
+	if _, err := enrollment.CanonicalizeEnrollment(fields); err != nil {
+		return err
+	}
+
+	res, err := enrollment.SignEnrollment(cfg.signer(), fields)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errEnrollSign, err)
+	}
+
+	if err := selfVerify(fields, res.Sig); err != nil {
+		return err
+	}
+
+	wire, err := enrollment.MarshalWire(fields, res.Sig)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "%s\n", wire); err != nil {
+		return err
+	}
+	return writeEnrollGuidance(errOut, inv, fp, cfg.AssumeYes)
+}
+
+// validateEnrollConfig fails closed on any missing required field BEFORE any
+// network or signer interaction.
+func validateEnrollConfig(cfg EnrollConfig) error {
+	switch {
+	case cfg.InviteTokenOrURL == "":
+		return fmt.Errorf("%s", ErrEnrollEmptyInvite)
+	case cfg.DisplayName == "":
+		return fmt.Errorf("%s", ErrEnrollEmptyDisplayName)
+	case cfg.Slug == "":
+		return fmt.Errorf("%s", ErrEnrollEmptySlug)
+	case cfg.PubKeyB64 == "":
+		return fmt.Errorf("%s", ErrEnrollEmptyPubKey)
+	case cfg.TransportPubKeyB64 == "":
+		return fmt.Errorf("%s", ErrEnrollEmptyTransportPubKey)
+	}
+	return nil
+}
+
+// crossCheckRoot is the security spine: the relay's advertised root MUST decode
+// to a valid key, be self-consistent (network_id == NetworkID(pubkey)), and
+// match the invite's anchor (raw bytes AND network id). Any mismatch is a
+// distinct hard error — the flow NEVER proceeds on a mismatch.
+func crossCheckRoot(inv invite.Invite, root relayclient.WellKnownRoot) error {
+	relayRaw, err := base64.StdEncoding.DecodeString(root.RootPubKey)
+	if err != nil {
+		return fmt.Errorf("%s", errEnrollRelayRootDecode)
+	}
+	relayPub, err := registry.NewPublicKey(relayRaw)
+	if err != nil {
+		return fmt.Errorf("%s", errEnrollRelayRootDecode)
+	}
+	if registry.NetworkID(relayPub.Bytes()) != root.NetworkID {
+		return fmt.Errorf("%s", errEnrollRelaySelfInconsistent)
+	}
+
+	inviteRaw, err := base64.StdEncoding.DecodeString(inv.RootPubKey)
+	if err != nil {
+		return fmt.Errorf("%s", errEnrollInviteRootDecode)
+	}
+	if !bytes.Equal(relayRaw, inviteRaw) {
+		return fmt.Errorf("%s", errEnrollRootMismatch)
+	}
+	if root.NetworkID != inv.NetworkID {
+		return fmt.Errorf("%s", errEnrollNetworkIDMismatch)
+	}
+	return nil
+}
+
+// confirmFingerprint prints the OOB-confirm step. With --yes it auto-confirms;
+// otherwise it prompts on errOut and reads a line from in, accepting y/Y/yes
+// (trim+lower). Anything else aborts.
+func confirmFingerprint(errOut io.Writer, in io.Reader, fp string, assumeYes bool) error {
+	if assumeYes {
+		return nil
+	}
+	if _, err := fmt.Fprintf(errOut, "%s%s\n%s", EnrollFingerprintLabel, fp, EnrollConfirmPrompt); err != nil {
+		return err
+	}
+	line, _ := readLine(in)
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	default:
+		return fmt.Errorf("%s", errEnrollAborted)
+	}
+}
+
+// readLine reads a single line (up to the first '\n') from in.
+func readLine(in io.Reader) (string, error) {
+	var sb strings.Builder
+	buf := make([]byte, 1)
+	for {
+		n, err := in.Read(buf)
+		if n > 0 {
+			if buf[0] == '\n' {
+				return sb.String(), nil
+			}
+			sb.WriteByte(buf[0])
+		}
+		if err != nil {
+			return sb.String(), err
+		}
+	}
+}
+
+// assembleFields builds the enrollment.Fields from cfg + the decoded invite.
+// transport_endpoint is nil (OMITTED) when --transport-endpoint is empty
+// (absent != null).
+func assembleFields(cfg EnrollConfig, inv invite.Invite) (enrollment.Fields, error) {
+	nonce := make([]byte, enrollNonceLen)
+	if _, err := io.ReadFull(cfg.rand(), nonce); err != nil {
+		return enrollment.Fields{}, fmt.Errorf("%s: %w", errEnrollNonce, err)
+	}
+	var endpoint *string
+	if cfg.TransportEndpoint != "" {
+		endpoint = &cfg.TransportEndpoint
+	}
+	return enrollment.Fields{
+		AlgVersion:        enrollment.AlgVersion,
+		Created:           cfg.now().Unix(),
+		DisplayName:       cfg.DisplayName,
+		KeyEpoch:          enrollFirstKeyEpoch,
+		NetworkID:         inv.NetworkID,
+		Nonce:             base64.StdEncoding.EncodeToString(nonce),
+		PubKey:            cfg.PubKeyB64,
+		Slug:              cfg.Slug,
+		TransportEndpoint: endpoint,
+		TransportPubKey:   cfg.TransportPubKeyB64,
+	}, nil
+}
+
+// selfVerify decodes the returned sig and re-verifies it against the request's
+// OWN pubkey (proof-of-possession). A decode failure or a non-verifying sig is a
+// LOUD error: the signer holds a different key than --pubkey.
+func selfVerify(fields enrollment.Fields, sigB64 string) error {
+	raw, err := base64.StdEncoding.DecodeString(sigB64)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errEnrollSelfVerifyDecode, err)
+	}
+	ok, err := enrollment.VerifyEnrollment(fields, raw)
+	if err != nil || !ok {
+		return fmt.Errorf("%s", ErrEnrollSelfVerify)
+	}
+	return nil
+}
+
+// writeEnrollGuidance prints the human-readable summary to errOut: network,
+// relay, fingerprint (+ how it was confirmed), the signed/self-verified note,
+// and the next step.
+func writeEnrollGuidance(errOut io.Writer, inv invite.Invite, fp string, assumeYes bool) error {
+	confirm := EnrollConfirmedNote
+	if assumeYes {
+		confirm = EnrollAutoConfirmedNote
+	}
+	_, err := fmt.Fprintf(errOut, "%s%s\n%s%s\n%s%s (%s)\n%s\n%s\n",
+		EnrollNetworkLabel, inv.NetworkID,
+		EnrollRelayLabel, inv.Relay,
+		EnrollFingerprintLabel, fp, confirm,
+		EnrollSignedNote,
+		EnrollNextStepNote,
+	)
+	return err
+}

--- a/internal/identitycli/enroll_test.go
+++ b/internal/identitycli/enroll_test.go
@@ -236,6 +236,30 @@ func TestEnrollInviteDecodeErrorPropagates(t *testing.T) {
 			assert.Empty(t, out.String(), "no request must be emitted on a bad invite")
 		})
 	}
+
+	// network-mismatch: a hand-built token carrying a VALID root key but a
+	// network_id that does NOT derive from it. invite.Encode cannot produce this
+	// (its validate() rejects the mismatch), so assemble the wire JSON directly.
+	// This exercises the security-spine binding invite.Decode enforces and proves
+	// Enroll propagates it (rejecting for the RIGHT reason, not incidentally).
+	t.Run("network-mismatch", func(t *testing.T) {
+		rootPub, _ := fixedKey(t, 0xA1)
+		otherPub, _ := fixedKey(t, 0xC3)
+		body, err := json.Marshal(map[string]string{
+			invite.FieldNetworkID:  registry.NetworkID(otherPub),
+			invite.FieldRelay:      "https://relay.example",
+			invite.FieldRootPubKey: base64.StdEncoding.EncodeToString(rootPub),
+		})
+		require.NoError(t, err)
+		token := "vmenroll1:" + base64.RawURLEncoding.EncodeToString(body)
+
+		h := newEnrollHarness(t)
+		h.cfg.InviteTokenOrURL = token
+		out, _, err := runEnroll(h.cfg, nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, invite.ErrNetworkIDMismatch)
+		assert.Empty(t, out.String(), "no request must be emitted on a network-mismatch invite")
+	})
 }
 
 // TestEnrollWellKnownFetchFailures covers non-200, malformed, and bad-scheme

--- a/internal/identitycli/enroll_test.go
+++ b/internal/identitycli/enroll_test.go
@@ -1,0 +1,540 @@
+package identitycli_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/enrollment"
+	"github.com/peiman/vaultmind/internal/identity/invite"
+	"github.com/peiman/vaultmind/internal/identity/registry"
+	"github.com/peiman/vaultmind/internal/identity/relayclient"
+	"github.com/peiman/vaultmind/internal/identitycli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSignerClient signs in-process with a held ed25519 key (the keyless seam),
+// or returns failErr to simulate an unreachable/refusing signer. A test points
+// priv at the key whose public half it passes as --pubkey, so self-verify
+// passes; pointing it elsewhere proves the self-verify guard fires.
+type fakeSignerClient struct {
+	priv    ed25519.PrivateKey
+	failErr error
+}
+
+func (f *fakeSignerClient) Sign(canonicalBytes []byte) ([]byte, error) {
+	if f.failErr != nil {
+		return nil, f.failErr
+	}
+	return ed25519.Sign(f.priv, canonicalBytes), nil
+}
+
+// fixedKey derives a deterministic ed25519 keypair from a one-byte seed fill so
+// pubkeys in tests are LOW-ENTROPY (the gitleaks entropy scanner stays quiet).
+func fixedKey(t *testing.T, fill byte) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	seed := bytes.Repeat([]byte{fill}, ed25519.SeedSize)
+	priv := ed25519.NewKeyFromSeed(seed)
+	return priv.Public().(ed25519.PublicKey), priv
+}
+
+// lowEntropyTransportB64 is a deterministic 32-byte (length-only-checked)
+// WireGuard pubkey, base64-std. It is NOT validated as a key, so a repeated
+// byte is fine and keeps entropy low.
+func lowEntropyTransportB64() string {
+	return base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x11}, 32))
+}
+
+// rootKey mints a deterministic ROOT keypair and returns its base64-std pubkey
+// plus the derived network id.
+func rootKey(t *testing.T, fill byte) (rootB64, networkID string) {
+	t.Helper()
+	pub, _ := fixedKey(t, fill)
+	return base64.StdEncoding.EncodeToString(pub), registry.NetworkID(pub)
+}
+
+// relayServing returns an httptest server that serves the given WellKnownRoot at
+// the canonical path.
+func relayServing(t *testing.T, root relayclient.WellKnownRoot) *httptest.Server {
+	t.Helper()
+	body, err := json.Marshal(root)
+	require.NoError(t, err)
+	mux := http.NewServeMux()
+	mux.HandleFunc(relayclient.WellKnownRootPath, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// enrollHarness wires a consistent invite + relay + member key for the happy
+// path; individual tests mutate the EnrollConfig they get back.
+type enrollHarness struct {
+	cfg        identitycli.EnrollConfig
+	memberPub  ed25519.PublicKey
+	memberPriv ed25519.PrivateKey
+	networkID  string
+	relayURL   string
+}
+
+func newEnrollHarness(t *testing.T) enrollHarness {
+	t.Helper()
+	rootB64, networkID := rootKey(t, 0xA1)
+	memberPub, memberPriv := fixedKey(t, 0xB2)
+
+	srv := relayServing(t, relayclient.WellKnownRoot{
+		RootPubKey:   rootB64,
+		NetworkID:    networkID,
+		RootKeyEpoch: 1,
+	})
+
+	token, _, err := invite.Encode(invite.Invite{
+		NetworkID:  networkID,
+		Relay:      srv.URL,
+		RootPubKey: rootB64,
+	})
+	require.NoError(t, err)
+
+	return enrollHarness{
+		cfg: identitycli.EnrollConfig{
+			InviteTokenOrURL:   token,
+			DisplayName:        "Mira",
+			Slug:               "mira",
+			PubKeyB64:          base64.StdEncoding.EncodeToString(memberPub),
+			TransportPubKeyB64: lowEntropyTransportB64(),
+			AssumeYes:          true,
+			HTTPClient:         srv.Client(),
+			Signer:             &fakeSignerClient{priv: memberPriv},
+			Now:                func() time.Time { return time.Unix(2_000_000, 0) },
+			RandReader:         bytes.NewReader(bytes.Repeat([]byte{0x07}, 64)),
+		},
+		memberPub:  memberPub,
+		memberPriv: memberPriv,
+		networkID:  networkID,
+		relayURL:   srv.URL,
+	}
+}
+
+// runEnroll runs Enroll and returns the captured stdout/stderr plus the error.
+func runEnroll(cfg identitycli.EnrollConfig, in io.Reader) (out, errOut *bytes.Buffer, err error) {
+	out, errOut = &bytes.Buffer{}, &bytes.Buffer{}
+	if in == nil {
+		in = strings.NewReader("")
+	}
+	err = identitycli.Enroll(out, errOut, in, cfg)
+	return out, errOut, err
+}
+
+// TestEnrollHappyPath_EmitsVerifyingWire drives the full flow and proves the
+// emitted wire parses, carries a sig, and self-verifies (proof-of-possession).
+func TestEnrollHappyPath_EmitsVerifyingWire(t *testing.T) {
+	h := newEnrollHarness(t)
+	out, errOut, err := runEnroll(h.cfg, nil)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got), "emitted wire must be JSON: %q", out.String())
+	sigB64, ok := got[enrollment.FieldSig].(string)
+	require.True(t, ok, "wire must carry a sig")
+	assert.NotEmpty(t, sigB64)
+
+	// Reconstruct Fields from the emitted wire and verify the sig against the
+	// OWN pubkey.
+	rawSig, err := base64.StdEncoding.DecodeString(sigB64)
+	require.NoError(t, err)
+	fields := fieldsFromWire(t, got)
+	verified, verr := enrollment.VerifyEnrollment(fields, rawSig)
+	require.NoError(t, verr)
+	assert.True(t, verified, "emitted request must self-verify")
+
+	// stderr guidance carries the network, relay, and the signed note.
+	se := errOut.String()
+	assert.Contains(t, se, h.networkID)
+	assert.Contains(t, se, identitycli.EnrollSignedNote)
+	assert.Contains(t, se, identitycli.EnrollNextStepNote)
+}
+
+// fieldsFromWire reconstructs enrollment.Fields from the parsed wire JSON map so
+// a test can re-verify the signature.
+func fieldsFromWire(t *testing.T, m map[string]any) enrollment.Fields {
+	t.Helper()
+	f := enrollment.Fields{
+		AlgVersion:      int64(m[enrollment.FieldAlgVersion].(float64)),
+		Created:         int64(m[enrollment.FieldCreated].(float64)),
+		DisplayName:     m[enrollment.FieldDisplayName].(string),
+		KeyEpoch:        int64(m[enrollment.FieldKeyEpoch].(float64)),
+		NetworkID:       m[enrollment.FieldNetworkID].(string),
+		Nonce:           m[enrollment.FieldNonce].(string),
+		PubKey:          m[enrollment.FieldPubKey].(string),
+		Slug:            m[enrollment.FieldSlug].(string),
+		TransportPubKey: m[enrollment.FieldTransportPubKey].(string),
+	}
+	if v, ok := m[enrollment.FieldTransportEndpoint].(string); ok {
+		f.TransportEndpoint = &v
+	}
+	return f
+}
+
+// TestEnrollEmitsKeyEpoch1AndAlgVersion1 pins the hardcoded first-enrollment
+// invariants.
+func TestEnrollEmitsKeyEpoch1AndAlgVersion1(t *testing.T) {
+	h := newEnrollHarness(t)
+	out, _, err := runEnroll(h.cfg, nil)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.EqualValues(t, 1, got[enrollment.FieldKeyEpoch])
+	assert.EqualValues(t, enrollment.AlgVersion, got[enrollment.FieldAlgVersion])
+	assert.EqualValues(t, 2_000_000, got[enrollment.FieldCreated])
+}
+
+// TestEnrollTransportEndpointOmittedWhenEmpty proves an empty endpoint is OMITTED
+// from the wire (absent != null), and a set one is present.
+func TestEnrollTransportEndpointOmittedWhenEmpty(t *testing.T) {
+	h := newEnrollHarness(t)
+	out, _, err := runEnroll(h.cfg, nil)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	_, present := got[enrollment.FieldTransportEndpoint]
+	assert.False(t, present, "transport_endpoint must be omitted when --transport-endpoint is empty")
+
+	h2 := newEnrollHarness(t)
+	h2.cfg.TransportEndpoint = "relay.example:51820"
+	out2, _, err := runEnroll(h2.cfg, nil)
+	require.NoError(t, err)
+	var got2 map[string]any
+	require.NoError(t, json.Unmarshal(out2.Bytes(), &got2))
+	assert.Equal(t, "relay.example:51820", got2[enrollment.FieldTransportEndpoint])
+}
+
+// TestEnrollInviteDecodeErrorPropagates covers the bad-invite branch.
+func TestEnrollInviteDecodeErrorPropagates(t *testing.T) {
+	cases := map[string]string{
+		"bad prefix": "not-an-invite",
+		"bad base64": "vmenroll1:!!!notbase64!!!",
+		"bad json":   "vmenroll1:" + base64.RawURLEncoding.EncodeToString([]byte("not json")),
+	}
+	for name, token := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := newEnrollHarness(t)
+			h.cfg.InviteTokenOrURL = token
+			out, _, err := runEnroll(h.cfg, nil)
+			require.Error(t, err)
+			assert.Empty(t, out.String(), "no request must be emitted on a bad invite")
+		})
+	}
+}
+
+// TestEnrollWellKnownFetchFailures covers non-200, malformed, and bad-scheme
+// relay responses.
+func TestEnrollWellKnownFetchFailures(t *testing.T) {
+	t.Run("non-200", func(t *testing.T) {
+		rootB64, networkID := rootKey(t, 0xA1)
+		mux := http.NewServeMux()
+		mux.HandleFunc(relayclient.WellKnownRootPath, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+		cfg := enrollCfgFor(t, srv.URL, srv.Client(), rootB64, networkID)
+		out, _, err := runEnroll(cfg, nil)
+		require.Error(t, err)
+		assert.Empty(t, out.String())
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		rootB64, networkID := rootKey(t, 0xA1)
+		mux := http.NewServeMux()
+		mux.HandleFunc(relayclient.WellKnownRootPath, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("{broken"))
+		})
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+		cfg := enrollCfgFor(t, srv.URL, srv.Client(), rootB64, networkID)
+		out, _, err := runEnroll(cfg, nil)
+		require.Error(t, err)
+		assert.Empty(t, out.String())
+	})
+}
+
+// enrollCfgFor builds a happy EnrollConfig pointing at relayURL, with an invite
+// for the given root, EXCEPT the relay may not actually serve a matching root —
+// callers use it to drive fetch/cross-check failure tests.
+func enrollCfgFor(t *testing.T, relayURL string, client *http.Client, rootB64, networkID string) identitycli.EnrollConfig {
+	t.Helper()
+	memberPub, memberPriv := fixedKey(t, 0xB2)
+	token, _, err := invite.Encode(invite.Invite{
+		NetworkID:  networkID,
+		Relay:      relayURL,
+		RootPubKey: rootB64,
+	})
+	require.NoError(t, err)
+	return identitycli.EnrollConfig{
+		InviteTokenOrURL:   token,
+		DisplayName:        "Mira",
+		Slug:               "mira",
+		PubKeyB64:          base64.StdEncoding.EncodeToString(memberPub),
+		TransportPubKeyB64: lowEntropyTransportB64(),
+		AssumeYes:          true,
+		HTTPClient:         client,
+		Signer:             &fakeSignerClient{priv: memberPriv},
+		Now:                func() time.Time { return time.Unix(2_000_000, 0) },
+		RandReader:         bytes.NewReader(bytes.Repeat([]byte{0x07}, 64)),
+	}
+}
+
+// TestEnrollCrossCheck_RelayRootMismatch: the relay advertises a DIFFERENT root
+// than the invite — a distinct hard error, no request emitted.
+func TestEnrollCrossCheck_RelayRootMismatch(t *testing.T) {
+	inviteRootB64, inviteNetwork := rootKey(t, 0xA1)
+	otherRootB64, otherNetwork := rootKey(t, 0xCC)
+
+	// Relay self-consistently advertises the OTHER root (pub matches its
+	// network_id), so the only failure is relay-root != invite-root.
+	srv := relayServing(t, relayclient.WellKnownRoot{
+		RootPubKey: otherRootB64,
+		NetworkID:  otherNetwork,
+	})
+	cfg := enrollCfgFor(t, srv.URL, srv.Client(), inviteRootB64, inviteNetwork)
+	out, _, err := runEnroll(cfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "wrong relay or MITM")
+	assert.Empty(t, out.String())
+}
+
+// TestEnrollCrossCheck_RelaySelfInconsistent: the relay's network_id does not
+// match NetworkID(its own advertised root) — a distinct hard error.
+func TestEnrollCrossCheck_RelaySelfInconsistent(t *testing.T) {
+	rootB64, networkID := rootKey(t, 0xA1)
+	srv := relayServing(t, relayclient.WellKnownRoot{
+		RootPubKey: rootB64,
+		NetworkID:  "vmnet1:00000000000000000000000000000000", // lies about its own id
+	})
+	cfg := enrollCfgFor(t, srv.URL, srv.Client(), rootB64, networkID)
+	out, _, err := runEnroll(cfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "self-inconsistent")
+	assert.Empty(t, out.String())
+}
+
+// TestEnrollCrossCheck_RelayRootDecodeFails: the relay advertises a non-key root
+// pubkey.
+func TestEnrollCrossCheck_RelayRootDecodeFails(t *testing.T) {
+	rootB64, networkID := rootKey(t, 0xA1)
+	srv := relayServing(t, relayclient.WellKnownRoot{
+		RootPubKey: "!!!not-base64!!!",
+		NetworkID:  networkID,
+	})
+	cfg := enrollCfgFor(t, srv.URL, srv.Client(), rootB64, networkID)
+	out, _, err := runEnroll(cfg, nil)
+	require.Error(t, err)
+	assert.Empty(t, out.String())
+}
+
+// NOTE on the network_id-mismatch cross-check (enroll.go: errEnrollNetworkIDMismatch):
+// it is DEFENSIVE DEPTH that cannot be reached via valid inputs. By the time the
+// flow reaches it, relay-root-bytes == invite-root-bytes is already proven, and
+// NetworkID is a pure function of the root, so NetworkID(relay) == NetworkID(invite);
+// the relay-self-consistency check (== root.NetworkID) and invite.Decode's binding
+// check (== inv.NetworkID) then force root.NetworkID == inv.NetworkID. The check
+// stays as a belt-and-suspenders guard the spec mandates as a distinct hard error.
+// Its sibling branches (relay-root mismatch, relay self-inconsistent) are covered
+// above.
+
+// TestEnrollFingerprintConfirm covers the interactive y/yes/Y accept and the
+// n/empty/garbage abort paths (no --yes).
+func TestEnrollFingerprintConfirm(t *testing.T) {
+	accept := []string{"y\n", "Y\n", "yes\n", " yes \n", "YES\n"}
+	for _, ans := range accept {
+		t.Run("accept-"+strings.TrimSpace(ans), func(t *testing.T) {
+			h := newEnrollHarness(t)
+			h.cfg.AssumeYes = false
+			out, errOut, err := runEnroll(h.cfg, strings.NewReader(ans))
+			require.NoError(t, err)
+			assert.NotEmpty(t, out.String(), "accepted confirm must emit a request")
+			assert.Contains(t, errOut.String(), identitycli.EnrollConfirmPrompt)
+		})
+	}
+
+	reject := []string{"n\n", "\n", "garbage\n", "no\n", ""}
+	for _, ans := range reject {
+		t.Run("reject-"+strings.TrimSpace(ans), func(t *testing.T) {
+			h := newEnrollHarness(t)
+			h.cfg.AssumeYes = false
+			out, _, err := runEnroll(h.cfg, strings.NewReader(ans))
+			require.Error(t, err)
+			assert.Empty(t, out.String(), "rejected confirm must emit nothing")
+		})
+	}
+}
+
+// TestEnrollYesSkipsPrompt proves --yes never prompts (no read from in) and
+// still emits.
+func TestEnrollYesSkipsPrompt(t *testing.T) {
+	h := newEnrollHarness(t) // AssumeYes=true
+	out, errOut, err := runEnroll(h.cfg, strings.NewReader("should-not-be-read"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.String())
+	assert.NotContains(t, errOut.String(), identitycli.EnrollConfirmPrompt)
+	assert.Contains(t, errOut.String(), identitycli.EnrollAutoConfirmedNote)
+}
+
+// TestEnrollSelfVerifyMismatch: the signer holds a DIFFERENT key than --pubkey.
+// Self-verify must fire loudly and emit NOTHING.
+func TestEnrollSelfVerifyMismatch(t *testing.T) {
+	h := newEnrollHarness(t)
+	// Replace the signer with one holding an unrelated key.
+	_, wrongPriv := fixedKey(t, 0x42)
+	h.cfg.Signer = &fakeSignerClient{priv: wrongPriv}
+
+	out, _, err := runEnroll(h.cfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), identitycli.ErrEnrollSelfVerify)
+	assert.Empty(t, out.String(), "self-verify failure must emit no request")
+}
+
+// TestEnrollSignerUnreachable wraps a signer failure with guidance and emits
+// nothing.
+func TestEnrollSignerUnreachable(t *testing.T) {
+	h := newEnrollHarness(t)
+	h.cfg.Signer = &fakeSignerClient{failErr: errors.New("dial unix: connection refused")}
+	out, _, err := runEnroll(h.cfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "identity signer")
+	assert.Empty(t, out.String())
+}
+
+// TestEnrollGateFailFast: a non-ASCII slug fails the enrollment gate with the
+// exact enrollment.Err* message BEFORE the signer is ever dialed (proven by a
+// signer that would FAIL if reached).
+func TestEnrollGateFailFast(t *testing.T) {
+	h := newEnrollHarness(t)
+	h.cfg.Slug = "miré" // non-ASCII -> ErrSlugASCII
+	// A signer that would error if called; the gate must short-circuit first.
+	h.cfg.Signer = &fakeSignerClient{failErr: errors.New("signer should NOT be dialed")}
+
+	out, _, err := runEnroll(h.cfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), enrollment.ErrSlugASCII)
+	assert.NotContains(t, err.Error(), "should NOT be dialed")
+	assert.Empty(t, out.String())
+}
+
+// TestEnrollRequiredFieldsFailClosed proves each missing required field is a
+// distinct fail-closed error with no network/signer interaction.
+func TestEnrollRequiredFieldsFailClosed(t *testing.T) {
+	base := newEnrollHarness(t).cfg
+	cases := map[string]func(*identitycli.EnrollConfig){
+		"invite":        func(c *identitycli.EnrollConfig) { c.InviteTokenOrURL = "" },
+		"display-name":  func(c *identitycli.EnrollConfig) { c.DisplayName = "" },
+		"slug":          func(c *identitycli.EnrollConfig) { c.Slug = "" },
+		"pubkey":        func(c *identitycli.EnrollConfig) { c.PubKeyB64 = "" },
+		"transport-pub": func(c *identitycli.EnrollConfig) { c.TransportPubKeyB64 = "" },
+	}
+	for name, mut := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := base
+			mut(&cfg)
+			out, _, err := runEnroll(cfg, nil)
+			require.Error(t, err)
+			assert.Empty(t, out.String())
+		})
+	}
+}
+
+// TestEnrollAcceptsEnrollURL proves the --invite value may be a full enroll URL
+// (token in the fragment), not just a bare token.
+func TestEnrollAcceptsEnrollURL(t *testing.T) {
+	h := newEnrollHarness(t)
+	_, url, err := invite.Encode(invite.Invite{
+		NetworkID:  h.networkID,
+		Relay:      h.relayURL,
+		RootPubKey: mustInviteRoot(t, h.cfg.InviteTokenOrURL),
+	})
+	require.NoError(t, err)
+	h.cfg.InviteTokenOrURL = url
+
+	out, _, err := runEnroll(h.cfg, nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.String())
+}
+
+// mustInviteRoot decodes the harness token to recover its root pubkey so the URL
+// variant is minted from the same anchor.
+func mustInviteRoot(t *testing.T, token string) string {
+	t.Helper()
+	inv, err := invite.Decode(token)
+	require.NoError(t, err)
+	return inv.RootPubKey
+}
+
+// TestEnrollWireStripSigEqualsCanonical ties the emitted wire to the signature:
+// dropping sig + re-canonicalizing equals the canonical bytes the signature
+// covers.
+func TestEnrollWireStripSigEqualsCanonical(t *testing.T) {
+	h := newEnrollHarness(t)
+	out, _, err := runEnroll(h.cfg, nil)
+	require.NoError(t, err)
+
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &obj))
+	delete(obj, enrollment.FieldSig)
+	stripped, err := json.Marshal(obj)
+	require.NoError(t, err)
+	recanon, err := identity.Canonicalize(stripped)
+	require.NoError(t, err)
+
+	fields := fieldsFromWire(t, mustReparse(t, out.Bytes()))
+	want, err := enrollment.CanonicalizeEnrollment(fields)
+	require.NoError(t, err)
+	assert.Equal(t, want.Bytes(), recanon.Bytes())
+}
+
+func mustReparse(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}
+
+// TestEnrollDefaultSeams exercises the PRODUCTION default seams: Now, RandReader,
+// and Signer are all left nil, so now()/rand() fall back to time.Now/crypto-rand
+// and signer() builds a real *signer.Client pointed at a dead socket. The flow
+// must reach the (unreachable) signer and fail closed with guidance — proving the
+// default seams are wired without needing a live daemon. HTTPClient is also left
+// nil so relayclient.FetchRoot's default-client branch runs.
+func TestEnrollDefaultSeams(t *testing.T) {
+	rootB64, networkID := rootKey(t, 0xA1)
+	memberPub, _ := fixedKey(t, 0xB2)
+	srv := relayServing(t, relayclient.WellKnownRoot{RootPubKey: rootB64, NetworkID: networkID})
+	token, _, err := invite.Encode(invite.Invite{NetworkID: networkID, Relay: srv.URL, RootPubKey: rootB64})
+	require.NoError(t, err)
+
+	cfg := identitycli.EnrollConfig{
+		InviteTokenOrURL:   token,
+		DisplayName:        "Mira",
+		Slug:               "mira",
+		PubKeyB64:          base64.StdEncoding.EncodeToString(memberPub),
+		TransportPubKeyB64: lowEntropyTransportB64(),
+		SignerSocket:       "/nonexistent/identity-signer.sock",
+		AssumeYes:          true,
+		// HTTPClient, Signer, Now, RandReader all nil => default seams.
+	}
+	out, _, err := runEnroll(cfg, nil)
+	require.Error(t, err, "default signer at a dead socket must fail closed")
+	assert.Contains(t, err.Error(), "identity signer")
+	assert.Empty(t, out.String())
+}

--- a/internal/onboard/COMMANDS.md
+++ b/internal/onboard/COMMANDS.md
@@ -56,6 +56,7 @@ Generated from the command tree — do not edit by hand (run `task generate:docs
 | `vaultmind hooks install` | Install Claude Code hook scripts into a project | you want to wire VaultMind into a project by writing its hook scripts. |
 | `vaultmind hooks uninstall` | Remove VaultMind's Claude Code hook entries from a project | you want to remove VaultMind's Claude Code hook entries from a project. |
 | `vaultmind identity` | Contract-B agent identity: keypair custody and signing | you need Contract-B agent identity: mint a keypair or sign an entry via the keyless signer. |
+| `vaultmind identity enroll` | Enroll into a Contract-B network from an invite, then self-sign the request | you are a member with an invite and want to enroll: cross-check the relay's root against the invite, confirm the fingerprint, and self-sign an enrollment request for your admin. |
 | `vaultmind identity init` | Mint an agent keypair and seal the private key to the signer | you are setting up an agent and need to mint its ed25519 keypair and seal the private key to the signer. |
 | `vaultmind identity invite` | Emit an UNSIGNED network invite carrying the trust anchor (Contract-B) | you are an admin and want to emit a network invite (the trust anchor plus relay, with an out-of-band fingerprint) for a member to enroll against. |
 | `vaultmind identity sign` | Validate, canonicalize, and sign an entry via the keyless signer | you have a Contract-B entry to sign and want it validated, canonicalized, and signed by the keyless signer. |


### PR DESCRIPTION
The member-onboarding verb — the half that converges with workhorse's now-merged enrollment-consume (E2). Consume a \`vmenroll1:\` invite → fetch the relay's \`/.well-known/vaultmind-root\` → security-spine cross-checks → OOB fingerprint confirm → assemble the frozen enrollment-request \`Fields\` → fail-fast canonicalize → keyless sign → proof-of-possession self-verify → emit the signed wire JSON for OOB handoff to the admin.

## What's here
- **`internal/identity/relayclient/`** (new) — `FetchRoot` for `/.well-known/vaultmind-root`: scheme-validated, context-bound (15s), bodyclose, forward-compatible decode. First outbound HTTP in the tool; introduces the `httptest` pattern.
- **`enrollment.MarshalWire`** (new exported) — the wire JSON (signed subset + `sig`, `transport_endpoint` omitempty/absent≠null). Field names match the frozen cross-language contract byte-exact; **canonicalization untouched** (the cross-language contract workhorse binds to is unchanged).
- **`identitycli.Enroll`** — the orchestrator. All seams (HTTPClient/Signer/Now/RandReader) injectable, defaulting when nil.
- **`cmd/identity_enroll.go`** — ultra-thin (ADR-001); config metadata + generated key constants (ADR-005).

## Security spine (cross-checks, each tested)
- relay root pubkey == invite root pubkey (raw bytes)
- relay self-consistency: `NetworkID(pub) == network_id`
- network_id match; invite-decode binding propagated (incl. the network-mismatch case)
- fail-closed: nothing emitted on confirm-abort, cross-check mismatch, or self-verify failure (signer key ≠ --pubkey caught loudly)

## Verification
- `task check` GREEN — all 23 checks, project coverage 87.02% (≥84%). New pkgs: enrollment 95.8%, relayclient 95.7%, identitycli 93.0%.
- Built TDD; multi-lens review (security / contract-parity / conventions) + adversarial verify. Contract-parity lens: 0 findings. One MEDIUM test-gap (missing network-mismatch case) caught and fixed (commit 8554bcc).

Next slice: `identity enroll-add` (admin consumes the emitted request → registry update), then the `doctor` mesh-section + quick-start docs.