### PR TITLE
feat(identity): persist OOB trust anchor at enroll + harden FetchRoot (Contract-B, sec-review M2)

### DIFF
--- a/cmd/identity.go
+++ b/cmd/identity.go
@@ -14,6 +14,10 @@ const (
 	signerKeyFilename = "identity-signer.key"
 	// signerSocketFilename is the 0600 Unix-domain socket the signer listens on.
 	signerSocketFilename = "identity-signer.sock"
+	// networkAnchorFilename is the 0600 file `identity enroll` pins the
+	// OOB-confirmed network trust anchor to (beside the signer key in the XDG data
+	// dir). A later `doctor` slice authenticates registry verification against it.
+	networkAnchorFilename = "network-roots.json"
 )
 
 var identityCmd = &cobra.Command{
@@ -41,4 +45,11 @@ func defaultSignerKeyPath() (string, error) {
 // defaultSignerSocketPath returns the signer socket path under the XDG state dir.
 func defaultSignerSocketPath() (string, error) {
 	return xdg.StateFile(signerSocketFilename)
+}
+
+// defaultNetworkAnchorPath returns the persisted-trust-anchor path under the XDG
+// data dir (beside the sealed signer key). `identity enroll` pins the
+// OOB-confirmed network root here; it is NOT a user flag.
+func defaultNetworkAnchorPath() (string, error) {
+	return xdg.DataFile(networkAnchorFilename)
 }

--- a/cmd/identity_enroll.go
+++ b/cmd/identity_enroll.go
@@ -25,6 +25,10 @@ func runIdentityEnroll(cmd *cobra.Command, _ []string) error {
 		}
 		sockPath = p
 	}
+	anchorPath, err := defaultNetworkAnchorPath()
+	if err != nil {
+		return fmt.Errorf("resolving network anchor path: %w", err)
+	}
 	cfg := identitycli.EnrollConfig{
 		InviteTokenOrURL:   getConfigValueWithFlags[string](cmd, "invite", config.KeyAppIdentityenrollInvite),
 		DisplayName:        getConfigValueWithFlags[string](cmd, "display-name", config.KeyAppIdentityenrollDisplayName),
@@ -33,6 +37,7 @@ func runIdentityEnroll(cmd *cobra.Command, _ []string) error {
 		TransportPubKeyB64: getConfigValueWithFlags[string](cmd, "transport-pubkey", config.KeyAppIdentityenrollTransportPubkey),
 		TransportEndpoint:  getConfigValueWithFlags[string](cmd, "transport-endpoint", config.KeyAppIdentityenrollTransportEndpoint),
 		SignerSocket:       sockPath,
+		AnchorStorePath:    anchorPath,
 		AssumeYes:          getConfigValueWithFlags[bool](cmd, "yes", config.KeyAppIdentityenrollYes),
 	}
 	return identitycli.Enroll(cmd.OutOrStdout(), cmd.ErrOrStderr(), cmd.InOrStdin(), cfg)

--- a/cmd/identity_test.go
+++ b/cmd/identity_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/anchor"
 	"github.com/peiman/vaultmind/internal/identity/enrollment"
 	"github.com/peiman/vaultmind/internal/identity/envelope"
 	"github.com/peiman/vaultmind/internal/identity/invite"
@@ -378,6 +379,17 @@ func TestDefaultSignerPathsResolveUnderXDG(t *testing.T) {
 	if keyPath == sockPath {
 		t.Fatal("key and socket default paths must differ")
 	}
+
+	anchorPath, err := defaultNetworkAnchorPath()
+	if err != nil {
+		t.Fatalf("defaultNetworkAnchorPath: %v", err)
+	}
+	if !strings.HasSuffix(anchorPath, networkAnchorFilename) {
+		t.Fatalf("anchor path %q does not end in %q", anchorPath, networkAnchorFilename)
+	}
+	if anchorPath == keyPath || anchorPath == sockPath {
+		t.Fatal("anchor default path must differ from key and socket paths")
+	}
 }
 
 // TestIdentityInviteCommandRoundTrips drives `identity invite` through RootCmd
@@ -501,6 +513,12 @@ func enrollRelayServer(t *testing.T, rootPub ed25519.PublicKey) (srv *httptest.S
 // so the emitted wire self-verifies (proof-of-possession). This exercises the
 // production cmd wiring (no seam injection): real signer.Client + real HTTP.
 func TestIdentityEnrollCommandHappyPath(t *testing.T) {
+	// Isolate the XDG data dir so the cmd-resolved anchor path lands in tmp (and
+	// the test can assert the anchor was persisted via the production wiring).
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
 	sockPath, memberPub := startCmdSigner(t)
 	rootPub, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -536,12 +554,31 @@ func TestIdentityEnrollCommandHappyPath(t *testing.T) {
 	if got[enrollment.FieldNetworkID] != networkID {
 		t.Fatalf("emitted network_id = %v, want %s", got[enrollment.FieldNetworkID], networkID)
 	}
+
+	// The cmd-resolved anchor path must now hold the OOB-confirmed root, proving
+	// the production wiring persists it (not just the seam-injected unit test).
+	anchorPath, err := defaultNetworkAnchorPath()
+	if err != nil {
+		t.Fatalf("defaultNetworkAnchorPath: %v", err)
+	}
+	anchors, err := anchor.Load(anchorPath)
+	if err != nil {
+		t.Fatalf("anchor.Load: %v", err)
+	}
+	if len(anchors) != 1 || anchors[0].NetworkID != networkID || anchors[0].RootPubKey != rootB64 {
+		t.Fatalf("persisted anchor = %+v, want one anchor for %s / %s", anchors, networkID, rootB64)
+	}
 }
 
 // TestIdentityEnrollCommandFailsClosedWhenSignerUnreachable drives the command
 // with a valid invite + relay but a dead signer socket, and asserts it fails
 // closed with no request emitted.
 func TestIdentityEnrollCommandFailsClosedWhenSignerUnreachable(t *testing.T) {
+	// Isolate the XDG data dir so the cmd-resolved anchor path lands in tmp.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
 	rootPub, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("GenerateKey root: %v", err)

--- a/internal/identity/anchor/anchor.go
+++ b/internal/identity/anchor/anchor.go
@@ -1,0 +1,236 @@
+// Package anchor is the SSOT for the persisted Contract-B trust anchor: the
+// out-of-band-confirmed {network_id, root_pubkey} pair that `identity enroll`
+// pins on first enrollment and that a later `doctor` slice authenticates registry
+// verification against. Persisting the anchor IS pinning the root, because
+// network_id = vmnet1:hex(SHA-256(root_pubkey)[:16]) — the 128-bit fingerprint
+// the member already confirmed OOB at enroll.
+//
+// Every stored anchor is INTERNALLY CONSISTENT: Upsert refuses any anchor whose
+// network_id does not derive from its own root_pubkey (a stored anchor that lies
+// about which root it pins is corrupt or hostile). Writes are ATOMIC (temp file
+// in the same dir + chmod 0600 + rename) so a crash never leaves a half-written
+// or corrupt anchor on disk.
+package anchor
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/peiman/vaultmind/internal/identity/registry"
+)
+
+// Persisted-file shape + permission constants (SSOT — referenced, never inlined).
+const (
+	// anchorFilePerm is the mode the persisted anchor file is chmod'd to: owner
+	// read/write only. The anchor is a trust-relevant artifact, so it is no more
+	// world-readable than the identity key beside it.
+	anchorFilePerm = 0600
+	// anchorDirPerm is the mode an absent parent dir is created with: owner-only.
+	anchorDirPerm = 0700
+	// anchorTempPattern is the temp-file name pattern used for the atomic write.
+	// The temp lives in the SAME dir as the target so os.Rename is atomic (a
+	// cross-device rename is not).
+	anchorTempPattern = "network-roots-*.json.tmp"
+)
+
+// Validation / decode error strings (SSOT). Each rejection is a distinct typed
+// error so a caller (and a test) can tell WHY an anchor was refused.
+const (
+	// ErrEmptyNetworkID is returned by Upsert when the anchor's NetworkID is empty.
+	ErrEmptyNetworkID = "anchor: network_id is empty"
+	// ErrBadNetworkIDPrefix is returned when the NetworkID lacks the vmnet1: prefix.
+	ErrBadNetworkIDPrefix = "anchor: network_id must carry the vmnet1: prefix"
+	// ErrRootPubKeyDecode is returned when RootPubKey is not base64-std of a valid
+	// ed25519 public key (bad base64 / wrong length / small-order reject).
+	ErrRootPubKeyDecode = "anchor: root_pubkey is not a valid base64-std ed25519 public key"
+	// ErrNetworkIDMismatch is returned when NetworkID != NetworkID(root_pubkey) —
+	// the anchor is internally inconsistent (corrupt or hostile): its network_id
+	// does not derive from the root it claims to pin.
+	ErrNetworkIDMismatch = "anchor: network_id does not derive from root_pubkey — anchor is internally inconsistent"
+	// errDecodeStore wraps a malformed on-disk anchor store.
+	errDecodeStore = "anchor: decode anchor store"
+	// errWriteTemp wraps a temp-file write failure during the atomic write.
+	errWriteTemp = "anchor: write temp anchor file"
+	// errRenameTemp wraps the temp→final rename failure during the atomic write.
+	errRenameTemp = "anchor: rename temp anchor file into place"
+	// errMkdirParent wraps a parent-dir creation failure.
+	errMkdirParent = "anchor: create anchor parent directory"
+	// errMarshalStore wraps a marshal failure of the anchor store (should not
+	// happen for a struct of validated strings).
+	errMarshalStore = "anchor: marshal anchor store"
+)
+
+// NetworkAnchor is one persisted trust anchor: the OOB-confirmed root of a single
+// network. RootPubKey is base64-std (padded) of the 32-byte ed25519 ROOT public
+// key — the same encoding the invite carries — and NetworkID is the vmnet1: id
+// that derives from it.
+type NetworkAnchor struct {
+	NetworkID   string `json:"network_id"`
+	RootPubKey  string `json:"root_pubkey"`
+	ConfirmedAt int64  `json:"confirmed_at"`
+	Relay       string `json:"relay,omitempty"`
+}
+
+// store is the on-disk envelope: a top-level "networks" array, multi-network
+// forward-compatible so a member can be enrolled in more than one network.
+type store struct {
+	Networks []NetworkAnchor `json:"networks"`
+}
+
+// Load reads the anchor store at path and returns its anchors. A MISSING file
+// returns (nil, nil) — a not-yet-enrolled member legitimately has no anchor, so
+// absence is NOT an error (and nilnil does not fire: the return is a slice, not a
+// pointer-error pair). A present-but-malformed file IS an error: the store is
+// strictly decoded (unknown fields and trailing bytes are rejected) because a
+// corrupt trust anchor must fail loud, never be silently tolerated.
+func Load(path string) ([]NetworkAnchor, error) {
+	// path is cmd-resolved via xdg.DataFile (defaultNetworkAnchorPath) or
+	// test-supplied — never external/attacker-controlled input.
+	// #nosec G304
+	// nosemgrep: go-path-traversal
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	s, err := decodeStore(raw)
+	if err != nil {
+		return nil, err
+	}
+	return s.Networks, nil
+}
+
+// Upsert validates a, then replaces the existing anchor whose NetworkID matches
+// (or appends a new one) and writes the store back ATOMICALLY. The anchor is
+// rejected unless it is internally consistent — vmnet1: prefix, a valid
+// (small-order-rejected) 32-byte ed25519 root pubkey, AND
+// NetworkID == NetworkID(root_pubkey) — so a corrupt or hostile anchor never
+// reaches disk. An absent parent dir is created (0700).
+func Upsert(path string, a NetworkAnchor) error {
+	if err := validate(a); err != nil {
+		return err
+	}
+	existing, err := Load(path)
+	if err != nil {
+		return err
+	}
+	existing = upsertInto(existing, a)
+	return writeStoreAtomic(path, store{Networks: existing})
+}
+
+// Find returns the anchor whose NetworkID equals networkID, and a found flag.
+// It is the lookup helper a later doctor slice uses to resolve the pinned root
+// for a given network.
+func Find(anchors []NetworkAnchor, networkID string) (NetworkAnchor, bool) {
+	for _, a := range anchors {
+		if a.NetworkID == networkID {
+			return a, true
+		}
+	}
+	return NetworkAnchor{}, false
+}
+
+// upsertInto replaces the matching-NetworkID entry in anchors (preserving order)
+// or appends a when none matches. It returns the updated slice.
+func upsertInto(anchors []NetworkAnchor, a NetworkAnchor) []NetworkAnchor {
+	for i := range anchors {
+		if anchors[i].NetworkID == a.NetworkID {
+			anchors[i] = a
+			return anchors
+		}
+	}
+	return append(anchors, a)
+}
+
+// validate enforces the anchor's internal consistency: non-empty vmnet1: id, a
+// valid (small-order-rejected) 32-byte ed25519 root pubkey, and the binding
+// NetworkID == NetworkID(root_pubkey). A stored anchor whose network_id does not
+// derive from its root pins nothing — reject it.
+func validate(a NetworkAnchor) error {
+	if a.NetworkID == "" {
+		return fmt.Errorf("%s", ErrEmptyNetworkID)
+	}
+	if !hasGlobalPrefix(a.NetworkID) {
+		return fmt.Errorf("%s", ErrBadNetworkIDPrefix)
+	}
+	raw, err := base64.StdEncoding.DecodeString(a.RootPubKey)
+	if err != nil {
+		return fmt.Errorf("%s", ErrRootPubKeyDecode)
+	}
+	pub, err := registry.NewPublicKey(raw)
+	if err != nil {
+		return fmt.Errorf("%s", ErrRootPubKeyDecode)
+	}
+	if registry.NetworkID(pub.Bytes()) != a.NetworkID {
+		return fmt.Errorf("%s", ErrNetworkIDMismatch)
+	}
+	return nil
+}
+
+// hasGlobalPrefix reports whether id carries the reserved vmnet1: global prefix.
+func hasGlobalPrefix(id string) bool {
+	return len(id) >= len(registry.GlobalPrefix) && id[:len(registry.GlobalPrefix)] == registry.GlobalPrefix
+}
+
+// decodeStore strictly decodes raw into a store: unknown fields are rejected and
+// trailing bytes after the first JSON value are rejected, so a corrupt or
+// tampered store fails loud instead of being partially accepted.
+func decodeStore(raw []byte) (store, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var s store
+	if err := dec.Decode(&s); err != nil {
+		return store{}, fmt.Errorf("%s: %w", errDecodeStore, err)
+	}
+	if dec.More() {
+		return store{}, fmt.Errorf("%s: trailing data after JSON value", errDecodeStore)
+	}
+	return s, nil
+}
+
+// writeStoreAtomic marshals s and writes it to path atomically: it creates an
+// absent parent dir (0700), writes a temp file in the SAME dir, chmods it 0600,
+// and renames it into place. A crash mid-write leaves either the old file or no
+// new file — never a half-written anchor.
+func writeStoreAtomic(path string, s store) error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("%s: %w", errMarshalStore, err)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, anchorDirPerm); err != nil {
+		return fmt.Errorf("%s: %w", errMkdirParent, err)
+	}
+	tmp, err := os.CreateTemp(dir, anchorTempPattern)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errWriteTemp, err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup if we bail before the rename succeeds; after a
+	// successful rename the temp name no longer exists, so the remove is a no-op.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("%s: %w", errWriteTemp, err)
+	}
+	if err := tmp.Chmod(anchorFilePerm); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("%s: %w", errWriteTemp, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("%s: %w", errWriteTemp, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("%s: %w", errRenameTemp, err)
+	}
+	return nil
+}

--- a/internal/identity/anchor/anchor_test.go
+++ b/internal/identity/anchor/anchor_test.go
@@ -70,6 +70,7 @@ func TestUpsertCreatesParentDir(t *testing.T) {
 	info, err := os.Stat(dir)
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "absent parent dir must be created 0700")
 }
 
 // TestUpsertWritesFileMode0600 proves the persisted file is chmod 0600.

--- a/internal/identity/anchor/anchor_test.go
+++ b/internal/identity/anchor/anchor_test.go
@@ -1,0 +1,283 @@
+package anchor_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/identity/anchor"
+	"github.com/peiman/vaultmind/internal/identity/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedRoot mints a deterministic LOW-ENTROPY root keypair from a one-byte seed
+// fill (so the gitleaks entropy scanner stays quiet) and returns its base64-std
+// pubkey plus the network id it derives. Reusing ed25519.NewKeyFromSeed keeps the
+// keys reproducible across runs.
+func fixedRoot(t *testing.T, fill byte) (rootB64, networkID string) {
+	t.Helper()
+	seed := bytes.Repeat([]byte{fill}, ed25519.SeedSize)
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	return base64.StdEncoding.EncodeToString(pub), registry.NetworkID(pub)
+}
+
+// anchorFor builds an internally consistent NetworkAnchor for the given seed.
+func anchorFor(t *testing.T, fill byte) anchor.NetworkAnchor {
+	t.Helper()
+	rootB64, networkID := fixedRoot(t, fill)
+	return anchor.NetworkAnchor{
+		NetworkID:   networkID,
+		RootPubKey:  rootB64,
+		ConfirmedAt: 2_000_000,
+		Relay:       "https://relay.example",
+	}
+}
+
+// TestLoadMissingFileReturnsNilNil proves a not-yet-enrolled member (no anchor
+// file) gets (nil, nil) — a missing file is NOT an error.
+func TestLoadMissingFileReturnsNilNil(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist", "network-roots.json")
+	got, err := anchor.Load(path)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// TestUpsertThenLoadRoundTrips proves an upserted anchor round-trips byte-for-byte
+// through Load.
+func TestUpsertThenLoadRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "network-roots.json")
+	a := anchorFor(t, 0xA1)
+	require.NoError(t, anchor.Upsert(path, a))
+
+	got, err := anchor.Load(path)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, a, got[0])
+}
+
+// TestUpsertCreatesParentDir proves Upsert creates an absent parent dir (0700).
+func TestUpsertCreatesParentDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "identity")
+	path := filepath.Join(dir, "network-roots.json")
+	require.NoError(t, anchor.Upsert(path, anchorFor(t, 0xA1)))
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+// TestUpsertWritesFileMode0600 proves the persisted file is chmod 0600.
+func TestUpsertWritesFileMode0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "network-roots.json")
+	require.NoError(t, anchor.Upsert(path, anchorFor(t, 0xA1)))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+// TestUpsertNewAppends proves upserting a SECOND distinct network appends rather
+// than replacing the first (multi-network forward-compatible).
+func TestUpsertNewAppends(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "network-roots.json")
+	a1 := anchorFor(t, 0xA1)
+	a2 := anchorFor(t, 0xB2)
+	require.NoError(t, anchor.Upsert(path, a1))
+	require.NoError(t, anchor.Upsert(path, a2))
+
+	got, err := anchor.Load(path)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, a1, got[0])
+	assert.Equal(t, a2, got[1])
+}
+
+// TestUpsertExistingReplaces proves re-upserting the SAME network replaces the
+// entry (no duplicate) and updates the mutable fields.
+func TestUpsertExistingReplaces(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "network-roots.json")
+	a := anchorFor(t, 0xA1)
+	require.NoError(t, anchor.Upsert(path, a))
+
+	updated := a
+	updated.ConfirmedAt = 3_000_000
+	updated.Relay = "https://relay2.example"
+	require.NoError(t, anchor.Upsert(path, updated))
+
+	got, err := anchor.Load(path)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "re-upserting the same network must NOT duplicate")
+	assert.Equal(t, updated, got[0])
+}
+
+// TestUpsertReplacesPreservesOrder proves replacing a middle entry keeps the
+// other entries in place.
+func TestUpsertReplacesPreservesOrder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "network-roots.json")
+	a1, a2, a3 := anchorFor(t, 0xA1), anchorFor(t, 0xB2), anchorFor(t, 0xC3)
+	require.NoError(t, anchor.Upsert(path, a1))
+	require.NoError(t, anchor.Upsert(path, a2))
+	require.NoError(t, anchor.Upsert(path, a3))
+
+	updated := a2
+	updated.ConfirmedAt = 9_000_000
+	require.NoError(t, anchor.Upsert(path, updated))
+
+	got, err := anchor.Load(path)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, a1, got[0])
+	assert.Equal(t, updated, got[1])
+	assert.Equal(t, a3, got[2])
+}
+
+// TestUpsertNoTempLeftBehind proves the atomic write leaves no temp file beside
+// the target after a successful Upsert.
+func TestUpsertNoTempLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "network-roots.json")
+	require.NoError(t, anchor.Upsert(path, anchorFor(t, 0xA1)))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the final file must remain — no temp leftover")
+	assert.Equal(t, "network-roots.json", entries[0].Name())
+}
+
+// TestUpsertOnDiskShape pins the on-disk JSON envelope shape: a top-level
+// "networks" array of anchors.
+func TestUpsertOnDiskShape(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "network-roots.json")
+	a := anchorFor(t, 0xA1)
+	require.NoError(t, anchor.Upsert(path, a))
+
+	raw, err := os.ReadFile(path) //nolint:gosec // test reads its own temp file
+	require.NoError(t, err)
+	var env struct {
+		Networks []anchor.NetworkAnchor `json:"networks"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	require.Len(t, env.Networks, 1)
+	assert.Equal(t, a, env.Networks[0])
+}
+
+// TestLoadMalformedJSONErrors proves a malformed / non-object body is an error.
+func TestLoadMalformedJSONErrors(t *testing.T) {
+	cases := map[string]string{
+		"truncated":     "{not json",
+		"trailing junk": `{"networks":[]}trailing`,
+		"unknown field": `{"networks":[],"evil":1}`,
+		"wrong type":    `{"networks":"not-an-array"}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "network-roots.json")
+			require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+			_, err := anchor.Load(path)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestUpsertRejectsBadAnchor proves Upsert validates internal consistency: a bad
+// pubkey, a network_id that does not derive from the root, a non-vmnet1 prefix,
+// and an empty network_id are all rejected — and the file is NOT created.
+func TestUpsertRejectsBadAnchor(t *testing.T) {
+	rootB64, networkID := fixedRoot(t, 0xA1)
+	otherRootB64, otherNetwork := fixedRoot(t, 0xB2)
+
+	cases := map[string]anchor.NetworkAnchor{
+		"empty network_id": {NetworkID: "", RootPubKey: rootB64, ConfirmedAt: 1},
+		"non-vmnet1 prefix": {
+			NetworkID:  "vmnetX:deadbeefdeadbeefdeadbeefdeadbeef",
+			RootPubKey: rootB64,
+		},
+		"bad base64 pubkey": {NetworkID: networkID, RootPubKey: "!!!not-base64!!!"},
+		"wrong-length pubkey": {
+			NetworkID:  networkID,
+			RootPubKey: base64.StdEncoding.EncodeToString([]byte("too-short")),
+		},
+		"network_id does not derive from root": {
+			NetworkID:  otherNetwork, // derives from otherRoot, not rootB64
+			RootPubKey: rootB64,
+		},
+		"root derives a different network_id": {
+			NetworkID:  networkID, // derives from rootB64, not otherRoot
+			RootPubKey: otherRootB64,
+		},
+	}
+	for name, a := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "network-roots.json")
+			err := anchor.Upsert(path, a)
+			require.Error(t, err)
+			_, statErr := os.Stat(path)
+			assert.True(t, os.IsNotExist(statErr), "a rejected anchor must NOT create the file")
+		})
+	}
+}
+
+// TestUpsertRejectsSmallOrderPubKey proves a small-order (universal-forgery)
+// 32-byte pubkey is rejected even when correct-length.
+func TestUpsertRejectsSmallOrderPubKey(t *testing.T) {
+	// The 32-byte all-zero key is small-order; NewPublicKey rejects it.
+	smallOrder := base64.StdEncoding.EncodeToString(make([]byte, ed25519.PublicKeySize))
+	path := filepath.Join(t.TempDir(), "network-roots.json")
+	err := anchor.Upsert(path, anchor.NetworkAnchor{
+		NetworkID:  registry.NetworkID(make([]byte, ed25519.PublicKeySize)),
+		RootPubKey: smallOrder,
+	})
+	require.Error(t, err)
+}
+
+// TestLoadReadErrorPropagates proves a read error that is NOT "missing file"
+// (e.g. path is a directory) surfaces as an error, not (nil, nil).
+func TestLoadReadErrorPropagates(t *testing.T) {
+	dir := t.TempDir() // a directory, not a regular file
+	_, err := anchor.Load(dir)
+	require.Error(t, err, "reading a directory as the store must error, not return (nil,nil)")
+}
+
+// TestUpsertPropagatesMalformedExisting proves Upsert fails (does not silently
+// overwrite) when the existing on-disk store is malformed — a corrupt store must
+// fail loud, not be clobbered.
+func TestUpsertPropagatesMalformedExisting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "network-roots.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0600))
+	err := anchor.Upsert(path, anchorFor(t, 0xA1))
+	require.Error(t, err)
+}
+
+// TestUpsertRenameFailsWhenTargetIsDir proves the atomic rename fails loud when
+// the target path is an existing directory (rename-onto-dir is rejected), so a
+// write that cannot complete atomically surfaces an error.
+func TestUpsertRenameFailsWhenTargetIsDir(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "network-roots.json")
+	require.NoError(t, os.Mkdir(target, 0700)) // make the target a DIRECTORY
+	err := anchor.Upsert(target, anchorFor(t, 0xA1))
+	require.Error(t, err, "renaming the temp file onto an existing directory must fail")
+}
+
+// TestFind proves the lookup helper returns the matching anchor and a found flag,
+// and (zero, false) on a miss.
+func TestFind(t *testing.T) {
+	a1, a2 := anchorFor(t, 0xA1), anchorFor(t, 0xB2)
+	anchors := []anchor.NetworkAnchor{a1, a2}
+
+	got, ok := anchor.Find(anchors, a2.NetworkID)
+	require.True(t, ok)
+	assert.Equal(t, a2, got)
+
+	_, ok = anchor.Find(anchors, "vmnet1:00000000000000000000000000000000")
+	assert.False(t, ok)
+
+	_, ok = anchor.Find(nil, a1.NetworkID)
+	assert.False(t, ok)
+}

--- a/internal/identity/relayclient/export_test.go
+++ b/internal/identity/relayclient/export_test.go
@@ -1,0 +1,12 @@
+package relayclient
+
+import "time"
+
+// SetFetchTimeoutForTest overrides the internal fetch deadline for a single test
+// and returns a restore func. It exists ONLY so a deadline test can use a short
+// timeout instead of waiting the production 15s; production code never calls it.
+func SetFetchTimeoutForTest(d time.Duration) (restore func()) {
+	prev := relayFetchTimeout
+	relayFetchTimeout = d
+	return func() { relayFetchTimeout = prev }
+}

--- a/internal/identity/relayclient/relayclient.go
+++ b/internal/identity/relayclient/relayclient.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -18,10 +19,17 @@ import (
 // from. SSOT so the fetch path and any docs reference one definition.
 const WellKnownRootPath = "/.well-known/vaultmind-root"
 
-// relayFetchTimeout bounds a well-known fetch when the caller passes a nil
-// client (the default client gets this timeout). When the caller supplies a
-// client, its own timeout/transport wins.
-const relayFetchTimeout = 15 * time.Second
+// maxRootBodyBytes caps the well-known root response body before decode. The
+// legit payload is ~150 B; 64 KiB is generous headroom while bounding a hostile
+// or runaway relay so a no-cap decode can never OOM the keyless CLI. A body that
+// hits the cap fails LOUD (a decode error), never silently truncated.
+const maxRootBodyBytes = 64 << 10
+
+// relayFetchTimeout bounds EVERY well-known fetch: FetchRoot wraps the request in
+// a context.WithTimeout(relayFetchTimeout) of its own, so even a caller-supplied
+// no-timeout *http.Client cannot hang the fetch. It is a var (not a const) ONLY so
+// a test can shorten it via SetFetchTimeoutForTest; production never reassigns it.
+var relayFetchTimeout = 15 * time.Second
 
 // Error strings (SSOT). Each failure mode is a distinct typed reject so the
 // enroll flow can tell a misconfigured base URL from a dead relay.
@@ -66,21 +74,31 @@ type WellKnownRoot struct {
 
 // FetchRoot GETs {relayBaseURL}/.well-known/vaultmind-root and decodes the
 // WellKnownRoot. It validates the base URL scheme (http/https only) BEFORE
-// dialing, uses a context-bound request, and FAILS CLOSED on a non-200 status
-// or a malformed body. It deliberately does NOT DisallowUnknownFields so the
+// dialing, wraps the request in its OWN context.WithTimeout(relayFetchTimeout) so
+// a caller-supplied no-timeout client can never hang it, CAPS the response body
+// at maxRootBodyBytes before decode, and FAILS CLOSED on a non-200 status or a
+// malformed/over-cap body. It deliberately does NOT DisallowUnknownFields so the
 // relay can add forward-compatible fields without breaking older members.
 //
-// client may be nil; a timeout-bounded default client is used in that case. The
-// returned WellKnownRoot is UNTRUSTED — the caller must cross-check it against
-// the invite before relying on it.
+// This client is intentionally remote-permissive (enroll fetches REMOTE relays):
+// it does NOT loopback-pin — that is a separate doctor-only client in a later
+// slice. client may be nil; a default client is used in that case. The returned
+// WellKnownRoot is UNTRUSTED — the caller must cross-check it against the invite
+// before relying on it.
 func FetchRoot(ctx context.Context, client *http.Client, relayBaseURL string) (WellKnownRoot, error) {
 	endpoint, err := wellKnownURL(relayBaseURL)
 	if err != nil {
 		return WellKnownRoot{}, err
 	}
 	if client == nil {
-		client = &http.Client{Timeout: relayFetchTimeout}
+		client = &http.Client{}
 	}
+
+	// Inescapable deadline: bound the request inside FetchRoot so a caller-supplied
+	// *http.Client with no Timeout (and a context with no deadline) still cannot
+	// hang the fetch.
+	ctx, cancel := context.WithTimeout(ctx, relayFetchTimeout)
+	defer cancel()
 
 	//nolint:gosec // relay base URL is operator-provided via the signed invite; scheme validated above
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
@@ -98,8 +116,11 @@ func FetchRoot(ctx context.Context, client *http.Client, relayBaseURL string) (W
 		return WellKnownRoot{}, fmt.Errorf("%s: %d", errStatus, resp.StatusCode)
 	}
 
+	// Cap the body before decode: a runaway/hostile relay cannot OOM the CLI. An
+	// over-cap body surfaces as a decode error (the JSON value is cut short), which
+	// fails loud rather than silently truncating.
 	var root WellKnownRoot
-	if err := json.NewDecoder(resp.Body).Decode(&root); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxRootBodyBytes)).Decode(&root); err != nil {
 		return WellKnownRoot{}, fmt.Errorf("%s: %w", errDecode, err)
 	}
 	return root, nil

--- a/internal/identity/relayclient/relayclient_test.go
+++ b/internal/identity/relayclient/relayclient_test.go
@@ -1,6 +1,7 @@
 package relayclient_test
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -124,6 +125,67 @@ func TestFetchRootNilClientUsesDefault(t *testing.T) {
 	got, err := relayclient.FetchRoot(context.Background(), nil, srv.URL)
 	require.NoError(t, err)
 	assert.Equal(t, lowEntropyRootB64, got.RootPubKey)
+}
+
+// TestFetchRootOversizedBodyFails proves a body exceeding the 64 KiB cap fails
+// LOUD (a decode/oversize error) instead of being silently truncated or OOMing
+// the CLI. The server streams far more than the cap; FetchRoot must error.
+func TestFetchRootOversizedBodyFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(relayclient.WellKnownRootPath, func(w http.ResponseWriter, _ *http.Request) {
+		// A syntactically-open object followed by a huge run of whitespace: the
+		// decoder must keep reading past the cap and hit the LimitReader's EOF,
+		// which surfaces as a decode error rather than a successful parse.
+		_, _ = w.Write([]byte(`{"root_pubkey":"`))
+		filler := bytes.Repeat([]byte("A"), 128<<10) // 128 KiB > 64 KiB cap
+		_, _ = w.Write(filler)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	_, err := relayclient.FetchRoot(context.Background(), srv.Client(), srv.URL)
+	require.Error(t, err, "an over-cap body must fail loud, never silently truncate")
+}
+
+// TestFetchRootValidBodyUnderCapSucceeds is the boundary companion to the
+// oversized test: a legitimate small payload decodes fine under the cap.
+func TestFetchRootValidBodyUnderCapSucceeds(t *testing.T) {
+	srv := newRelay(t, http.StatusOK, wellKnownBody)
+	got, err := relayclient.FetchRoot(context.Background(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, lowEntropyRootB64, got.RootPubKey)
+}
+
+// TestFetchRootInternalDeadlineBoundsNoTimeoutClient proves the deadline FetchRoot
+// applies INTERNALLY bounds a caller-supplied client that has NO timeout — a slow
+// server cannot hang the fetch. The internal timeout is overridden short for the
+// test so it doesn't take 15s.
+func TestFetchRootInternalDeadlineBoundsNoTimeoutClient(t *testing.T) {
+	restore := relayclient.SetFetchTimeoutForTest(20 * time.Millisecond)
+	t.Cleanup(restore)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(relayclient.WellKnownRootPath, func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second) // far longer than the overridden internal deadline
+		_, _ = w.Write([]byte(wellKnownBody))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// A client with NO timeout (and the parent context has none either): the ONLY
+	// bound is FetchRoot's internal context.WithTimeout.
+	noTimeoutClient := &http.Client{}
+	done := make(chan error, 1)
+	go func() {
+		_, err := relayclient.FetchRoot(context.Background(), noTimeoutClient, srv.URL)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.Error(t, err, "the internal deadline must bound a no-timeout client")
+	case <-time.After(1 * time.Second):
+		t.Fatal("FetchRoot hung past the internal deadline — no inescapable timeout")
+	}
 }
 
 // TestFetchRootDecodesTestdataFixture serves the committed testdata fixture and

--- a/internal/identitycli/enroll.go
+++ b/internal/identitycli/enroll.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/peiman/vaultmind/internal/identity/anchor"
 	"github.com/peiman/vaultmind/internal/identity/enrollment"
 	"github.com/peiman/vaultmind/internal/identity/invite"
 	"github.com/peiman/vaultmind/internal/identity/registry"
@@ -50,6 +51,9 @@ const (
 	EnrollSignedNote = "✓ signed & self-verified"
 	// EnrollNextStepNote tells the member to hand the emitted request to the admin.
 	EnrollNextStepNote = "hand this to your admin out-of-band; they run `vaultmind identity enroll-add`."
+	// EnrollAnchorPinnedNote confirms the OOB-confirmed network root was persisted
+	// so a future `vaultmind doctor` authenticates registry verification against it.
+	EnrollAnchorPinnedNote = "✓ pinned this network's root (a future `vaultmind doctor` will authenticate against it)"
 )
 
 // Enroll error strings (SSOT). Each failure mode is a distinct typed reject so
@@ -65,6 +69,10 @@ const (
 	ErrEnrollEmptyPubKey = "identitycli: --pubkey is required (your base64-std ed25519 identity pubkey)"
 	// ErrEnrollEmptyTransportPubKey is returned when --transport-pubkey is empty.
 	ErrEnrollEmptyTransportPubKey = "identitycli: --transport-pubkey is required (your base64-std WireGuard pubkey)"
+	// ErrEnrollEmptyAnchorPath is returned when AnchorStorePath is empty. The cmd
+	// layer always resolves it (xdg.DataFile); an empty value is a PROGRAMMING
+	// error, surfaced fail-closed before any network/signer interaction.
+	ErrEnrollEmptyAnchorPath = "identitycli: AnchorStorePath is empty (programming error: the cmd layer must set it)"
 
 	// errEnrollDecodeInvite wraps an invite.Decode failure (bad prefix/base64/json
 	// or network-id mismatch).
@@ -100,6 +108,10 @@ const (
 	// ErrEnrollSelfVerify is returned when proof-of-possession self-verification
 	// fails: the running signer holds a DIFFERENT key than --pubkey.
 	ErrEnrollSelfVerify = "self-signature failed to verify: the running signer's identity key does not match --pubkey (run `identity signer` with the key whose public half you passed to --pubkey)"
+	// ErrEnrollPersistAnchor wraps a failure to persist the OOB-confirmed trust
+	// anchor. Enroll FAILS CLOSED on it: the request is NOT emitted, so there is
+	// never a half-state (a request handed to the admin without the pinned root).
+	ErrEnrollPersistAnchor = "identitycli: persist network trust anchor"
 )
 
 // EnrollConfig carries everything the member-enroll flow needs, with injectable
@@ -113,6 +125,11 @@ type EnrollConfig struct {
 	TransportPubKeyB64 string // --transport-pubkey (base64-std WireGuard pubkey)
 	TransportEndpoint  string // --transport-endpoint (optional host:port; "" => omitted)
 	SignerSocket       string // --signer-socket
+
+	// AnchorStorePath is the file the OOB-confirmed trust anchor is pinned to. It
+	// is NOT a user flag — the cmd layer resolves it via defaultNetworkAnchorPath()
+	// (xdg.DataFile, beside the signer key). Empty is a programming error.
+	AnchorStorePath string
 
 	AssumeYes bool // --yes (skip the OOB fingerprint confirmation prompt)
 
@@ -179,6 +196,15 @@ func Enroll(out, errOut io.Writer, in io.Reader, cfg EnrollConfig) error {
 		return err
 	}
 
+	// Persist the now-OOB-authenticated trust anchor BEFORE signing/emitting. By
+	// here crossCheckRoot has proven the served root == the invite root, so
+	// inv.RootPubKey is authenticated; persisting {network_id, root_pubkey} pins
+	// the root for a future `doctor`. FAIL CLOSED: if the anchor cannot be saved,
+	// emit NOTHING — never hand the admin a request without the matching pin.
+	if err := persistAnchor(cfg, inv); err != nil {
+		return err
+	}
+
 	fields, err := assembleFields(cfg, inv)
 	if err != nil {
 		return err
@@ -223,6 +249,8 @@ func validateEnrollConfig(cfg EnrollConfig) error {
 		return fmt.Errorf("%s", ErrEnrollEmptyPubKey)
 	case cfg.TransportPubKeyB64 == "":
 		return fmt.Errorf("%s", ErrEnrollEmptyTransportPubKey)
+	case cfg.AnchorStorePath == "":
+		return fmt.Errorf("%s", ErrEnrollEmptyAnchorPath)
 	}
 	return nil
 }
@@ -294,6 +322,23 @@ func readLine(in io.Reader) (string, error) {
 	}
 }
 
+// persistAnchor pins the OOB-confirmed network root to cfg.AnchorStorePath. It is
+// called only AFTER crossCheckRoot + the fingerprint confirm, so inv.RootPubKey is
+// authenticated. anchor.Upsert validates internal consistency and writes
+// atomically; any failure is wrapped fail-closed so Enroll emits no request.
+func persistAnchor(cfg EnrollConfig, inv invite.Invite) error {
+	a := anchor.NetworkAnchor{
+		NetworkID:   inv.NetworkID,
+		RootPubKey:  inv.RootPubKey,
+		ConfirmedAt: cfg.now().Unix(),
+		Relay:       inv.Relay,
+	}
+	if err := anchor.Upsert(cfg.AnchorStorePath, a); err != nil {
+		return fmt.Errorf("%s: %w", ErrEnrollPersistAnchor, err)
+	}
+	return nil
+}
+
 // assembleFields builds the enrollment.Fields from cfg + the decoded invite.
 // transport_endpoint is nil (OMITTED) when --transport-endpoint is empty
 // (absent != null).
@@ -343,10 +388,11 @@ func writeEnrollGuidance(errOut io.Writer, inv invite.Invite, fp string, assumeY
 	if assumeYes {
 		confirm = EnrollAutoConfirmedNote
 	}
-	_, err := fmt.Fprintf(errOut, "%s%s\n%s%s\n%s%s (%s)\n%s\n%s\n",
+	_, err := fmt.Fprintf(errOut, "%s%s\n%s%s\n%s%s (%s)\n%s\n%s\n%s\n",
 		EnrollNetworkLabel, inv.NetworkID,
 		EnrollRelayLabel, inv.Relay,
 		EnrollFingerprintLabel, fp, confirm,
+		EnrollAnchorPinnedNote,
 		EnrollSignedNote,
 		EnrollNextStepNote,
 	)

--- a/internal/identitycli/enroll_test.go
+++ b/internal/identitycli/enroll_test.go
@@ -9,11 +9,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/anchor"
 	"github.com/peiman/vaultmind/internal/identity/enrollment"
 	"github.com/peiman/vaultmind/internal/identity/invite"
 	"github.com/peiman/vaultmind/internal/identity/registry"
@@ -114,6 +117,7 @@ func newEnrollHarness(t *testing.T) enrollHarness {
 			PubKeyB64:          base64.StdEncoding.EncodeToString(memberPub),
 			TransportPubKeyB64: lowEntropyTransportB64(),
 			AssumeYes:          true,
+			AnchorStorePath:    filepath.Join(t.TempDir(), "network-roots.json"),
 			HTTPClient:         srv.Client(),
 			Signer:             &fakeSignerClient{priv: memberPriv},
 			Now:                func() time.Time { return time.Unix(2_000_000, 0) },
@@ -313,6 +317,7 @@ func enrollCfgFor(t *testing.T, relayURL string, client *http.Client, rootB64, n
 		PubKeyB64:          base64.StdEncoding.EncodeToString(memberPub),
 		TransportPubKeyB64: lowEntropyTransportB64(),
 		AssumeYes:          true,
+		AnchorStorePath:    filepath.Join(t.TempDir(), "network-roots.json"),
 		HTTPClient:         client,
 		Signer:             &fakeSignerClient{priv: memberPriv},
 		Now:                func() time.Time { return time.Unix(2_000_000, 0) },
@@ -555,10 +560,80 @@ func TestEnrollDefaultSeams(t *testing.T) {
 		TransportPubKeyB64: lowEntropyTransportB64(),
 		SignerSocket:       "/nonexistent/identity-signer.sock",
 		AssumeYes:          true,
+		AnchorStorePath:    filepath.Join(t.TempDir(), "network-roots.json"),
 		// HTTPClient, Signer, Now, RandReader all nil => default seams.
 	}
 	out, _, err := runEnroll(cfg, nil)
 	require.Error(t, err, "default signer at a dead socket must fail closed")
 	assert.Contains(t, err.Error(), "identity signer")
+	assert.Empty(t, out.String())
+}
+
+// TestEnrollPersistsAnchor proves the happy path writes the OOB-confirmed trust
+// anchor to AnchorStorePath: network_id, root_pubkey, relay, and confirmed_at all
+// come from the invite + the fixed clock, and the persisted anchor is internally
+// consistent (Load re-validates the shape).
+func TestEnrollPersistsAnchor(t *testing.T) {
+	h := newEnrollHarness(t)
+	out, errOut, err := runEnroll(h.cfg, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, out.String())
+
+	anchors, err := anchor.Load(h.cfg.AnchorStorePath)
+	require.NoError(t, err)
+	require.Len(t, anchors, 1)
+
+	a := anchors[0]
+	assert.Equal(t, h.networkID, a.NetworkID)
+	assert.Equal(t, mustInviteRoot(t, h.cfg.InviteTokenOrURL), a.RootPubKey)
+	assert.Equal(t, h.relayURL, a.Relay)
+	assert.Equal(t, int64(2_000_000), a.ConfirmedAt, "confirmed_at must come from the fixed clock")
+
+	// errOut notes the root was pinned so a future doctor authenticates against it.
+	assert.Contains(t, errOut.String(), identitycli.EnrollAnchorPinnedNote)
+}
+
+// TestEnrollReEnrollUpsertsAnchor proves re-enrolling the SAME network replaces
+// the anchor in place (no duplicate) and refreshes confirmed_at.
+func TestEnrollReEnrollUpsertsAnchor(t *testing.T) {
+	h := newEnrollHarness(t)
+	_, _, err := runEnroll(h.cfg, nil)
+	require.NoError(t, err)
+
+	// Second enroll against the same network at a LATER clock, same store path.
+	h.cfg.Now = func() time.Time { return time.Unix(3_000_000, 0) }
+	_, _, err = runEnroll(h.cfg, nil)
+	require.NoError(t, err)
+
+	anchors, err := anchor.Load(h.cfg.AnchorStorePath)
+	require.NoError(t, err)
+	require.Len(t, anchors, 1, "re-enrolling the same network must NOT duplicate the anchor")
+	assert.Equal(t, int64(3_000_000), anchors[0].ConfirmedAt, "re-enroll must refresh confirmed_at")
+}
+
+// TestEnrollPersistFailureEmitsNothing proves a persist failure (an unwritable
+// store path) FAILS CLOSED: enroll returns an error and emits NO request — never
+// a half-state where the request is emitted but the anchor was not saved.
+func TestEnrollPersistFailureEmitsNothing(t *testing.T) {
+	h := newEnrollHarness(t)
+	// Make the store path unwritable: create a FILE where the parent dir would be,
+	// so MkdirAll of the anchor's parent dir fails.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0600))
+	h.cfg.AnchorStorePath = filepath.Join(blocker, "network-roots.json")
+
+	out, _, err := runEnroll(h.cfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), identitycli.ErrEnrollPersistAnchor)
+	assert.Empty(t, out.String(), "a persist failure must emit no request")
+}
+
+// TestEnrollEmptyAnchorPathIsProgrammingError proves an empty AnchorStorePath is a
+// fail-closed programming error (the cmd layer always sets it); no request emitted.
+func TestEnrollEmptyAnchorPathIsProgrammingError(t *testing.T) {
+	h := newEnrollHarness(t)
+	h.cfg.AnchorStorePath = ""
+	out, _, err := runEnroll(h.cfg, nil)
+	require.Error(t, err)
 	assert.Empty(t, out.String())
 }


### PR DESCRIPTION
Implements the security review's **M2** + the body-cap/deadline hardening (`agent-chat/docs/mesh/doctor-mesh-security-review-2026-06-10.md`). Slice 1 of the mesh-doctor work — the prerequisite that makes the upcoming `doctor` mesh check **authenticated by default**.

## Why
`enroll` already does the hard security work — OOB fingerprint confirm + `crossCheckRoot` (served root must equal the invite's OOB-confirmed root) — then **threw the anchor away**. Doctor (next slice) must pin registry verification to a root it trusts independently, *not* the daemon-advertised one (that's circular). So we persist the anchor enroll already authenticated.

## What's here
- **`internal/identity/anchor/`** (new SSOT): `Load` (missing→`(nil,nil)`, else strict decode), `Upsert` (atomic temp+chmod0600+rename, parent dir 0700, **validates** `vmnet1:` prefix + small-order-rejected ed25519 root + `registry.NetworkID(root)==network_id` — a stored anchor whose id doesn't derive from its root is rejected), `Find`.
- **enroll** persists `{network_id, root_pubkey, confirmed_at, relay}` after confirm+cross-check, **before** signing, **fail-closed** (`ErrEnrollPersistAnchor` — anchor saved AND request emitted, or neither). Path cmd-resolved via `defaultNetworkAnchorPath()` (`xdg.DataFile`), not a user flag.
- **`FetchRoot` hardening**: `io.LimitReader` 64 KiB body cap + inescapable `context.WithTimeout` — fixes the no-cap gap the review found in this **already-shipped** enroll fetch. **No loopback-pin** (enroll legitimately fetches remote relays; loopback-pin is the doctor-only client in slice 2).

## Verification
- `task check` GREEN — 23 checks, project cov 87.00%; anchor 87.1%, relayclient 96.0%, identitycli 92.3%.
- TDD; multi-lens review (security lens weighted) + adversarial verify. **Both HIGH-weighted lenses (security + correctness): 0 findings.** One LOW test-completeness gap (parent-dir 0700 assertion) caught + fixed (`dac5254`).
- Keyless preserved — no slice reads the private key.

Next: slice 2 (doctor mesh-section, M1/M3/M4 + loopback-pinned doctorclient + heartbeat liveness), slice 3 (docs).