### PR TITLE
feat(identity): doctor mesh-section — Contract-B identity health (sec-review M1/M3/M4)

### DIFF
--- a/.ckeletin/pkg/config/keys_generated.go
+++ b/.ckeletin/pkg/config/keys_generated.go
@@ -58,6 +58,10 @@ const (
 	KeyAppDoctorSummary                      = "app.doctor.summary"                       // Print summary counts only (suppress per-link details)
 	KeyAppDoctorAll                          = "app.doctor.all"                           // Diagnose every vault discovered under --root (multi-vault health)
 	KeyAppDoctorRoot                         = "app.doctor.root"                          // Root directory to discover vaults under when --all is set
+	KeyAppDoctorMeshRootPubkey               = "app.doctor.mesh_root_pubkey"              // Pin the Contract-B network root pubkey (base64) for authenticated mesh health...
+	KeyAppDoctorMeshRegistry                 = "app.doctor.mesh_registry"                 // Verify an offline Contract-B signed-registry file instead of fetching from th...
+	KeyAppDoctorMeshSlug                     = "app.doctor.mesh_slug"                     // Override the agent slug used to resolve your binding in the mesh registry (de...
+	KeyAppDoctorMeshHeartbeat                = "app.doctor.mesh_heartbeat"                // Override the wake-watcher heartbeat file path used for mesh watcher-liveness
 	KeyAppDoctorhealVault                    = "app.doctorheal.vault"                     // Path to vault root
 	KeyAppDoctorhealJson                     = "app.doctorheal.json"                      // Output in JSON format
 	KeyAppDoctorhealDryRun                   = "app.doctorheal.dry_run"                   // Preview repairs without writing (default applies)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -134,6 +134,11 @@ func runDoctorCore(cmd *cobra.Command, vaultPath string, jsonOut, summaryOnly bo
 		env := envelope.OK("doctor", result)
 		env.Meta.VaultPath = vaultPath
 		env.Meta.IndexHash = indexHash
+		// M4: surface every mesh warning as a structured envelope warning so
+		// scripted `jq '.status=="warning"'` / `.warnings[]` catches an
+		// unauthenticated (or misconfigured) mesh state. Status flips ok→warning;
+		// the exit code stays 0 (doctor's deliberate exit-0-on-warning contract).
+		addMeshWarningsToEnvelope(env, result.MeshIdentity)
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(env)
 	}
 	return writeDoctorHuman(cmd.OutOrStdout(), result, summaryOnly)
@@ -154,6 +159,12 @@ func diagnoseVault(cmd *cobra.Command, vaultPath string) (*query.DoctorResult, s
 
 	result, err := populateDoctorResult(vdb, vaultPath)
 	if err != nil {
+		return nil, "", err
+	}
+	// Contract-B mesh-identity section (single-vault path only — it is about the
+	// local agent's identity custody/binding/reachability, independent of the
+	// vault). Attached only when a mesh signal exists (nil ⇒ absent from --json).
+	if err := populateMeshIdentity(cmd, result); err != nil {
 		return nil, "", err
 	}
 	return result, vdb.GetIndexHash(), nil
@@ -243,19 +254,44 @@ func writeDoctorHuman(w io.Writer, result *query.DoctorResult, summaryOnly bool)
 	if err := writeStaleIndex(w, &result.Issues, summaryOnly); err != nil {
 		return err
 	}
+	// Contract-B mesh-identity section (conditionally present, like
+	// writeEmbeddingStatus — nil ⇒ nothing printed).
+	if err := writeMeshIdentity(w, result.MeshIdentity, summaryOnly); err != nil {
+		return err
+	}
 	// Errors/warnings rollup — the cold-start bottom line. Counts come from
-	// query.SurfacedIssueCounts (SSOT) over the SURFACED result.Issues set, so
-	// the text rollup always agrees with --json. It deliberately does NOT read
-	// result.IssuesSummary: that schema-validation AGGREGATE counts findings
-	// doctor never renders as text lines (and which the --json envelope's
-	// surfaced warnings/errors arrays do not count), which previously
-	// overstated warnings (e.g. "0 errors, 96 warnings") against a --json that
-	// surfaced none. result.issues_summary stays in --json untouched.
-	errCount, warnCount := query.SurfacedIssueCounts(result.Issues)
+	// query.ResultSurfacedIssueCounts (SSOT) over the SURFACED result.Issues set
+	// PLUS the mesh-identity section's warnings, so the text rollup always agrees
+	// with --json. It deliberately does NOT read result.IssuesSummary: that
+	// schema-validation AGGREGATE counts findings doctor never renders as text
+	// lines (and which the --json envelope's surfaced warnings/errors arrays do
+	// not count), which previously overstated warnings (e.g. "0 errors, 96
+	// warnings") against a --json that surfaced none. result.issues_summary stays
+	// in --json untouched.
+	errCount, warnCount := query.ResultSurfacedIssueCounts(result)
 	if _, err := fmt.Fprintf(w, "Issues: %d errors, %d warnings\n", errCount, warnCount); err != nil {
 		return err
 	}
 	return nil
+}
+
+// meshWarningCode is the structured-warning code for every mesh-identity warning
+// emitted into the --json envelope (M4). One code keeps the jq surface stable.
+const meshWarningCode = "mesh_identity"
+
+// addMeshWarningsToEnvelope folds each mesh-identity section warning into the
+// --json envelope as a structured warning (M4). It flips status ok→warning so
+// `jq '.status=="warning"'` catches an unauthenticated/misconfigured mesh state;
+// the exit code is unaffected (doctor stays exit-0-on-warning). The top-level
+// `result.mesh_identity.authenticated` boolean carries the machine-readable
+// authenticity verdict alongside.
+func addMeshWarningsToEnvelope(env *envelope.Envelope, mi *query.DoctorMeshIdentity) {
+	if mi == nil {
+		return
+	}
+	for _, warn := range mi.Warnings {
+		env.AddWarning(meshWarningCode, warn, "mesh_identity")
+	}
 }
 
 // writeLinkIssues prints the Obsidian-incompatible and dead-link sections.

--- a/cmd/doctor_mesh.go
+++ b/cmd/doctor_mesh.go
@@ -53,6 +53,7 @@ const (
 	meshDaemonUnreachable = "unreachable"
 	meshHeartbeatLabel    = "  watcher heartbeat: "
 	meshHeartbeatFresh    = "fresh"
+	meshHeartbeatAbsent   = "not found (wake-on-idle not confirmed)"
 	meshWarnPrefix        = "  ⚠ "
 )
 
@@ -196,7 +197,9 @@ func applyOfflineRegistry(in *query.MeshDoctorInput, registryFlag string) (bool,
 // not an error — tier-2 then reports not-enrolled.
 func resolveSlug(slugFlag string) string {
 	if slugFlag != "" {
-		return slugFlag
+		// Contract-B registry bindings store the BARE slug; "agent:" is only the
+		// chat wire principal. Strip it so an explicit --mesh-slug resolves.
+		return strings.TrimPrefix(slugFlag, "agent:")
 	}
 	return slugFromAgentsYAML(os.Getenv(envAgentRegistry), projectPath())
 }
@@ -244,7 +247,10 @@ func slugFromAgentsYAML(registryPath, projectDir string) string {
 	want := filepath.Clean(projectDir)
 	for _, a := range ay.Agents {
 		if filepath.Clean(a.ProjectPath) == want {
-			return "agent:" + strings.TrimPrefix(a.Slug, "agent:")
+			// Return the BARE slug: Contract-B registry bindings key on the bare
+			// slug ("agent:" is only the chat wire principal). Prefixing it here
+			// made registry.Resolve miss an enrolled member (false not-enrolled).
+			return strings.TrimPrefix(a.Slug, "agent:")
 		}
 	}
 	return ""
@@ -353,8 +359,15 @@ func writeMeshDaemon(w io.Writer, mi *query.DoctorMeshIdentity) error {
 	if _, err := fmt.Fprintln(w, meshDaemonLabel+daemon); err != nil {
 		return err
 	}
-	if mi.WatcherHeartbeatFresh {
+	switch {
+	case mi.WatcherHeartbeatFresh:
 		_, err := fmt.Fprintln(w, meshHeartbeatLabel+meshHeartbeatFresh)
+		return err
+	case mi.WatcherHeartbeatAge == 0:
+		// ABSENT (never found): an INFO line, not a ⚠ warning — most members
+		// have never run the watcher. Stale (Age>0) is surfaced as a warning
+		// by writeMeshWarnings, so no info line is printed for it here.
+		_, err := fmt.Fprintln(w, meshHeartbeatLabel+meshHeartbeatAbsent)
 		return err
 	}
 	return nil

--- a/cmd/doctor_mesh.go
+++ b/cmd/doctor_mesh.go
@@ -1,0 +1,371 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
+	"github.com/peiman/vaultmind/internal/identity/anchor"
+	"github.com/peiman/vaultmind/internal/identity/doctorclient"
+	"github.com/peiman/vaultmind/internal/identity/registry"
+	"github.com/peiman/vaultmind/internal/identity/signer"
+	"github.com/peiman/vaultmind/internal/query"
+	"github.com/peiman/vaultmind/internal/xdg"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// Mesh-doctor cmd-layer constants (SSOT). Env vars + default paths mirror the
+// agent-chat MCP so doctor auto-discovers the same substrate the member runs on.
+const (
+	// envDaemonURL is the chat-daemon base URL env var (loopback-pinned client).
+	envDaemonURL = "AGENT_CHAT_DAEMON_URL"
+	// defaultDaemonURL is the agent-chat daemon's default loopback HTTP endpoint.
+	defaultDaemonURL = "http://127.0.0.1:7850"
+	// envAgentRegistry is the agents.yaml path env var.
+	envAgentRegistry = "AGENT_CHAT_REGISTRY"
+	// envProjectPath is the project-path env var used to resolve the agent slug.
+	envProjectPath = "AGENT_CHAT_PROJECT_PATH"
+	// heartbeatFilename is the default wake-watcher heartbeat file (XDG config).
+	heartbeatFilename = "mesh-watch.heartbeat"
+)
+
+// Mesh-section human labels (SSOT — no inline literals in the writer).
+const (
+	meshSectionHeader     = "Mesh identity (Contract-B):"
+	meshKeyCustodyLabel   = "  key custody: "
+	meshKeyPresentYes     = "present"
+	meshKeyPresentNo      = "absent"
+	meshKeyModeBad        = " (mode NOT 0600)"
+	meshKeySizeBad        = " (unexpected size)"
+	meshSignerLabel       = "  signer: "
+	meshSignerUp          = "running"
+	meshSignerDown        = "not running (OK if on-demand)"
+	meshAuthLabel         = "  authentication: "
+	meshDaemonLabel       = "  daemon: "
+	meshDaemonReachable   = "HTTP reachable"
+	meshDaemonUnreachable = "unreachable"
+	meshHeartbeatLabel    = "  watcher heartbeat: "
+	meshHeartbeatFresh    = "fresh"
+	meshWarnPrefix        = "  ⚠ "
+)
+
+// meshDoctorErrParse prefixes a --mesh-root-pubkey decode/validate failure.
+const meshDoctorErrParse = "doctor: --mesh-root-pubkey is not a valid base64 ed25519 root pubkey"
+
+// meshDoctorErrRegistry prefixes a --mesh-registry read failure.
+const meshDoctorErrRegistry = "doctor: read --mesh-registry file"
+
+// populateMeshIdentity resolves the mesh substrate (key/socket paths, the pinned
+// root from --mesh-root-pubkey or the enroll-persisted anchor, the registry from
+// --mesh-registry or the daemon, and the slug from --mesh-slug or agents.yaml),
+// builds the keyless signer + loopback daemon client, runs the 3-tier check, and
+// attaches the section to result ONLY when a mesh signal exists (nil ⇒ omitted
+// from --json). It is the cmd-layer counterpart to query.BuildMeshIdentity.
+func populateMeshIdentity(cmd *cobra.Command, result *query.DoctorResult) error {
+	in, present, err := resolveMeshInput(cmd)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return nil // no mesh substrate — section omitted entirely
+	}
+	mi, err := query.BuildMeshIdentity(cmd.Context(), in)
+	if err != nil {
+		return err
+	}
+	if mi.HasSignal() {
+		result.MeshIdentity = mi
+	}
+	return nil
+}
+
+// resolveMeshInput assembles the MeshDoctorInput and reports whether any mesh
+// signal exists (identity key present, an anchor exists, a --mesh-* flag passed,
+// or the daemon is reachable). When no signal exists, the section is skipped.
+func resolveMeshInput(cmd *cobra.Command) (query.MeshDoctorInput, bool, error) {
+	keyPath, _ := defaultSignerKeyPath()
+	sockPath, _ := defaultSignerSocketPath()
+	heartbeatPath := getConfigValueWithFlags[string](cmd, "mesh-heartbeat", config.KeyAppDoctorMeshHeartbeat)
+	if heartbeatPath == "" {
+		heartbeatPath, _ = xdgHeartbeatPath()
+	}
+
+	in := query.MeshDoctorInput{
+		KeyPath:       keyPath,
+		SocketPath:    sockPath,
+		HeartbeatPath: heartbeatPath,
+		Now:           time.Now(),
+		Signer:        &signer.Client{SocketPath: sockPath},
+	}
+
+	rootFlag := getConfigValueWithFlags[string](cmd, "mesh-root-pubkey", config.KeyAppDoctorMeshRootPubkey)
+	registryFlag := getConfigValueWithFlags[string](cmd, "mesh-registry", config.KeyAppDoctorMeshRegistry)
+	slugFlag := getConfigValueWithFlags[string](cmd, "mesh-slug", config.KeyAppDoctorMeshSlug)
+
+	anchorPresent, err := applyPinAndNetwork(&in, rootFlag)
+	if err != nil {
+		return query.MeshDoctorInput{}, false, err
+	}
+
+	registryPresent, err := applyOfflineRegistry(&in, registryFlag)
+	if err != nil {
+		return query.MeshDoctorInput{}, false, err
+	}
+
+	in.Slug = resolveSlug(slugFlag)
+
+	daemon := newDoctorDaemonClient()
+	in.Daemon = daemon
+	daemonReachable := daemon != nil && daemonIsReachable(cmd.Context(), daemon)
+
+	keyPresent := keyFileExists(keyPath)
+	flagPassed := rootFlag != "" || registryFlag != "" || slugFlag != "" ||
+		cmd.Flags().Changed("mesh-heartbeat")
+	present := keyPresent || anchorPresent || registryPresent || flagPassed || daemonReachable
+	return in, present, nil
+}
+
+// applyPinAndNetwork sets the pinned root + network id from --mesh-root-pubkey
+// when given, else auto-discovers the FIRST persisted anchor. It returns whether
+// an anchor was found (a mesh signal). An explicit --mesh-root-pubkey that does
+// not decode is a hard error (the operator asked for a specific pin).
+func applyPinAndNetwork(in *query.MeshDoctorInput, rootFlag string) (bool, error) {
+	if rootFlag != "" {
+		raw, err := base64.StdEncoding.DecodeString(rootFlag)
+		if err != nil {
+			return false, fmt.Errorf("%s: %w", meshDoctorErrParse, err)
+		}
+		pk, err := registry.NewPublicKey(raw)
+		if err != nil {
+			return false, fmt.Errorf("%s: %w", meshDoctorErrParse, err)
+		}
+		in.PinnedRootPub = pk.Bytes()
+		in.NetworkID = registry.NetworkID(pk.Bytes())
+		return false, nil
+	}
+
+	anchorPath, err := defaultNetworkAnchorPath()
+	if err != nil {
+		return false, nil //nolint:nilerr // anchor path unresolved ⇒ no pin, not fatal
+	}
+	anchors, err := anchor.Load(anchorPath)
+	if err != nil || len(anchors) == 0 {
+		return false, nil //nolint:nilerr // missing/corrupt anchor ⇒ unpinned path
+	}
+	a := anchors[0]
+	raw, err := base64.StdEncoding.DecodeString(a.RootPubKey)
+	if err != nil {
+		return true, nil //nolint:nilerr // present-but-undecodable ⇒ stay unpinned
+	}
+	pk, err := registry.NewPublicKey(raw)
+	if err != nil {
+		return true, nil //nolint:nilerr // present-but-invalid ⇒ stay unpinned
+	}
+	in.PinnedRootPub = pk.Bytes()
+	in.NetworkID = a.NetworkID
+	return true, nil
+}
+
+// applyOfflineRegistry reads a --mesh-registry file into the input when given.
+// A passed-but-unreadable file is a hard error (the operator named a file).
+func applyOfflineRegistry(in *query.MeshDoctorInput, registryFlag string) (bool, error) {
+	if registryFlag == "" {
+		return false, nil
+	}
+	// registryFlag is an operator-supplied path (explicit --mesh-registry flag),
+	// not attacker-controlled input — same trust class as the vault path.
+	// #nosec G304
+	// nosemgrep: go-path-traversal
+	raw, err := os.ReadFile(registryFlag)
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", meshDoctorErrRegistry, err)
+	}
+	in.RegistryBytes = raw
+	return true, nil
+}
+
+// resolveSlug returns the explicit --mesh-slug when given, else resolves it from
+// the agents.yaml registry by matching the project path. An unresolvable slug is
+// not an error — tier-2 then reports not-enrolled.
+func resolveSlug(slugFlag string) string {
+	if slugFlag != "" {
+		return slugFlag
+	}
+	return slugFromAgentsYAML(os.Getenv(envAgentRegistry), projectPath())
+}
+
+// projectPath returns AGENT_CHAT_PROJECT_PATH, falling back to the working dir.
+func projectPath() string {
+	if p := os.Getenv(envProjectPath); p != "" {
+		return p
+	}
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	return ""
+}
+
+// agentsYAML is the minimal shape of the chat-mcp agents.yaml the slug resolver
+// reads: a list of {slug, project_path}. Other fields are ignored.
+type agentsYAML struct {
+	Agents []struct {
+		Slug        string `yaml:"slug"`
+		ProjectPath string `yaml:"project_path"`
+	} `yaml:"agents"`
+}
+
+// slugFromAgentsYAML resolves the agent slug whose project_path matches
+// projectDir (normalized via filepath.Clean). Returns "" when the registry path
+// is empty/unreadable or no entry matches. The slug is a LABEL — authenticity is
+// the tier-2 selfVerify, not the slug — so a wrong/missing slug is non-fatal.
+func slugFromAgentsYAML(registryPath, projectDir string) string {
+	if registryPath == "" || projectDir == "" {
+		return ""
+	}
+	// registryPath is an operator-controlled env var (AGENT_CHAT_REGISTRY), the
+	// same path the chat MCP itself reads — not attacker-controlled input.
+	// #nosec G304
+	// nosemgrep: go-path-traversal
+	raw, err := os.ReadFile(registryPath)
+	if err != nil {
+		return ""
+	}
+	var ay agentsYAML
+	if err := yaml.Unmarshal(raw, &ay); err != nil {
+		return ""
+	}
+	want := filepath.Clean(projectDir)
+	for _, a := range ay.Agents {
+		if filepath.Clean(a.ProjectPath) == want {
+			return "agent:" + strings.TrimPrefix(a.Slug, "agent:")
+		}
+	}
+	return ""
+}
+
+// newDoctorDaemonClient builds the loopback-pinned read-only daemon client from
+// the daemon URL env (default loopback). A construction failure (bad URL) yields
+// nil — tier-3 then reports the daemon unreachable rather than erroring doctor.
+func newDoctorDaemonClient() query.MeshDaemonClient {
+	url := os.Getenv(envDaemonURL)
+	if url == "" {
+		url = defaultDaemonURL
+	}
+	c, err := doctorclient.New(url)
+	if err != nil {
+		return nil
+	}
+	return c
+}
+
+// daemonIsReachable probes whoami to decide presence-gating without surfacing an
+// error (an unreachable daemon is simply "no daemon signal").
+func daemonIsReachable(ctx context.Context, d query.MeshDaemonClient) bool {
+	reachable, _, _ := d.Whoami(ctx)
+	return reachable
+}
+
+// keyFileExists reports whether the identity key file exists (Lstat — never
+// reads it). Used only for presence-gating the section.
+func keyFileExists(keyPath string) bool {
+	if keyPath == "" {
+		return false
+	}
+	_, err := os.Lstat(keyPath)
+	return err == nil
+}
+
+// xdgHeartbeatPath returns the default wake-watcher heartbeat path under XDG
+// config (~/.config/vaultmind/mesh-watch.heartbeat).
+func xdgHeartbeatPath() (string, error) {
+	return xdg.ConfigFile(heartbeatFilename)
+}
+
+// writeMeshIdentity renders the mesh-identity section to w. It is conditionally
+// present (nil ⇒ nothing printed), mirroring writeEmbeddingStatus's gate. Every
+// section warning is printed; the authenticated verdict reuses the section
+// Status so human + --json never disagree.
+func writeMeshIdentity(w io.Writer, mi *query.DoctorMeshIdentity, _ bool) error {
+	if mi == nil {
+		return nil
+	}
+	if _, err := fmt.Fprintln(w, meshSectionHeader); err != nil {
+		return err
+	}
+	if err := writeMeshCustody(w, mi); err != nil {
+		return err
+	}
+	if err := writeMeshAuth(w, mi); err != nil {
+		return err
+	}
+	if err := writeMeshDaemon(w, mi); err != nil {
+		return err
+	}
+	return writeMeshWarnings(w, mi)
+}
+
+// writeMeshCustody prints the tier-1 custody + signer lines.
+func writeMeshCustody(w io.Writer, mi *query.DoctorMeshIdentity) error {
+	custody := meshKeyPresentNo
+	if mi.KeyPresent {
+		custody = meshKeyPresentYes
+		if !mi.KeyModeOK {
+			custody += meshKeyModeBad
+		}
+		if !mi.KeySizeOK {
+			custody += meshKeySizeBad
+		}
+	}
+	if _, err := fmt.Fprintln(w, meshKeyCustodyLabel+custody); err != nil {
+		return err
+	}
+	signerState := meshSignerDown
+	if mi.SignerReachable {
+		signerState = meshSignerUp
+	}
+	_, err := fmt.Fprintln(w, meshSignerLabel+signerState)
+	return err
+}
+
+// writeMeshAuth prints the tier-2 authentication verdict (the section Status,
+// reserving "authenticated" for the cryptographically-proven green state).
+func writeMeshAuth(w io.Writer, mi *query.DoctorMeshIdentity) error {
+	_, err := fmt.Fprintln(w, meshAuthLabel+mi.Status)
+	return err
+}
+
+// writeMeshDaemon prints the tier-3 daemon reachability + heartbeat lines.
+func writeMeshDaemon(w io.Writer, mi *query.DoctorMeshIdentity) error {
+	daemon := meshDaemonUnreachable
+	if mi.DaemonReachable {
+		daemon = meshDaemonReachable
+		if mi.DaemonMode != "" {
+			daemon += " (" + mi.DaemonMode + ")"
+		}
+	}
+	if _, err := fmt.Fprintln(w, meshDaemonLabel+daemon); err != nil {
+		return err
+	}
+	if mi.WatcherHeartbeatFresh {
+		_, err := fmt.Fprintln(w, meshHeartbeatLabel+meshHeartbeatFresh)
+		return err
+	}
+	return nil
+}
+
+// writeMeshWarnings prints each section warning under the section.
+func writeMeshWarnings(w io.Writer, mi *query.DoctorMeshIdentity) error {
+	for _, warn := range mi.Warnings {
+		if _, err := fmt.Fprintln(w, meshWarnPrefix+warn); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/doctor_mesh_test.go
+++ b/cmd/doctor_mesh_test.go
@@ -31,7 +31,7 @@ agents:
 `), 0o644))
 
 	got := slugFromAgentsYAML(reg, dir)
-	require.Equal(t, "agent:mira", got)
+	require.Equal(t, "mira", got, "registry bindings key on the BARE slug, not the agent: wire principal")
 }
 
 func TestSlugFromAgentsYAML_AlreadyPrefixed(t *testing.T) {
@@ -43,7 +43,7 @@ agents:
     project_path: "`+dir+`"
 `), 0o644))
 
-	require.Equal(t, "agent:mira", slugFromAgentsYAML(reg, dir))
+	require.Equal(t, "mira", slugFromAgentsYAML(reg, dir), "an agent:-prefixed agents.yaml slug is stripped to the bare registry slug")
 }
 
 func TestSlugFromAgentsYAML_NoMatch(t *testing.T) {
@@ -314,7 +314,9 @@ func TestDoctor_MeshOfflineRegistryWithAnchorPin(t *testing.T) {
 	memberPub, _, err := ed25519.GenerateKey(seedReader("doctor-cmd-offline-member-seed-pad"))
 	require.NoError(t, err)
 
-	regBytes, nid := buildCmdSignedRegistry(t, rootPub, rootPriv, "agent:mira", memberPub, now)
+	// Registry binding keys on the BARE slug; the --mesh-slug "agent:mira" below
+	// is stripped to "mira" so the prefixed flag still resolves end-to-end.
+	regBytes, nid := buildCmdSignedRegistry(t, rootPub, rootPriv, "mira", memberPub, now)
 
 	// Persist the OOB anchor where doctor auto-discovers it.
 	anchorPath := filepath.Join(xdgData, "vaultmind", "network-roots.json")

--- a/cmd/doctor_mesh_test.go
+++ b/cmd/doctor_mesh_test.go
@@ -1,0 +1,400 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/envelope"
+	"github.com/peiman/vaultmind/internal/identity/anchor"
+	"github.com/peiman/vaultmind/internal/identity/registry"
+	"github.com/peiman/vaultmind/internal/query"
+	"github.com/stretchr/testify/require"
+)
+
+// --- slug resolution from agents.yaml ---------------------------------------
+
+func TestSlugFromAgentsYAML_Matches(t *testing.T) {
+	dir := t.TempDir()
+	reg := filepath.Join(dir, "agents.yaml")
+	require.NoError(t, os.WriteFile(reg, []byte(`
+agents:
+  - slug: "mira"
+    project_path: "`+dir+`"
+  - slug: "other"
+    project_path: "/somewhere/else"
+`), 0o644))
+
+	got := slugFromAgentsYAML(reg, dir)
+	require.Equal(t, "agent:mira", got)
+}
+
+func TestSlugFromAgentsYAML_AlreadyPrefixed(t *testing.T) {
+	dir := t.TempDir()
+	reg := filepath.Join(dir, "agents.yaml")
+	require.NoError(t, os.WriteFile(reg, []byte(`
+agents:
+  - slug: "agent:mira"
+    project_path: "`+dir+`"
+`), 0o644))
+
+	require.Equal(t, "agent:mira", slugFromAgentsYAML(reg, dir))
+}
+
+func TestSlugFromAgentsYAML_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	reg := filepath.Join(dir, "agents.yaml")
+	require.NoError(t, os.WriteFile(reg, []byte(`
+agents:
+  - slug: "other"
+    project_path: "/not/this"
+`), 0o644))
+
+	require.Equal(t, "", slugFromAgentsYAML(reg, dir))
+}
+
+func TestSlugFromAgentsYAML_EmptyInputs(t *testing.T) {
+	require.Equal(t, "", slugFromAgentsYAML("", "/x"))
+	require.Equal(t, "", slugFromAgentsYAML("/nope.yaml", ""))
+	require.Equal(t, "", slugFromAgentsYAML("/does/not/exist.yaml", "/x"))
+}
+
+// --- M4: --json carries authenticated:false + warning status, exit stays 0 ---
+
+func TestAddMeshWarningsToEnvelope_FlipsStatusToWarning(t *testing.T) {
+	env := envelope.OK("doctor", nil)
+	mi := &query.DoctorMeshIdentity{
+		Authenticated: false,
+		Status:        query.StatusMeshSelfConsistentUnpinned,
+		Warnings:      []string{query.WarnMeshUnpinned},
+	}
+	addMeshWarningsToEnvelope(env, mi)
+	require.Equal(t, "warning", env.Status)
+	require.Len(t, env.Warnings, 1)
+	require.Equal(t, meshWarningCode, env.Warnings[0].Code)
+	require.Equal(t, query.WarnMeshUnpinned, env.Warnings[0].Message)
+}
+
+func TestAddMeshWarningsToEnvelope_NilSectionNoChange(t *testing.T) {
+	env := envelope.OK("doctor", nil)
+	addMeshWarningsToEnvelope(env, nil)
+	require.Equal(t, "ok", env.Status)
+	require.Empty(t, env.Warnings)
+}
+
+func TestAddMeshWarningsToEnvelope_AuthenticatedNoWarnings(t *testing.T) {
+	env := envelope.OK("doctor", nil)
+	mi := &query.DoctorMeshIdentity{
+		Authenticated: true,
+		Status:        query.StatusMeshAuthenticated,
+	}
+	addMeshWarningsToEnvelope(env, mi)
+	require.Equal(t, "ok", env.Status)
+	require.Empty(t, env.Warnings)
+}
+
+// jsonMeshEnvelope decodes the M4-relevant slice of the doctor --json envelope.
+type jsonMeshEnvelope struct {
+	Status   string `json:"status"`
+	Warnings []struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"warnings"`
+	Result struct {
+		MeshIdentity *struct {
+			Authenticated bool   `json:"authenticated"`
+			Status        string `json:"status"`
+			KeyPresent    bool   `json:"key_present"`
+		} `json:"mesh_identity"`
+	} `json:"result"`
+}
+
+// TestDoctorJSON_MeshUnpinnedCarriesAuthenticatedFalseAndWarning is the M4
+// end-to-end assertion: with a key present (mesh signal) but NO pin, the --json
+// envelope carries status=warning, a structured warning, and
+// result.mesh_identity.authenticated=false — and the command exits 0.
+func TestDoctorJSON_MeshUnpinnedCarriesAuthenticatedFalseAndWarning(t *testing.T) {
+	chdirToTemp(t)
+	xdgData := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgData)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// Point the daemon URL at a closed loopback port so tier-3 is unreachable and
+	// the unpinned path stays deterministic (no live daemon in CI).
+	t.Setenv("AGENT_CHAT_DAEMON_URL", "http://127.0.0.1:1")
+
+	// Create a 0600, 64-byte identity key file so a mesh signal exists but there
+	// is no anchor → UNPINNED path.
+	keyPath := filepath.Join(xdgData, "vaultmind", "identity-signer.key")
+	require.NoError(t, os.MkdirAll(filepath.Dir(keyPath), 0o700))
+	require.NoError(t, os.WriteFile(keyPath, make([]byte, ed25519.PrivateKeySize), 0o600))
+
+	vault := buildCleanIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "--vault", vault, "--json")
+	require.NoError(t, err, "doctor exits 0 even with a mesh warning")
+
+	var je jsonMeshEnvelope
+	require.NoError(t, json.Unmarshal(out.Bytes(), &je))
+	require.NotNil(t, je.Result.MeshIdentity, "mesh section present (key signal)")
+	require.True(t, je.Result.MeshIdentity.KeyPresent)
+	require.False(t, je.Result.MeshIdentity.Authenticated, "M4: authenticated false")
+	require.Equal(t, query.StatusMeshSelfConsistentUnpinned, je.Result.MeshIdentity.Status)
+	require.Equal(t, "warning", je.Status, "M4: status flips to warning")
+	require.NotEmpty(t, je.Warnings, "M4: structured warning surfaced for jq")
+}
+
+// TestDoctorJSON_NoMeshSignalOmitsSection asserts the section is ABSENT from
+// --json when no mesh substrate exists (no key, no anchor, no flag, no daemon).
+func TestDoctorJSON_NoMeshSignalOmitsSection(t *testing.T) {
+	chdirToTemp(t)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("AGENT_CHAT_DAEMON_URL", "http://127.0.0.1:1")
+
+	vault := buildCleanIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "--vault", vault, "--json")
+	require.NoError(t, err)
+
+	var je jsonMeshEnvelope
+	require.NoError(t, json.Unmarshal(out.Bytes(), &je))
+	require.Nil(t, je.Result.MeshIdentity, "section omitted when no mesh signal")
+	require.Equal(t, "ok", je.Status)
+}
+
+// TestDoctor_MeshFlagPassedForcesSection asserts that passing --mesh-root-pubkey
+// alone is a mesh signal that surfaces the section even with no key file.
+func TestDoctor_MeshFlagPassedForcesSection(t *testing.T) {
+	chdirToTemp(t)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("AGENT_CHAT_DAEMON_URL", "http://127.0.0.1:1")
+
+	_, rootPriv, err := ed25519.GenerateKey(seedReader("doctor-cmd-flag-root-seed-padding!!"))
+	require.NoError(t, err)
+	rootPub := rootPriv.Public().(ed25519.PublicKey)
+
+	vault := buildCleanIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "--vault", vault, "--json",
+		"--mesh-root-pubkey", base64.StdEncoding.EncodeToString(rootPub))
+	require.NoError(t, err)
+
+	var je jsonMeshEnvelope
+	require.NoError(t, json.Unmarshal(out.Bytes(), &je))
+	require.NotNil(t, je.Result.MeshIdentity, "section present when --mesh-root-pubkey passed")
+	require.False(t, je.Result.MeshIdentity.Authenticated)
+}
+
+// --- writeMeshIdentity human rendering --------------------------------------
+
+func TestWriteMeshIdentity_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, writeMeshIdentity(&buf, nil, false))
+	require.Empty(t, buf.String())
+}
+
+func TestWriteMeshIdentity_AuthenticatedGreen(t *testing.T) {
+	var buf bytes.Buffer
+	mi := &query.DoctorMeshIdentity{
+		KeyPresent: true, KeyModeOK: true, KeySizeOK: true,
+		SignerReachable: true,
+		Authenticated:   true,
+		Status:          query.StatusMeshAuthenticated,
+		DaemonReachable: true,
+		DaemonMode:      query.DaemonModeAdvisoryConfigured,
+	}
+	require.NoError(t, writeMeshIdentity(&buf, mi, false))
+	s := buf.String()
+	require.Contains(t, s, meshSectionHeader)
+	require.Contains(t, s, query.StatusMeshAuthenticated)
+	require.Contains(t, s, meshKeyPresentYes)
+	require.NotContains(t, s, meshKeyModeBad)
+}
+
+func TestWriteMeshIdentity_DaemonReachableAndHeartbeatFresh(t *testing.T) {
+	var buf bytes.Buffer
+	mi := &query.DoctorMeshIdentity{
+		KeyPresent: true, KeyModeOK: true, KeySizeOK: true,
+		Status:                query.StatusMeshNotEnrolled,
+		DaemonReachable:       true,
+		DaemonMode:            query.DaemonModePlaintext,
+		WatcherHeartbeatFresh: true,
+	}
+	require.NoError(t, writeMeshIdentity(&buf, mi, false))
+	s := buf.String()
+	require.Contains(t, s, meshDaemonReachable)
+	require.Contains(t, s, query.DaemonModePlaintext)
+	require.Contains(t, s, meshHeartbeatFresh)
+}
+
+func TestWriteMeshIdentity_DaemonUnreachableNoHeartbeatLine(t *testing.T) {
+	var buf bytes.Buffer
+	mi := &query.DoctorMeshIdentity{
+		Status:                query.StatusMeshSelfConsistentUnpinned,
+		DaemonReachable:       false,
+		WatcherHeartbeatFresh: false,
+	}
+	require.NoError(t, writeMeshIdentity(&buf, mi, false))
+	s := buf.String()
+	require.Contains(t, s, meshDaemonUnreachable)
+	require.NotContains(t, s, meshHeartbeatFresh)
+}
+
+func TestWriteMeshIdentity_KeyAbsentAndSignerUp(t *testing.T) {
+	var buf bytes.Buffer
+	mi := &query.DoctorMeshIdentity{
+		KeyPresent:      false,
+		KeySizeOK:       false,
+		SignerReachable: true,
+		Status:          query.StatusMeshSelfConsistentUnpinned,
+	}
+	require.NoError(t, writeMeshIdentity(&buf, mi, false))
+	s := buf.String()
+	require.Contains(t, s, meshKeyPresentNo)
+	require.Contains(t, s, meshSignerUp)
+}
+
+func TestWriteMeshIdentity_KeySizeBadShown(t *testing.T) {
+	var buf bytes.Buffer
+	mi := &query.DoctorMeshIdentity{
+		KeyPresent: true, KeyModeOK: true, KeySizeOK: false,
+		Status: query.StatusMeshSelfConsistentUnpinned,
+	}
+	require.NoError(t, writeMeshIdentity(&buf, mi, false))
+	require.Contains(t, buf.String(), meshKeySizeBad)
+}
+
+func TestWriteMeshIdentity_WarningsRendered(t *testing.T) {
+	var buf bytes.Buffer
+	mi := &query.DoctorMeshIdentity{
+		KeyPresent: true, KeyModeOK: false, KeySizeOK: true,
+		Status:   query.StatusMeshSelfConsistentUnpinned,
+		Warnings: []string{query.WarnMeshKeyMode, query.WarnMeshUnpinned},
+	}
+	require.NoError(t, writeMeshIdentity(&buf, mi, false))
+	s := buf.String()
+	require.Contains(t, s, meshKeyModeBad)
+	require.Contains(t, s, query.WarnMeshUnpinned)
+	require.Contains(t, s, query.WarnMeshKeyMode)
+}
+
+// seedReader returns an io.Reader yielding a deterministic 32-byte ed25519 seed
+// from a low-entropy string (gitleaks-friendly: no real key material).
+func seedReader(seed string) *bytes.Reader {
+	b := make([]byte, ed25519.SeedSize)
+	copy(b, seed)
+	return bytes.NewReader(b)
+}
+
+// --- offline registry + anchor auto-discovery end-to-end --------------------
+
+// TestDoctor_MeshOfflineRegistryWithAnchorPin drives the AUTHENTICATED pinned
+// path through the cmd layer: an enroll-persisted anchor supplies the pin, and
+// --mesh-registry supplies the signed registry offline. With no running signer
+// the keyless selfVerify cannot pass, so the honest verdict is key-mismatch (NOT
+// green) — proving the cmd layer wires the pin + registry + slug correctly while
+// reserving green for a cryptographically proven binding.
+func TestDoctor_MeshOfflineRegistryWithAnchorPin(t *testing.T) {
+	chdirToTemp(t)
+	xdgData := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", xdgData)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("AGENT_CHAT_DAEMON_URL", "http://127.0.0.1:1")
+
+	now := time.Now()
+	rootPub, rootPriv, err := ed25519.GenerateKey(seedReader("doctor-cmd-offline-root-seed-pad!!"))
+	require.NoError(t, err)
+	memberPub, _, err := ed25519.GenerateKey(seedReader("doctor-cmd-offline-member-seed-pad"))
+	require.NoError(t, err)
+
+	regBytes, nid := buildCmdSignedRegistry(t, rootPub, rootPriv, "agent:mira", memberPub, now)
+
+	// Persist the OOB anchor where doctor auto-discovers it.
+	anchorPath := filepath.Join(xdgData, "vaultmind", "network-roots.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(anchorPath), 0o700))
+	require.NoError(t, anchor.Upsert(anchorPath, anchor.NetworkAnchor{
+		NetworkID:   nid,
+		RootPubKey:  base64.StdEncoding.EncodeToString(rootPub),
+		ConfirmedAt: now.Unix(),
+	}))
+
+	regFile := filepath.Join(t.TempDir(), "registry.json")
+	require.NoError(t, os.WriteFile(regFile, regBytes, 0o644))
+
+	vault := buildCleanIndexedTestVault(t)
+	out, _, err := runRootCmd(t, "doctor", "--vault", vault, "--json",
+		"--mesh-registry", regFile, "--mesh-slug", "agent:mira")
+	require.NoError(t, err)
+
+	var je jsonMeshEnvelope
+	require.NoError(t, json.Unmarshal(out.Bytes(), &je))
+	require.NotNil(t, je.Result.MeshIdentity)
+	require.False(t, je.Result.MeshIdentity.Authenticated,
+		"no running signer ⇒ keyless selfVerify cannot prove possession ⇒ never green")
+	require.Equal(t, query.StatusMeshKeyMismatch, je.Result.MeshIdentity.Status)
+}
+
+// TestDoctor_MeshOfflineRegistryUnreadable asserts a named --mesh-registry file
+// that cannot be read is a HARD error (the operator named a specific file).
+func TestDoctor_MeshOfflineRegistryUnreadable(t *testing.T) {
+	chdirToTemp(t)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("AGENT_CHAT_DAEMON_URL", "http://127.0.0.1:1")
+
+	vault := buildCleanIndexedTestVault(t)
+	_, _, err := runRootCmd(t, "doctor", "--vault", vault,
+		"--mesh-registry", filepath.Join(t.TempDir(), "does-not-exist.json"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), meshDoctorErrRegistry)
+}
+
+// TestDoctor_MeshBadRootPubkeyFlag asserts a malformed --mesh-root-pubkey is a
+// hard error (the operator asked for a specific pin).
+func TestDoctor_MeshBadRootPubkeyFlag(t *testing.T) {
+	chdirToTemp(t)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("AGENT_CHAT_DAEMON_URL", "http://127.0.0.1:1")
+
+	vault := buildCleanIndexedTestVault(t)
+	_, _, err := runRootCmd(t, "doctor", "--vault", vault,
+		"--mesh-root-pubkey", "not-valid-base64!!!")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), meshDoctorErrParse)
+}
+
+// buildCmdSignedRegistry roots a one-binding registry for the cmd-layer tests.
+func buildCmdSignedRegistry(t *testing.T, rootPub ed25519.PublicKey, rootPriv ed25519.PrivateKey, slug string, memberPub ed25519.PublicKey, now time.Time) ([]byte, string) {
+	t.Helper()
+	pk, err := registry.NewPublicKey(memberPub)
+	require.NoError(t, err)
+	reg := registry.Registry{
+		Epoch:      1,
+		ValidFrom:  now.Add(-time.Hour).Unix(),
+		ValidUntil: now.Add(24 * time.Hour).Unix(),
+		Agents: []registry.AgentBinding{{
+			Slug:                    slug,
+			DisplayName:             "Member",
+			PubKey:                  pk,
+			KeyEpoch:                1,
+			ValidFrom:               now.Add(-time.Hour).Unix(),
+			ValidUntil:              now.Add(24 * time.Hour).Unix(),
+			AuthorizedOriginDaemons: []string{"daemon:local"},
+		}},
+	}
+	env, err := registry.SignRegistry(rootPriv, reg)
+	require.NoError(t, err)
+	raw, err := registry.MarshalDistribution(env)
+	require.NoError(t, err)
+	return raw, registry.NetworkID(rootPub)
+}

--- a/cmd/doctor_rollup_count_test.go
+++ b/cmd/doctor_rollup_count_test.go
@@ -131,6 +131,7 @@ func readJSONSurfaced(t *testing.T, vault string) jsonSurfacedIssues {
 // the two counts came from different sets.
 func TestDoctor_TextRollupCounts_MatchJSONSurfacedSet(t *testing.T) {
 	chdirToTemp(t)
+	isolateMeshEnv(t)
 	vault := buildValidationWarningVault(t)
 
 	textErrors, textWarnings, _ := readTextIssueCounts(t, vault)
@@ -157,6 +158,7 @@ func TestDoctor_TextRollupCounts_MatchJSONSurfacedSet(t *testing.T) {
 // This guards against a fix that simply hard-codes 0/0.
 func TestDoctor_TextRollupCounts_ReflectSurfacedItems(t *testing.T) {
 	chdirToTemp(t)
+	isolateMeshEnv(t)
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".vaultmind"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".vaultmind", "config.yaml"), []byte(`

--- a/cmd/doctor_summary_test.go
+++ b/cmd/doctor_summary_test.go
@@ -108,6 +108,7 @@ func TestDeprecated_VaultStatus_WarnsAndDelegatesToDoctorSummary(t *testing.T) {
 // The deprecated `vault status --json` must still emit a machine-readable
 // envelope (delegating to doctor's JSON path) alongside the stderr notice.
 func TestDeprecated_VaultStatus_JSONDelegates(t *testing.T) {
+	isolateMeshEnv(t)
 	vault := buildIndexedTestVault(t)
 	out, errOut, err := runRootCmd(t, "vault", "status", "--vault", vault, "--json")
 	require.NoError(t, err)

--- a/cmd/testhelpers_test.go
+++ b/cmd/testhelpers_test.go
@@ -13,6 +13,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// isolateMeshEnv makes the Contract-B mesh-doctor section dormant for a test by
+// pointing every XDG base dir at fresh empty temp dirs (no identity key, no
+// network anchor) and the chat-daemon URL at a closed loopback port. With no key
+// file, no anchor, no --mesh-* flag and no reachable daemon, doctor surfaces NO
+// mesh section — so a test asserting purely on VAULT-issue rollups is not
+// perturbed by the developer's ambient identity. CI already runs `task check`
+// under a fresh XDG_DATA_HOME; this makes the same hermeticity hold locally too.
+func isolateMeshEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// A closed loopback port → the daemon probe reports unreachable.
+	t.Setenv("AGENT_CHAT_DAEMON_URL", "http://127.0.0.1:1")
+	// No agents.yaml → no slug; belt-and-suspenders so an ambient env var can't
+	// resurface a slug-driven signal.
+	t.Setenv("AGENT_CHAT_REGISTRY", "")
+	t.Setenv("AGENT_CHAT_PROJECT_PATH", t.TempDir())
+}
+
 // buildIndexedTestVault creates a tempdir vault with a minimal config and
 // a handful of linked notes, then runs the indexer once. Returns the vault
 // root path. Tests that need query/search/links/status use this helper so

--- a/internal/config/commands/doctor_config.go
+++ b/internal/config/commands/doctor_config.go
@@ -24,14 +24,27 @@ To repair what doctor finds, run 'doctor heal' (all auto-fixable) or
 Use --all to diagnose EVERY vault discovered under a root (directories
 containing a .vaultmind/ subdir), with a combined rollup plus a per-vault
 report. --root sets where discovery starts (default: the current directory).
---all composes with --summary and --json (one combined envelope).`,
+--all composes with --summary and --json (one combined envelope).
+
+When a Contract-B mesh signal exists (an identity key, a pinned network anchor,
+a --mesh-* flag, or a reachable local daemon) doctor also reports a mesh-identity
+section: key custody, whether your binding authenticates against a PINNED root,
+and chat reachability. Green is reserved for a cryptographically authenticated
+binding; everything else is a warning (doctor stays exit-0). --mesh-root-pubkey
+pins the root explicitly (otherwise the enroll-persisted anchor is used),
+--mesh-registry verifies an offline registry file, --mesh-slug overrides the
+agents.yaml slug, and --mesh-heartbeat overrides the wake-watcher heartbeat path.`,
 	ConfigPrefix: "app.doctor",
 	FlagOverrides: map[string]string{
-		"app.doctor.vault":   "vault",
-		"app.doctor.json":    "json",
-		"app.doctor.summary": "summary",
-		"app.doctor.all":     "all",
-		"app.doctor.root":    "root",
+		"app.doctor.vault":            "vault",
+		"app.doctor.json":             "json",
+		"app.doctor.summary":          "summary",
+		"app.doctor.all":              "all",
+		"app.doctor.root":             "root",
+		"app.doctor.mesh_root_pubkey": "mesh-root-pubkey",
+		"app.doctor.mesh_registry":    "mesh-registry",
+		"app.doctor.mesh_slug":        "mesh-slug",
+		"app.doctor.mesh_heartbeat":   "mesh-heartbeat",
 	},
 }
 
@@ -43,6 +56,10 @@ func DoctorOptions() []config.ConfigOption {
 		{Key: "app.doctor.summary", DefaultValue: false, Description: "Print summary counts only (suppress per-link details)", Type: "bool"},
 		{Key: "app.doctor.all", DefaultValue: false, Description: "Diagnose every vault discovered under --root (multi-vault health)", Type: "bool"},
 		{Key: "app.doctor.root", DefaultValue: ".", Description: "Root directory to discover vaults under when --all is set", Type: "string"},
+		{Key: "app.doctor.mesh_root_pubkey", DefaultValue: "", Description: "Pin the Contract-B network root pubkey (base64) for authenticated mesh health; overrides the enroll-persisted anchor", Type: "string"},
+		{Key: "app.doctor.mesh_registry", DefaultValue: "", Description: "Verify an offline Contract-B signed-registry file instead of fetching from the local daemon", Type: "string"},
+		{Key: "app.doctor.mesh_slug", DefaultValue: "", Description: "Override the agent slug used to resolve your binding in the mesh registry (default: agents.yaml)", Type: "string"},
+		{Key: "app.doctor.mesh_heartbeat", DefaultValue: "", Description: "Override the wake-watcher heartbeat file path used for mesh watcher-liveness", Type: "string"},
 	}
 }
 

--- a/internal/identity/doctorclient/doctorclient.go
+++ b/internal/identity/doctorclient/doctorclient.go
@@ -1,0 +1,305 @@
+// Package doctorclient is a LOOPBACK-PINNED, read-only HTTP client for probing
+// the LOCAL Contract-B chat daemon's well-known/whoami endpoints from `vaultmind
+// doctor`. It is deliberately NOT relayclient.FetchRoot: that client is
+// remote-permissive (enroll fetches REMOTE relays). doctor only ever talks to a
+// daemon on loopback, so this client is hard fail-closed:
+//
+//   - resolve-then-check: it resolves the daemon host and refuses unless EVERY
+//     resolved IP satisfies net.IP.IsLoopback (an allowlist of loopback fails
+//     closed on any non-loopback form — no alternate-IP bypass).
+//   - DNS-rebind defense: it pins the resolved loopback IP in a custom
+//     DialContext, so a TOCTOU rebind between resolve and dial cannot redirect
+//     the connection off-loopback.
+//   - redirect refusal: CheckRedirect refuses ALL redirects (well-known and
+//     whoami endpoints never legitimately redirect).
+//   - scheme allowlist: http/https only.
+//   - body caps: io.LimitReader bounds every response (64 KiB for the small
+//     well-known/whoami payloads, 1 MiB for the registry directory, mirroring the
+//     signer's maxRequestBytes); an over-cap body fails LOUD, never silently
+//     truncated.
+//   - inescapable deadline: every fetch wraps the request in its OWN
+//     context.WithTimeout so a caller cannot hang doctor.
+//
+// It performs NO trust decisions: authenticity is owned by the pinned-root verify
+// in the doctor mesh logic. This package is pure transport.
+package doctorclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Well-known + whoami paths the local daemon serves (SSOT). They mirror the
+// agent-chat daemon routes: /.well-known/vaultmind-root (200/404),
+// /.well-known/vaultmind-directory (raw signed registry bytes), /whoami.
+const (
+	// WellKnownRootPath serves {root_pubkey, network_id, root_key_epoch?}.
+	WellKnownRootPath = "/.well-known/vaultmind-root"
+	// WellKnownDirectoryPath serves the byte-exact signed registry artifact.
+	WellKnownDirectoryPath = "/.well-known/vaultmind-directory"
+	// WhoamiPath serves the daemon's static configured identity.
+	WhoamiPath = "/whoami"
+)
+
+// Body caps. The well-known root + whoami payloads are tiny (~150 B); 64 KiB is
+// generous headroom. The directory is the full signed registry; 1 MiB mirrors
+// the signer's maxRequestBytes. An over-cap body fails LOUD.
+const (
+	maxWellKnownBodyBytes = 64 << 10
+	maxDirectoryBodyBytes = 1 << 20
+)
+
+// defaultFetchTimeout bounds EVERY fetch unless overridden via WithTimeout. It is
+// the inescapable deadline a caller cannot defeat.
+const defaultFetchTimeout = 5 * time.Second
+
+// Scheme allowlist (SSOT).
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
+// Error strings (SSOT). Each rejection is a distinct, named reason.
+const (
+	// errBadScheme is returned when the daemon base URL is unparseable, has no
+	// host, or carries a non-http(s) scheme.
+	errBadScheme = "doctorclient: daemon URL must be an http(s) URL with a host"
+	// errNonLoopback is returned (fail-closed) when the daemon host resolves to
+	// zero IPs or to ANY non-loopback IP. The allowlist admits ONLY loopback.
+	errNonLoopback = "doctorclient: daemon host does not resolve to loopback (refusing off-loopback probe)"
+	// errRedirect is returned when the daemon responds with a redirect — the
+	// well-known/whoami endpoints never legitimately redirect.
+	errRedirect = "doctorclient: refusing redirect from local daemon"
+	// errResolve wraps a resolver failure.
+	errResolve = "doctorclient: resolve daemon host"
+	// errBuildRequest wraps a request-construction failure (should not happen).
+	errBuildRequest = "doctorclient: build request"
+	// errFetch wraps a transport failure (dial/timeout/cancelled context).
+	errFetch = "doctorclient: fetch"
+	// errStatus wraps an unexpected non-200/non-404 status.
+	errStatus = "doctorclient: unexpected status"
+	// errDecode wraps a JSON decode failure of a well-known/whoami body.
+	errDecode = "doctorclient: decode response JSON"
+	// errBodyTooLarge is returned when a response body exceeds its cap.
+	errBodyTooLarge = "doctorclient: response body exceeds cap"
+	// errReadBody wraps a body read failure.
+	errReadBody = "doctorclient: read response body"
+)
+
+// ErrNotConfigured is returned by FetchRoot/FetchDirectory when the daemon
+// answers 404 — i.e. the endpoint exists but no root/registry is configured
+// (plaintext daemon). It is a typed sentinel so the caller can distinguish
+// "served nothing" from a transport error.
+var ErrNotConfigured = errors.New("doctorclient: daemon endpoint not configured (404)")
+
+// WellKnownRoot is the daemon-advertised PUBLIC trust anchor. It is UNTRUSTED:
+// the doctor logic verifies a registry against a PINNED root, never this.
+type WellKnownRoot struct {
+	RootPubKey   string `json:"root_pubkey"`
+	NetworkID    string `json:"network_id"`
+	RootKeyEpoch int64  `json:"root_key_epoch,omitempty"`
+}
+
+// whoamiResponse mirrors the daemon's /whoami body.
+type whoamiResponse struct {
+	Agent string `json:"agent"`
+}
+
+// resolverFunc resolves a host to its IPs. It is a seam so tests can drive the
+// loopback-allowlist check without real DNS. Production uses net.DefaultResolver.
+type resolverFunc func(ctx context.Context, host string) ([]net.IP, error)
+
+// Client is a loopback-pinned read-only probe of one local daemon base URL.
+type Client struct {
+	baseURL  *url.URL
+	host     string
+	resolve  resolverFunc
+	timeout  time.Duration
+	pinnedIP net.IP
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithResolver overrides the DNS resolver (test seam).
+func WithResolver(r resolverFunc) Option { return func(c *Client) { c.resolve = r } }
+
+// WithTimeout overrides the inescapable per-fetch deadline.
+func WithTimeout(d time.Duration) Option { return func(c *Client) { c.timeout = d } }
+
+// New validates baseURL (scheme + host) and returns a Client. The loopback
+// resolve-check happens per-fetch (so a transient resolver failure surfaces at
+// the call, not at construction), pinning the resolved IP for the dial.
+func New(baseURL string, opts ...Option) (*Client, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil || (u.Scheme != schemeHTTP && u.Scheme != schemeHTTPS) || u.Host == "" {
+		return nil, fmt.Errorf("%s", errBadScheme)
+	}
+	c := &Client{
+		baseURL: u,
+		host:    u.Hostname(),
+		resolve: defaultResolve,
+		timeout: defaultFetchTimeout,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+// defaultResolve resolves via net.DefaultResolver.
+func defaultResolve(ctx context.Context, host string) ([]net.IP, error) {
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, 0, len(addrs))
+	for _, a := range addrs {
+		ips = append(ips, a.IP)
+	}
+	return ips, nil
+}
+
+// FetchRoot GETs the well-known root and decodes it. A 404 returns
+// ErrNotConfigured (the daemon is plaintext / no root configured).
+func (c *Client) FetchRoot(ctx context.Context) (WellKnownRoot, error) {
+	body, err := c.get(ctx, WellKnownRootPath, maxWellKnownBodyBytes)
+	if err != nil {
+		return WellKnownRoot{}, err
+	}
+	var root WellKnownRoot
+	if err := json.Unmarshal(body, &root); err != nil {
+		return WellKnownRoot{}, fmt.Errorf("%s: %w", errDecode, err)
+	}
+	return root, nil
+}
+
+// FetchDirectory GETs the well-known directory and returns the RAW byte-exact
+// signed-registry artifact (the bytes the root signature covers). A 404 returns
+// ErrNotConfigured.
+func (c *Client) FetchDirectory(ctx context.Context) ([]byte, error) {
+	return c.get(ctx, WellKnownDirectoryPath, maxDirectoryBodyBytes)
+}
+
+// Whoami probes /whoami. It is a LIVENESS check: a 200 proves only that
+// something listens (the returned agent is the DAEMON identity, never the member
+// slug). It returns (reachable, agent, err); a transport failure yields
+// (false, "", nil) — an unreachable daemon is an INFO state, not a hard error.
+func (c *Client) Whoami(ctx context.Context) (bool, string, error) {
+	body, err := c.get(ctx, WhoamiPath, maxWellKnownBodyBytes)
+	if err != nil {
+		// A 404 still means something answered (reachable); any other error is a
+		// genuine transport failure (not reachable). Either way Whoami is a
+		// liveness probe — it never propagates the error to its caller.
+		return errors.Is(err, ErrNotConfigured), "", nil
+	}
+	// Reachable: a parse failure leaves the agent empty but still reachable (a
+	// live listener served a body we could not decode).
+	var wr whoamiResponse
+	_ = json.Unmarshal(body, &wr)
+	return true, wr.Agent, nil
+}
+
+// get resolves+loopback-checks the host, pins the resolved IP, performs the GET
+// under an inescapable deadline, refuses redirects, and returns the capped body.
+// A 404 maps to ErrNotConfigured; any other non-200 is an error.
+func (c *Client) get(ctx context.Context, path string, maxBytes int64) ([]byte, error) {
+	if err := c.ensureLoopbackPin(ctx); err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	endpoint := c.baseURL.JoinPath(path).String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errBuildRequest, err)
+	}
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errFetch, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotConfigured
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: %d", errStatus, resp.StatusCode)
+	}
+	return readCapped(resp.Body, maxBytes)
+}
+
+// ensureLoopbackPin resolves the daemon host and refuses unless EVERY resolved
+// IP is loopback. It pins the first loopback IP for the dial (DNS-rebind
+// defense). When the host is already a literal IP, it is checked directly.
+func (c *Client) ensureLoopbackPin(ctx context.Context) error {
+	if ip := net.ParseIP(c.host); ip != nil {
+		if !ip.IsLoopback() {
+			return fmt.Errorf("%s", errNonLoopback)
+		}
+		c.pinnedIP = ip
+		return nil
+	}
+	ips, err := c.resolve(ctx, c.host)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errResolve, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("%s", errNonLoopback)
+	}
+	for _, ip := range ips {
+		if !ip.IsLoopback() {
+			return fmt.Errorf("%s", errNonLoopback)
+		}
+	}
+	c.pinnedIP = ips[0]
+	return nil
+}
+
+// httpClient builds the hardened *http.Client: a DialContext that pins the
+// resolved loopback IP (rewriting the dial address to the pinned IP, defeating a
+// rebind), CheckRedirect that refuses all redirects, and the inescapable Timeout
+// is provided by the per-fetch context (Timeout here is a belt-and-suspenders).
+func (c *Client) httpClient() *http.Client {
+	dialer := &net.Dialer{Timeout: c.timeout}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			_, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			// Pin to the resolved loopback IP regardless of the dialed host.
+			pinned := net.JoinHostPort(c.pinnedIP.String(), port)
+			return dialer.DialContext(ctx, network, pinned)
+		},
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   c.timeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return errors.New(errRedirect)
+		},
+	}
+}
+
+// readCapped reads body up to maxBytes; an over-cap body (one more byte than
+// the cap) fails LOUD with errBodyTooLarge rather than silently truncating.
+func readCapped(body io.Reader, maxBytes int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(body, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errReadBody, err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%s (> %d bytes)", errBodyTooLarge, maxBytes)
+	}
+	return data, nil
+}

--- a/internal/identity/doctorclient/doctorclient_test.go
+++ b/internal/identity/doctorclient/doctorclient_test.go
@@ -1,0 +1,298 @@
+package doctorclient
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubResolver records the host it is asked to resolve and returns a fixed set
+// of IPs, so a test can drive the loopback-allowlist check without real DNS.
+type stubResolver struct {
+	ips  []net.IP
+	host string
+}
+
+func (s *stubResolver) lookup(_ context.Context, host string) ([]net.IP, error) {
+	s.host = host
+	return s.ips, nil
+}
+
+func loopbackResolver(t *testing.T) resolverFunc {
+	t.Helper()
+	r := &stubResolver{ips: []net.IP{net.ParseIP("127.0.0.1")}}
+	return r.lookup
+}
+
+func TestNew_RejectsNonHTTPScheme(t *testing.T) {
+	_, err := New("file:///etc/passwd", WithResolver(loopbackResolver(t)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errBadScheme)
+}
+
+func TestNew_RejectsEmptyHost(t *testing.T) {
+	_, err := New("http://", WithResolver(loopbackResolver(t)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errBadScheme)
+}
+
+func TestFetchRoot_LoopbackAccepted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"root_pubkey":"AAAA","network_id":"vmnet1:abcd","root_key_epoch":1}`))
+	}))
+	defer srv.Close()
+
+	// httptest binds 127.0.0.1; pin the resolver to loopback explicitly so the
+	// allowlist accepts it deterministically (independent of system resolver).
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+
+	root, err := c.FetchRoot(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "vmnet1:abcd", root.NetworkID)
+	require.Equal(t, "AAAA", root.RootPubKey)
+	require.EqualValues(t, 1, root.RootKeyEpoch)
+}
+
+func TestFetchRoot_NonLoopbackResolveRejected(t *testing.T) {
+	// A resolver that maps the daemon host to a PUBLIC IP must be rejected
+	// fail-closed BEFORE any dial — this is the SSRF/rebind defense.
+	r := &stubResolver{ips: []net.IP{net.ParseIP("203.0.113.5")}}
+	c, err := New("http://daemon.local:7777", WithResolver(r.lookup))
+	require.NoError(t, err)
+
+	_, err = c.FetchRoot(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errNonLoopback)
+}
+
+func TestFetchRoot_MixedResolveRejected(t *testing.T) {
+	// If ANY resolved IP is non-loopback, the allowlist fails closed.
+	r := &stubResolver{ips: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("10.0.0.1")}}
+	c, err := New("http://daemon.local:7777", WithResolver(r.lookup))
+	require.NoError(t, err)
+
+	_, err = c.FetchRoot(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errNonLoopback)
+}
+
+func TestFetchRoot_EmptyResolveRejected(t *testing.T) {
+	r := &stubResolver{ips: []net.IP{}}
+	c, err := New("http://daemon.local:7777", WithResolver(r.lookup))
+	require.NoError(t, err)
+
+	_, err = c.FetchRoot(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errNonLoopback)
+}
+
+func TestFetchRoot_RedirectRefused(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, "http://127.0.0.1:9/evil", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+
+	_, err = c.FetchRoot(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errRedirect)
+}
+
+func TestFetchRoot_OversizedBodyRejected(t *testing.T) {
+	// Body far larger than the 64 KiB root cap fails LOUD, never silent-truncates.
+	huge := strings.Repeat("A", int(maxWellKnownBodyBytes)+1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"network_id":"vmnet1:abcd","root_pubkey":"` + huge + `"}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+
+	_, err = c.FetchRoot(context.Background())
+	require.Error(t, err)
+}
+
+func TestFetchRoot_Non200Rejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+
+	_, err = c.FetchRoot(context.Background())
+	require.ErrorIs(t, err, ErrNotConfigured)
+}
+
+func TestFetchDirectory_ReturnsRawBytes(t *testing.T) {
+	raw := []byte(`{"registry":"AAAA","root_sig":"BBBB"}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(raw)
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+
+	got, err := c.FetchDirectory(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, raw, got)
+}
+
+func TestFetchDirectory_OversizedBodyRejected(t *testing.T) {
+	huge := strings.Repeat("A", int(maxDirectoryBodyBytes)+1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(huge))
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+
+	_, err = c.FetchDirectory(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errBodyTooLarge)
+}
+
+func TestFetchDirectory_Non200IsNotConfigured(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+
+	_, err = c.FetchDirectory(context.Background())
+	require.ErrorIs(t, err, ErrNotConfigured)
+}
+
+func TestWhoami_Reachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"agent":"agent:mira"}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+
+	reachable, agent, err := c.Whoami(context.Background())
+	require.NoError(t, err)
+	require.True(t, reachable)
+	require.Equal(t, "agent:mira", agent)
+}
+
+func TestWhoami_UnreachableNoServer(t *testing.T) {
+	// Point at a closed loopback port — Whoami reports not-reachable, no error
+	// is required to be non-nil (it is a liveness probe), but reachable=false.
+	c, err := New("http://127.0.0.1:1", WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+
+	reachable, _, _ := c.Whoami(context.Background())
+	require.False(t, reachable)
+}
+
+func TestFetchRoot_DefaultResolverLiteralLoopback(t *testing.T) {
+	// No WithResolver: exercise the production literal-IP loopback path + the
+	// default resolver code path (httptest binds a literal 127.0.0.1 URL).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"root_pubkey":"AAAA","network_id":"vmnet1:lit"}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL)
+	require.NoError(t, err)
+	root, err := c.FetchRoot(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "vmnet1:lit", root.NetworkID)
+}
+
+func TestDefaultResolve_LocalhostIsLoopback(t *testing.T) {
+	// Exercise the PRODUCTION resolver directly: localhost must resolve to at
+	// least one loopback IP on every CI host, and every returned IP must be
+	// loopback (so the allowlist would admit it).
+	ips, err := defaultResolve(context.Background(), "localhost")
+	require.NoError(t, err)
+	require.NotEmpty(t, ips)
+	for _, ip := range ips {
+		require.True(t, ip.IsLoopback(), "localhost resolved a non-loopback IP: %s", ip)
+	}
+}
+
+func TestFetchRoot_LiteralNonLoopbackRejected(t *testing.T) {
+	// A literal public IP host is rejected without any resolver call.
+	c, err := New("http://203.0.113.9:7777")
+	require.NoError(t, err)
+	_, err = c.FetchRoot(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errNonLoopback)
+}
+
+func TestFetchRoot_ResolverErrorSurfaced(t *testing.T) {
+	failing := func(_ context.Context, _ string) ([]net.IP, error) {
+		return nil, errResolveFailure
+	}
+	c, err := New("http://daemon.local:7777", WithResolver(failing))
+	require.NoError(t, err)
+	_, err = c.FetchRoot(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errResolve)
+}
+
+func TestFetchRoot_UnexpectedStatusSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)))
+	require.NoError(t, err)
+	_, err = c.FetchRoot(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), errStatus)
+}
+
+func TestReadCapped_ExactlyAtCapAccepted(t *testing.T) {
+	body := strings.NewReader(strings.Repeat("A", 10))
+	got, err := readCapped(body, 10)
+	require.NoError(t, err)
+	require.Len(t, got, 10)
+}
+
+// errResolveFailure is a sentinel resolver error for the resolver-error test.
+var errResolveFailure = &resolverTestError{}
+
+type resolverTestError struct{}
+
+func (*resolverTestError) Error() string { return "stub resolver failure" }
+
+func TestFetch_DeadlineBoundsNoTimeoutCaller(t *testing.T) {
+	// A handler that hangs longer than the client's internal deadline must not
+	// hang the fetch: the inescapable context.WithTimeout bounds it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(srv.URL, WithResolver(loopbackResolver(t)), WithTimeout(150*time.Millisecond))
+	require.NoError(t, err)
+
+	start := time.Now()
+	_, err = c.FetchRoot(context.Background())
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 1500*time.Millisecond, "deadline must bound a slow daemon")
+}

--- a/internal/query/doctor.go
+++ b/internal/query/doctor.go
@@ -38,6 +38,13 @@ type DoctorResult struct {
 	Types             map[string]StatusTypeInfo `json:"types,omitempty"`
 	IssuesSummary     *StatusIssuesSummary      `json:"issues_summary,omitempty"`
 	Issues            DoctorIssues              `json:"issues"`
+
+	// MeshIdentity is the Contract-B identity-health section. It is a POINTER
+	// with omitempty so it is ABSENT from --json unless a mesh signal exists
+	// (identity key file present, an anchor exists, a --mesh-* flag passed, or
+	// the daemon is reachable). Populated by the cmd layer (paths come from xdg +
+	// flags + env). nil ⇒ no mesh substrate, the section is omitted entirely.
+	MeshIdentity *DoctorMeshIdentity `json:"mesh_identity,omitempty"`
 }
 
 // DoctorEmbeddings reports the vault's semantic-retrieval readiness. Surfaces
@@ -159,6 +166,19 @@ func SurfacedIssueCounts(issues DoctorIssues) (errors, warnings int) {
 		warnings++
 	}
 	return errors, warnings
+}
+
+// ResultSurfacedIssueCounts is the result-level SSOT rollup: it folds the
+// vault-issue counts (SurfacedIssueCounts over result.Issues) together with the
+// mesh-identity section's contribution (MeshSurfacedCounts). Mesh issues are
+// WARNINGS only (doctor keeps exit-0-on-warning; no new exit code), so a
+// not-authenticated mesh state bumps the warning rollup without ever turning it
+// into an error. The cmd-layer rollup line uses this so the text "Issues: E
+// errors, W warnings" reflects the mesh section too.
+func ResultSurfacedIssueCounts(result *DoctorResult) (errs, warns int) {
+	errs, warns = SurfacedIssueCounts(result.Issues)
+	mErrs, mWarns := MeshSurfacedCounts(result.MeshIdentity)
+	return errs + mErrs, warns + mWarns
 }
 
 // ContentDrift describes one note whose current file content hash

--- a/internal/query/mesh_doctor.go
+++ b/internal/query/mesh_doctor.go
@@ -82,16 +82,15 @@ const (
 // Warning strings (SSOT) — each drives both the human Warnings slice and an
 // envelope.AddWarning in the cmd layer.
 const (
-	WarnMeshKeyMode          = "identity key file is not 0600 (custody mode is wrong)"
-	WarnMeshKeySize          = "identity key file is not the expected ed25519 private-key size"
-	WarnMeshUnpinned         = "registry self-consistent (daemon-advertised root), NOT authenticated — enroll persists a pin, or pass --mesh-root-pubkey"
-	WarnMeshNotEnrolled      = "your slug is not in the network registry yet (enroll-add pending?)"
-	WarnMeshKeyMismatch      = "your binding exists but the running signer does not hold its key (wrong signer/key?)"
-	WarnMeshUnverifiable     = "the network registry did not verify against your pinned root (bad signature, stale, or rolled back)"
-	WarnMeshNoRegistry       = "no registry available to verify (daemon unreachable and no --mesh-registry given)"
-	WarnMeshEnforcementOff   = "message-signature enforcement is NOT YET active (advisory mode is a no-op today)"
-	WarnMeshHeartbeatStale   = "wake-watcher heartbeat is stale — the watcher may be present-but-dead"
-	WarnMeshHeartbeatMissing = "no wake-watcher heartbeat (wake-on-idle not confirmed)"
+	WarnMeshKeyMode        = "identity key file is not 0600 (custody mode is wrong)"
+	WarnMeshKeySize        = "identity key file is not the expected ed25519 private-key size"
+	WarnMeshUnpinned       = "registry self-consistent (daemon-advertised root), NOT authenticated — enroll persists a pin, or pass --mesh-root-pubkey"
+	WarnMeshNotEnrolled    = "your slug is not in the network registry yet (enroll-add pending?)"
+	WarnMeshKeyMismatch    = "your binding exists but the running signer does not hold its key (wrong signer/key?)"
+	WarnMeshUnverifiable   = "the network registry did not verify against your pinned root (bad signature, stale, or rolled back)"
+	WarnMeshNoRegistry     = "no registry available to verify (daemon unreachable and no --mesh-registry given)"
+	WarnMeshEnforcementOff = "message-signature enforcement is NOT YET active (advisory mode is a no-op today)"
+	WarnMeshHeartbeatStale = "wake-watcher heartbeat is stale — the watcher may be present-but-dead"
 )
 
 // MeshSigner is the keyless signing seam: doctor asks the SIGNER (over the UDS)
@@ -284,7 +283,11 @@ func checkHeartbeat(mi *DoctorMeshIdentity, heartbeatPath string, now time.Time)
 	}
 	info, err := os.Lstat(heartbeatPath)
 	if err != nil {
-		mi.addWarning(WarnMeshHeartbeatMissing)
+		// ABSENT is INFO, not a warning: most members have never run the watcher,
+		// so an absent heartbeat must not inflate the warning count or trip
+		// `jq '.status=="warning"'`. WatcherHeartbeatFresh=false + Age==0 is the
+		// signal; the human writer renders the "not found" note. Only STALE
+		// (present-but-dead) is a warning.
 		return
 	}
 	age := now.Sub(info.ModTime())

--- a/internal/query/mesh_doctor.go
+++ b/internal/query/mesh_doctor.go
@@ -1,0 +1,447 @@
+package query
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"io/fs"
+	"net"
+	"os"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/doctorclient"
+	"github.com/peiman/vaultmind/internal/identity/registry"
+)
+
+// ── Mesh-doctor: Contract-B identity health (sec-review M1/M3/M4) ────────────
+//
+// NORTH STAR: a health check whose one job is "am I OK?" must NEVER paint GREEN
+// over a compromised — or even misconfigured — substrate. GREEN
+// (Authenticated=true) is reserved for what doctor can CRYPTOGRAPHICALLY PROVE:
+// a registry verified against a PINNED root (M1) AND a keyless proof that the
+// running signer holds the binding key (M3). Everything else is WARNING/INFO and
+// Authenticated stays false (M4: top-level boolean + envelope warning).
+
+// Tier-2 status values (SSOT). Each is a distinct, machine-readable verdict.
+const (
+	// StatusMeshAuthenticated: pinned root verified the registry AND the running
+	// signer proved possession of the resolved binding key. The ONLY green state.
+	StatusMeshAuthenticated = "authenticated"
+	// StatusMeshSelfConsistentUnpinned: no pin; the daemon-advertised root
+	// verified its own registry for self-consistency ONLY — NOT authenticated.
+	StatusMeshSelfConsistentUnpinned = "self-consistent-unpinned"
+	// StatusMeshNotEnrolled: pinned + registry verified, but the member slug has
+	// no live binding (enroll-add pending).
+	StatusMeshNotEnrolled = "not-enrolled"
+	// StatusMeshKeyMismatch: pinned + binding resolved, but the running signer
+	// does NOT hold the binding's key (wrong signer/key).
+	StatusMeshKeyMismatch = "key-mismatch"
+	// StatusMeshUnverifiable: pinned, but the registry failed to verify
+	// (bad-sig/stale/rollback) or could not be fetched.
+	StatusMeshUnverifiable = "unverifiable"
+	// StatusMeshNoSignal: no mesh signal present (caller should not surface the
+	// section at all — see HasSignal).
+	StatusMeshNoSignal = "no-signal"
+)
+
+// Tier-3 daemon-mode values (SSOT). FACTUAL served-state labels only — they do
+// NOT imply message-signature protection (enforcement is a no-op today).
+const (
+	// DaemonModePlaintext: the daemon serves no well-known root (404).
+	DaemonModePlaintext = "plaintext"
+	// DaemonModeAdvisoryConfigured: a well-known root is served (registry
+	// configured). Advisory only — verdict-gating is a return-true no-op today.
+	DaemonModeAdvisoryConfigured = "advisory-configured"
+	// DaemonModeUnknown: the daemon was unreachable, so its mode is unknown.
+	DaemonModeUnknown = ""
+)
+
+// Constants governing custody + freshness.
+const (
+	// keyFilePerm is the only acceptable key-file mode: owner read/write only.
+	keyFilePerm os.FileMode = 0o600
+	// heartbeatStaleAfter is the freshness window for the watcher heartbeat
+	// (~6× the 15s poll). Older than this → the watcher may be present-but-dead.
+	heartbeatStaleAfter = 90 * time.Second
+	// doctorMaxStaleness bounds how stale a verified registry may be before
+	// doctor treats it as unverifiable (a stale registry may hide a revocation).
+	doctorMaxStaleness = 24 * time.Hour
+	// selfVerifyNonceBytes is the random-challenge length for proof-of-possession.
+	selfVerifyNonceBytes = 32
+	// selfVerifyDomainTag domain-separates the proof-of-possession challenge so a
+	// signed challenge can NEVER be mistaken for an envelope/registry signature.
+	selfVerifyDomainTag = "vaultmind-doctor-selfverify-v1:"
+	// signerProbeNetwork + signerProbeTimeout bound the on-demand signer dial.
+	signerProbeNetwork = "unix"
+	signerProbeTimeout = 1500 * time.Millisecond
+)
+
+// Warning strings (SSOT) — each drives both the human Warnings slice and an
+// envelope.AddWarning in the cmd layer.
+const (
+	WarnMeshKeyMode          = "identity key file is not 0600 (custody mode is wrong)"
+	WarnMeshKeySize          = "identity key file is not the expected ed25519 private-key size"
+	WarnMeshUnpinned         = "registry self-consistent (daemon-advertised root), NOT authenticated — enroll persists a pin, or pass --mesh-root-pubkey"
+	WarnMeshNotEnrolled      = "your slug is not in the network registry yet (enroll-add pending?)"
+	WarnMeshKeyMismatch      = "your binding exists but the running signer does not hold its key (wrong signer/key?)"
+	WarnMeshUnverifiable     = "the network registry did not verify against your pinned root (bad signature, stale, or rolled back)"
+	WarnMeshNoRegistry       = "no registry available to verify (daemon unreachable and no --mesh-registry given)"
+	WarnMeshEnforcementOff   = "message-signature enforcement is NOT YET active (advisory mode is a no-op today)"
+	WarnMeshHeartbeatStale   = "wake-watcher heartbeat is stale — the watcher may be present-but-dead"
+	WarnMeshHeartbeatMissing = "no wake-watcher heartbeat (wake-on-idle not confirmed)"
+)
+
+// MeshSigner is the keyless signing seam: doctor asks the SIGNER (over the UDS)
+// to sign a challenge; it NEVER reads the private key file itself. signer.Client
+// satisfies this.
+type MeshSigner interface {
+	Sign(canonicalBytes []byte) ([]byte, error)
+}
+
+// MeshDaemonClient is the loopback-pinned daemon-probe seam. doctorclient.Client
+// satisfies this.
+type MeshDaemonClient interface {
+	FetchRoot(ctx context.Context) (doctorclient.WellKnownRoot, error)
+	FetchDirectory(ctx context.Context) ([]byte, error)
+	Whoami(ctx context.Context) (bool, string, error)
+}
+
+// MeshDoctorInput carries everything BuildMeshIdentity needs. The cmd layer
+// resolves paths (xdg + flags + env), the anchor pin, the slug, and constructs
+// the signer + loopback daemon client.
+type MeshDoctorInput struct {
+	// Tier-1 custody (STAT-ONLY — never read).
+	KeyPath    string
+	SocketPath string
+
+	// Tier-2 authenticity.
+	PinnedRootPub ed25519.PublicKey // nil ⇒ UNPINNED path (never green)
+	NetworkID     string
+	RegistryBytes []byte // offline registry override (--mesh-registry); else fetched
+	Slug          string
+	Signer        MeshSigner // keyless proof-of-possession
+
+	// Tier-3 reachability.
+	Daemon        MeshDaemonClient
+	HeartbeatPath string
+
+	// Clock seam.
+	Now time.Time
+}
+
+// DoctorMeshIdentity is the JSON-serializable mesh-health section. It is a
+// POINTER on DoctorResult (nil ⇒ absent from --json) so the section appears only
+// when a mesh signal exists.
+type DoctorMeshIdentity struct {
+	// Tier 1 — identity custody (local, keyless).
+	KeyPresent      bool `json:"key_present"`
+	KeyModeOK       bool `json:"key_mode_ok"`
+	KeySizeOK       bool `json:"key_size_ok"`
+	SignerReachable bool `json:"signer_reachable"` // INFO — signer is on-demand
+
+	// Tier 2 — binding resolves in the live mesh (authenticated).
+	Pinned          bool   `json:"pinned"`
+	Authenticated   bool   `json:"authenticated"` // M4 top-level boolean
+	NetworkID       string `json:"network_id,omitempty"`
+	BindingResolves bool   `json:"binding_resolves"`
+	HoldsBindingKey bool   `json:"holds_binding_key"` // selfVerify proof-of-possession
+	Status          string `json:"status"`
+
+	// Tier 3 — chat reachability (honest labels).
+	DaemonReachable       bool   `json:"daemon_reachable"`
+	DaemonMode            string `json:"daemon_mode,omitempty"`
+	EnforcementActive     bool   `json:"enforcement_active"` // always false today
+	WatcherHeartbeatFresh bool   `json:"watcher_heartbeat_fresh"`
+	WatcherHeartbeatAge   int    `json:"watcher_heartbeat_age_secs"`
+
+	// Warnings each also drive an envelope.AddWarning in the cmd layer.
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// addWarning appends w to the section's warnings (deduplicated by string).
+func (m *DoctorMeshIdentity) addWarning(w string) {
+	for _, existing := range m.Warnings {
+		if existing == w {
+			return
+		}
+	}
+	m.Warnings = append(m.Warnings, w)
+}
+
+// BuildMeshIdentity runs the 3-tier Contract-B identity health check and returns
+// the populated section. It NEVER reads the private key file (tier-1 is Lstat
+// stat-only; the binding-key check is a keyless proof-of-possession via the
+// signer). Authenticated is true ONLY on the pinned + resolves + selfVerify-pass
+// path (M1+M3); every other state leaves Authenticated false (M4).
+func BuildMeshIdentity(ctx context.Context, in MeshDoctorInput) (*DoctorMeshIdentity, error) {
+	mi := &DoctorMeshIdentity{
+		Status:            StatusMeshNoSignal,
+		DaemonMode:        DaemonModeUnknown,
+		NetworkID:         in.NetworkID,
+		EnforcementActive: false,
+	}
+
+	checkKeyCustody(mi, in.KeyPath)
+	mi.SignerReachable = signerReachable(in.SocketPath)
+
+	// Tier 3 first (daemon reachability) so tier-2 can reuse a fetched registry.
+	registryBytes := evaluateTier3(ctx, mi, in)
+
+	// Tier 2 — authenticity.
+	evaluateTier2(ctx, mi, in, registryBytes)
+
+	return mi, nil
+}
+
+// checkKeyCustody fills tier-1 booleans from an Lstat of the key path — STAT
+// ONLY, the file is never opened/read. Lstat (not Stat) means a SYMLINK at the
+// key path is seen as a symlink, not a regular 0600 file, so its mode check
+// fails (sshd strict-modes alignment).
+func checkKeyCustody(mi *DoctorMeshIdentity, keyPath string) {
+	info, err := os.Lstat(keyPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return // not-yet-initialised member: all tier-1 booleans stay false
+		}
+		// An unexpected stat error (permission on the parent dir, etc.) leaves
+		// the booleans false; doctor never reads the key to recover.
+		return
+	}
+	mi.KeyPresent = true
+	// A regular file at exactly 0600 (a symlink's Mode() is ModeSymlink, so the
+	// regular-file requirement + perm match both fail for a link).
+	mi.KeyModeOK = info.Mode().IsRegular() && info.Mode().Perm() == keyFilePerm
+	mi.KeySizeOK = info.Size() == int64(ed25519.PrivateKeySize)
+	if !mi.KeyModeOK {
+		mi.addWarning(WarnMeshKeyMode)
+	}
+	if !mi.KeySizeOK {
+		mi.addWarning(WarnMeshKeySize)
+	}
+}
+
+// signerReachable dial-probes the signer socket (the reapStaleSocket technique:
+// a successful dial means a live signer answers). Signer-not-running is INFO,
+// never red — the signer runs on-demand. It NEVER reads the key file.
+func signerReachable(socketPath string) bool {
+	if socketPath == "" {
+		return false
+	}
+	conn, err := net.DialTimeout(signerProbeNetwork, socketPath, signerProbeTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// evaluateTier3 probes the daemon (loopback-pinned) for reachability + factual
+// served mode, and checks the watcher heartbeat freshness. It returns any
+// registry bytes fetched from the daemon (for tier-2 reuse) — empty when the
+// caller supplied an offline registry or the daemon is unreachable/plaintext.
+func evaluateTier3(ctx context.Context, mi *DoctorMeshIdentity, in MeshDoctorInput) []byte {
+	checkHeartbeat(mi, in.HeartbeatPath, in.Now)
+
+	if in.Daemon == nil {
+		return nil
+	}
+	reachable, _, _ := in.Daemon.Whoami(ctx)
+	mi.DaemonReachable = reachable
+	if !reachable {
+		return nil
+	}
+
+	// Factual served mode from the well-known root presence (200 vs 404).
+	root, err := in.Daemon.FetchRoot(ctx)
+	switch {
+	case errors.Is(err, doctorclient.ErrNotConfigured):
+		mi.DaemonMode = DaemonModePlaintext
+	case err == nil && root.RootPubKey != "":
+		mi.DaemonMode = DaemonModeAdvisoryConfigured
+		// Advisory/enforcing NEVER implies protection today — say so.
+		mi.addWarning(WarnMeshEnforcementOff)
+	default:
+		mi.DaemonMode = DaemonModeUnknown
+	}
+
+	// Reuse a daemon-served registry for tier-2 when no offline registry given.
+	if len(in.RegistryBytes) == 0 {
+		if dir, derr := in.Daemon.FetchDirectory(ctx); derr == nil {
+			return dir
+		}
+	}
+	return nil
+}
+
+// checkHeartbeat reads the watcher heartbeat file's mtime and sets freshness —
+// FRESHNESS, not a process check. Absent ⇒ not confirmed; stale ⇒ warning.
+func checkHeartbeat(mi *DoctorMeshIdentity, heartbeatPath string, now time.Time) {
+	if heartbeatPath == "" {
+		return
+	}
+	info, err := os.Lstat(heartbeatPath)
+	if err != nil {
+		mi.addWarning(WarnMeshHeartbeatMissing)
+		return
+	}
+	age := now.Sub(info.ModTime())
+	if age < 0 {
+		age = 0
+	}
+	mi.WatcherHeartbeatAge = int(age.Seconds())
+	if age <= heartbeatStaleAfter {
+		mi.WatcherHeartbeatFresh = true
+		return
+	}
+	mi.addWarning(WarnMeshHeartbeatStale)
+}
+
+// evaluateTier2 runs the authenticity check. registryBytes is the daemon-fetched
+// registry (when no offline override). The UNPINNED path (no pin) verifies only
+// for self-consistency and NEVER goes green (M1).
+func evaluateTier2(ctx context.Context, mi *DoctorMeshIdentity, in MeshDoctorInput, registryBytes []byte) {
+	regBytes := in.RegistryBytes
+	if len(regBytes) == 0 {
+		regBytes = registryBytes
+	}
+
+	if len(in.PinnedRootPub) == 0 {
+		evaluateUnpinned(ctx, mi, in, regBytes)
+		return
+	}
+	mi.Pinned = true
+	evaluatePinned(mi, in, regBytes)
+}
+
+// evaluateUnpinned (M1): with NO pin, verify the registry against the
+// DAEMON-ADVERTISED root for self-consistency ONLY. Authenticated stays false;
+// status is self-consistent-unpinned with a loud warning. Never green.
+func evaluateUnpinned(ctx context.Context, mi *DoctorMeshIdentity, in MeshDoctorInput, regBytes []byte) {
+	mi.Status = StatusMeshSelfConsistentUnpinned
+	mi.addWarning(WarnMeshUnpinned)
+
+	if in.Daemon == nil || len(regBytes) == 0 {
+		return
+	}
+	root, err := in.Daemon.FetchRoot(ctx)
+	if err != nil || root.RootPubKey == "" {
+		return
+	}
+	advertised, err := base64.StdEncoding.DecodeString(root.RootPubKey)
+	if err != nil {
+		return
+	}
+	// Self-consistency check ONLY — this proves the daemon's registry was signed
+	// by the daemon's own advertised root. It authenticates NOTHING (a malicious
+	// daemon serves a matched {evil_root, evil_registry}). Authenticated remains
+	// false; we record NetworkID for display only.
+	if _, _, verr := registry.VerifyAndLoad(advertised, mustParse(regBytes), 0, in.Now, doctorMaxStaleness); verr == nil {
+		if mi.NetworkID == "" {
+			mi.NetworkID = root.NetworkID
+		}
+	}
+}
+
+// evaluatePinned runs the authenticated path: VerifyAndLoad against the PINNED
+// root, Resolve the slug, then a keyless selfVerify of the binding key. Green
+// only on the full pass.
+func evaluatePinned(mi *DoctorMeshIdentity, in MeshDoctorInput, regBytes []byte) {
+	if len(regBytes) == 0 {
+		mi.Status = StatusMeshUnverifiable
+		mi.addWarning(WarnMeshNoRegistry)
+		return
+	}
+	env, err := registry.ParseDistribution(regBytes)
+	if err != nil {
+		mi.Status = StatusMeshUnverifiable
+		mi.addWarning(WarnMeshUnverifiable)
+		return
+	}
+	reg, _, err := registry.VerifyAndLoad(in.PinnedRootPub, env, 0, in.Now, doctorMaxStaleness)
+	if err != nil {
+		mi.Status = StatusMeshUnverifiable
+		mi.addWarning(WarnMeshUnverifiable)
+		return
+	}
+	binding, err := registry.Resolve(reg, in.Slug, in.Now)
+	if err != nil {
+		mi.Status = StatusMeshNotEnrolled
+		mi.addWarning(WarnMeshNotEnrolled)
+		return
+	}
+	mi.BindingResolves = true
+
+	// M3 keyless proof-of-possession: ask the signer to sign a fresh
+	// domain-tagged random challenge, verify against the RESOLVED BINDING pubkey.
+	// The private key file is NEVER read.
+	if selfVerifyBindingKey(in.Signer, binding.PubKey.Bytes()) {
+		mi.HoldsBindingKey = true
+		mi.Authenticated = true
+		mi.Status = StatusMeshAuthenticated
+		return
+	}
+	mi.Status = StatusMeshKeyMismatch
+	mi.addWarning(WarnMeshKeyMismatch)
+}
+
+// selfVerifyBindingKey performs the keyless proof-of-possession: it builds a
+// fresh random domain-tagged challenge, asks the signer to sign it, and verifies
+// the signature against bindingPub. A nil signer, a signer error, or a non-match
+// all return false (fail closed). NO private-key file access occurs anywhere.
+func selfVerifyBindingKey(signer MeshSigner, bindingPub ed25519.PublicKey) bool {
+	if signer == nil {
+		return false
+	}
+	nonce := make([]byte, selfVerifyNonceBytes)
+	if _, err := rand.Read(nonce); err != nil {
+		return false
+	}
+	challenge := buildSelfVerifyChallenge(nonce)
+	sig, err := signer.Sign(challenge.Bytes())
+	if err != nil {
+		return false
+	}
+	ok, err := identity.VerifyCanonical(bindingPub, challenge, sig)
+	return err == nil && ok
+}
+
+// buildSelfVerifyChallenge domain-separates a random nonce so the signed bytes
+// can NEVER be replayed as an envelope/registry signature. The result is fed to
+// the signer (Sign over .Bytes()) and to VerifyCanonical.
+func buildSelfVerifyChallenge(nonce []byte) identity.CanonicalBytes {
+	tagged := make([]byte, 0, len(selfVerifyDomainTag)+len(nonce))
+	tagged = append(tagged, []byte(selfVerifyDomainTag)...)
+	tagged = append(tagged, nonce...)
+	return identity.CanonicalBytesFromTrusted(tagged)
+}
+
+// mustParse parses regBytes, returning a zero envelope on failure (the caller's
+// VerifyAndLoad then rejects it — fail closed). Used only on the unpinned
+// self-consistency path where a parse failure simply yields "no self-consistency
+// shown".
+func mustParse(regBytes []byte) registry.SignedRegistry {
+	env, err := registry.ParseDistribution(regBytes)
+	if err != nil {
+		return registry.SignedRegistry{}
+	}
+	return env
+}
+
+// HasSignal reports whether any mesh signal exists, so the cmd layer can decide
+// whether to attach the section at all (nil ⇒ absent from --json).
+func (m *DoctorMeshIdentity) HasSignal() bool {
+	return m != nil && m.Status != StatusMeshNoSignal
+}
+
+// MeshSurfacedCounts returns the error/warning counts the mesh section
+// contributes to the doctor rollup. Per M4 + doctor convention, mesh issues are
+// WARNINGS (exit stays 0): every section Warnings entry counts as one warning.
+func MeshSurfacedCounts(m *DoctorMeshIdentity) (errs, warns int) {
+	if m == nil {
+		return 0, 0
+	}
+	return 0, len(m.Warnings)
+}

--- a/internal/query/mesh_doctor_keyless_test.go
+++ b/internal/query/mesh_doctor_keyless_test.go
@@ -1,0 +1,63 @@
+package query
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestKeylessInvariant_NoPrivateKeyRead is the M3 keyless guard: it parses the
+// mesh-doctor source and asserts NO os.ReadFile / os.Open / os.OpenFile /
+// ioutil.ReadFile call exists anywhere in the file. Tier-1 custody is STAT-ONLY
+// (os.Lstat); the "I hold my binding key" proof is a keyless proof-of-possession
+// via the signer. The private key file must NEVER be opened for read. If a
+// future edit introduces a key read, this test fails loud.
+//
+// This is a structural guard, not a behavioural one: it forbids the family of
+// read primitives in the file outright. The legitimate file-read needs
+// (registry file, agents.yaml) live in the cmd layer and read DIFFERENT paths,
+// not the private key — so this package-scoped guard can be absolute.
+func TestKeylessInvariant_NoPrivateKeyRead(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "mesh_doctor.go", nil, parser.AllErrors)
+	require.NoError(t, err)
+
+	forbidden := map[string]map[string]bool{
+		"os":     {"ReadFile": true, "Open": true, "OpenFile": true},
+		"ioutil": {"ReadFile": true},
+	}
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if methods, ok := forbidden[pkg.Name]; ok && methods[sel.Sel.Name] {
+			t.Fatalf("KEYLESS INVARIANT VIOLATED: mesh_doctor.go calls %s.%s — "+
+				"the private key file must NEVER be read; tier-1 is stat-only "+
+				"(os.Lstat) and the binding-key check is a keyless proof-of-possession",
+				pkg.Name, sel.Sel.Name)
+		}
+		return true
+	})
+
+	// Belt-and-suspenders: assert os.Lstat IS present (the stat-only custody
+	// check) so a refactor that drops custody checking is also caught. Reading
+	// the SOURCE file in a test is unrelated to the keyless invariant — that
+	// invariant forbids PRODUCTION code reading the PRIVATE KEY, asserted above.
+	raw, err := os.ReadFile("mesh_doctor.go")
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "os.Lstat", "tier-1 custody must use os.Lstat (stat-only)")
+}

--- a/internal/query/mesh_doctor_test.go
+++ b/internal/query/mesh_doctor_test.go
@@ -1,0 +1,571 @@
+package query
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/peiman/vaultmind/internal/identity"
+	"github.com/peiman/vaultmind/internal/identity/anchor"
+	"github.com/peiman/vaultmind/internal/identity/doctorclient"
+	"github.com/peiman/vaultmind/internal/identity/registry"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test doubles -----------------------------------------------------------
+
+// stubDaemon implements MeshDaemonClient for the tier-2/tier-3 tests.
+type stubDaemon struct {
+	root        doctorclient.WellKnownRoot
+	rootErr     error
+	directory   []byte
+	dirErr      error
+	whoamiOK    bool
+	whoamiAgent string
+}
+
+func (s *stubDaemon) FetchRoot(_ context.Context) (doctorclient.WellKnownRoot, error) {
+	return s.root, s.rootErr
+}
+func (s *stubDaemon) FetchDirectory(_ context.Context) ([]byte, error) {
+	return s.directory, s.dirErr
+}
+func (s *stubDaemon) Whoami(_ context.Context) (bool, string, error) {
+	return s.whoamiOK, s.whoamiAgent, nil
+}
+
+// stubSigner implements MeshSigner. holds the private key so it can answer a
+// proof-of-possession challenge — exactly the keyless route doctor must use
+// (the CLI never reads the key file; the SIGNER holds it).
+type stubSigner struct {
+	priv    ed25519.PrivateKey
+	signErr error
+}
+
+func (s *stubSigner) Sign(canonical []byte) ([]byte, error) {
+	if s.signErr != nil {
+		return nil, s.signErr
+	}
+	return ed25519.Sign(s.priv, canonical), nil
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+// lowEntropyKey deterministically derives an ed25519 keypair from a seed string
+// (gitleaks-friendly: NewKeyFromSeed of a known-low-entropy seed, never a real
+// secret).
+func lowEntropyKey(t *testing.T, seed string) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	s := make([]byte, ed25519.SeedSize)
+	copy(s, seed)
+	priv := ed25519.NewKeyFromSeed(s)
+	return priv.Public().(ed25519.PublicKey), priv
+}
+
+// buildSignedRegistry roots a one-binding registry under rootPriv and returns the
+// distribution bytes + the network id derived from the root.
+func buildSignedRegistry(t *testing.T, rootPub ed25519.PublicKey, rootPriv ed25519.PrivateKey, slug string, memberPub ed25519.PublicKey, now time.Time) ([]byte, string) {
+	t.Helper()
+	pk, err := registry.NewPublicKey(memberPub)
+	require.NoError(t, err)
+	reg := registry.Registry{
+		Epoch:      1,
+		ValidFrom:  now.Add(-time.Hour).Unix(),
+		ValidUntil: now.Add(24 * time.Hour).Unix(),
+		Agents: []registry.AgentBinding{{
+			Slug:                    slug,
+			DisplayName:             "Member",
+			PubKey:                  pk,
+			KeyEpoch:                1,
+			ValidFrom:               now.Add(-time.Hour).Unix(),
+			ValidUntil:              now.Add(24 * time.Hour).Unix(),
+			AuthorizedOriginDaemons: []string{"daemon:local"},
+		}},
+	}
+	env, err := registry.SignRegistry(rootPriv, reg)
+	require.NoError(t, err)
+	raw, err := registry.MarshalDistribution(env)
+	require.NoError(t, err)
+	return raw, registry.NetworkID(rootPub)
+}
+
+func writeKeyFile(t *testing.T, path string, mode os.FileMode, size int) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, make([]byte, size), 0o600))
+	require.NoError(t, os.Chmod(path, mode))
+}
+
+// --- TIER 1 -----------------------------------------------------------------
+
+func TestMeshDoctor_Tier1_KeyPresentGoodModeAndSize(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "identity-signer.key")
+	writeKeyFile(t, keyPath, 0o600, ed25519.PrivateKeySize)
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:    keyPath,
+		SocketPath: filepath.Join(dir, "missing.sock"),
+		Now:        time.Now(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mi)
+	require.True(t, mi.KeyPresent)
+	require.True(t, mi.KeyModeOK)
+	require.True(t, mi.KeySizeOK)
+	// signer not running is INFO, not a hard error.
+	require.False(t, mi.SignerReachable)
+}
+
+func TestMeshDoctor_Tier1_KeyAbsent(t *testing.T) {
+	dir := t.TempDir()
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:    filepath.Join(dir, "nope.key"),
+		SocketPath: filepath.Join(dir, "missing.sock"),
+		Now:        time.Now(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mi)
+	require.False(t, mi.KeyPresent)
+	require.False(t, mi.KeyModeOK)
+	require.False(t, mi.KeySizeOK)
+}
+
+func TestMeshDoctor_Tier1_KeyBadMode(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "identity-signer.key")
+	writeKeyFile(t, keyPath, 0o644, ed25519.PrivateKeySize)
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:    keyPath,
+		SocketPath: filepath.Join(dir, "missing.sock"),
+		Now:        time.Now(),
+	})
+	require.NoError(t, err)
+	require.True(t, mi.KeyPresent)
+	require.False(t, mi.KeyModeOK)
+	require.True(t, mi.KeySizeOK)
+	require.NotEmpty(t, mi.Warnings)
+}
+
+func TestMeshDoctor_Tier1_KeyBadSize(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "identity-signer.key")
+	writeKeyFile(t, keyPath, 0o600, 10)
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:    keyPath,
+		SocketPath: filepath.Join(dir, "missing.sock"),
+		Now:        time.Now(),
+	})
+	require.NoError(t, err)
+	require.True(t, mi.KeyPresent)
+	require.False(t, mi.KeySizeOK)
+}
+
+func TestMeshDoctor_Tier1_SymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	realKey := filepath.Join(dir, "real.key")
+	writeKeyFile(t, realKey, 0o600, ed25519.PrivateKeySize)
+	linkPath := filepath.Join(dir, "identity-signer.key")
+	require.NoError(t, os.Symlink(realKey, linkPath))
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:    linkPath,
+		SocketPath: filepath.Join(dir, "missing.sock"),
+		Now:        time.Now(),
+	})
+	require.NoError(t, err)
+	// Lstat sees the symlink, NOT a regular 0600 file → mode check fails.
+	require.True(t, mi.KeyPresent)
+	require.False(t, mi.KeyModeOK)
+}
+
+// keylessGuardKey is a path the test asserts is NEVER opened for read. The
+// readGuard install replaces os file-open hooks; here we assert via a sentinel:
+// BuildMeshIdentity must only Lstat the key, never read it. We prove it by
+// putting unreadable (0000) content that would error on read but stat fine.
+func TestMeshDoctor_Tier1_KeylessNeverReadsKey(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "identity-signer.key")
+	// Write a 64-byte file then strip ALL read perms. A 0600 file is required for
+	// KeyModeOK; here we use 0200 (write-only) so any os.ReadFile would FAIL —
+	// if doctor tried to read it, the result would differ. Custody stat still
+	// works (size+mode via Lstat).
+	writeKeyFile(t, keyPath, 0o200, ed25519.PrivateKeySize)
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:    keyPath,
+		SocketPath: filepath.Join(dir, "missing.sock"),
+		Now:        time.Now(),
+	})
+	require.NoError(t, err)
+	require.True(t, mi.KeyPresent)
+	require.True(t, mi.KeySizeOK)
+	// 0200 != 0600 → mode not OK, but NO read attempted (no error surfaced).
+	require.False(t, mi.KeyModeOK)
+}
+
+// --- TIER 2 -----------------------------------------------------------------
+
+func TestMeshDoctor_Tier2_PinnedResolvesSelfVerifyGreen(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rootPub, rootPriv := lowEntropyKey(t, "doctor-root-seed-green")
+	memberPub, memberPriv := lowEntropyKey(t, "doctor-member-seed-green")
+	raw, nid := buildSignedRegistry(t, rootPub, rootPriv, "agent:mira", memberPub, now)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "identity-signer.key")
+	writeKeyFile(t, keyPath, 0o600, ed25519.PrivateKeySize)
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       keyPath,
+		SocketPath:    filepath.Join(dir, "missing.sock"),
+		PinnedRootPub: rootPub,
+		NetworkID:     nid,
+		RegistryBytes: raw,
+		Slug:          "agent:mira",
+		Now:           now,
+		Signer:        &stubSigner{priv: memberPriv},
+	})
+	require.NoError(t, err)
+	require.True(t, mi.Pinned)
+	require.True(t, mi.Authenticated)
+	require.True(t, mi.BindingResolves)
+	require.True(t, mi.HoldsBindingKey)
+	require.Equal(t, StatusMeshAuthenticated, mi.Status)
+	require.Equal(t, nid, mi.NetworkID)
+}
+
+func TestMeshDoctor_Tier2_PinnedResolvesSelfVerifyFailKeyMismatch(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rootPub, rootPriv := lowEntropyKey(t, "doctor-root-seed-mismatch")
+	memberPub, _ := lowEntropyKey(t, "doctor-member-seed-mismatch")
+	_, wrongPriv := lowEntropyKey(t, "doctor-WRONG-signer-seed")
+	raw, nid := buildSignedRegistry(t, rootPub, rootPriv, "agent:mira", memberPub, now)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "identity-signer.key")
+	writeKeyFile(t, keyPath, 0o600, ed25519.PrivateKeySize)
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       keyPath,
+		SocketPath:    filepath.Join(dir, "missing.sock"),
+		PinnedRootPub: rootPub,
+		NetworkID:     nid,
+		RegistryBytes: raw,
+		Slug:          "agent:mira",
+		Now:           now,
+		Signer:        &stubSigner{priv: wrongPriv}, // signer holds the WRONG key
+	})
+	require.NoError(t, err)
+	require.True(t, mi.Pinned)
+	require.True(t, mi.BindingResolves)
+	require.False(t, mi.HoldsBindingKey)
+	require.False(t, mi.Authenticated)
+	require.Equal(t, StatusMeshKeyMismatch, mi.Status)
+}
+
+func TestMeshDoctor_Tier2_PinnedSlugAbsentNotEnrolled(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rootPub, rootPriv := lowEntropyKey(t, "doctor-root-seed-absent")
+	memberPub, memberPriv := lowEntropyKey(t, "doctor-member-seed-absent")
+	raw, nid := buildSignedRegistry(t, rootPub, rootPriv, "agent:someoneelse", memberPub, now)
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       filepath.Join(t.TempDir(), "k.key"),
+		SocketPath:    filepath.Join(t.TempDir(), "missing.sock"),
+		PinnedRootPub: rootPub,
+		NetworkID:     nid,
+		RegistryBytes: raw,
+		Slug:          "agent:mira",
+		Now:           now,
+		Signer:        &stubSigner{priv: memberPriv},
+	})
+	require.NoError(t, err)
+	require.True(t, mi.Pinned)
+	require.False(t, mi.BindingResolves)
+	require.False(t, mi.Authenticated)
+	require.Equal(t, StatusMeshNotEnrolled, mi.Status)
+	require.NotEmpty(t, mi.Warnings)
+}
+
+func TestMeshDoctor_Tier2_PinnedBadSigRed(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rootPub, rootPriv := lowEntropyKey(t, "doctor-root-seed-badsig")
+	otherPub, _ := lowEntropyKey(t, "doctor-OTHER-root")
+	memberPub, _ := lowEntropyKey(t, "doctor-member-seed-badsig")
+	raw, _ := buildSignedRegistry(t, rootPub, rootPriv, "agent:mira", memberPub, now)
+
+	// Pin a DIFFERENT root than the one that signed → VerifyAndLoad fails.
+	otherNID := registry.NetworkID(otherPub)
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       filepath.Join(t.TempDir(), "k.key"),
+		SocketPath:    filepath.Join(t.TempDir(), "missing.sock"),
+		PinnedRootPub: otherPub,
+		NetworkID:     otherNID,
+		RegistryBytes: raw,
+		Slug:          "agent:mira",
+		Now:           now,
+	})
+	require.NoError(t, err)
+	require.True(t, mi.Pinned)
+	require.False(t, mi.Authenticated)
+	require.Equal(t, StatusMeshUnverifiable, mi.Status)
+	require.NotEmpty(t, mi.Warnings)
+}
+
+func TestMeshDoctor_Tier2_PinnedStaleRed(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rootPub, rootPriv := lowEntropyKey(t, "doctor-root-seed-stale")
+	memberPub, _ := lowEntropyKey(t, "doctor-member-seed-stale")
+	raw, nid := buildSignedRegistry(t, rootPub, rootPriv, "agent:mira", memberPub, now)
+
+	// Verify FAR in the future → registry valid_until passed → ErrStale.
+	future := now.Add(72 * time.Hour)
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       filepath.Join(t.TempDir(), "k.key"),
+		SocketPath:    filepath.Join(t.TempDir(), "missing.sock"),
+		PinnedRootPub: rootPub,
+		NetworkID:     nid,
+		RegistryBytes: raw,
+		Slug:          "agent:mira",
+		Now:           future,
+	})
+	require.NoError(t, err)
+	require.False(t, mi.Authenticated)
+	require.Equal(t, StatusMeshUnverifiable, mi.Status)
+}
+
+func TestMeshDoctor_Tier2_UnpinnedSelfConsistentWarn(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rootPub, rootPriv := lowEntropyKey(t, "doctor-root-seed-unpinned")
+	memberPub, memberPriv := lowEntropyKey(t, "doctor-member-seed-unpinned")
+	raw, nid := buildSignedRegistry(t, rootPub, rootPriv, "agent:mira", memberPub, now)
+
+	// NO pin. The daemon advertises its own root; doctor verifies for
+	// self-consistency ONLY → authenticated=false, never green.
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       filepath.Join(t.TempDir(), "k.key"),
+		SocketPath:    filepath.Join(t.TempDir(), "missing.sock"),
+		RegistryBytes: raw,
+		Slug:          "agent:mira",
+		Now:           now,
+		Signer:        &stubSigner{priv: memberPriv},
+		Daemon: &stubDaemon{
+			root:      doctorclient.WellKnownRoot{RootPubKey: b64(rootPub), NetworkID: nid},
+			directory: raw,
+			whoamiOK:  true,
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, mi.Pinned)
+	require.False(t, mi.Authenticated)
+	require.Equal(t, StatusMeshSelfConsistentUnpinned, mi.Status)
+	require.NotEmpty(t, mi.Warnings)
+}
+
+func TestMeshDoctor_Tier2_FetchesDirectoryFromDaemonWhenNoOfflineRegistry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rootPub, rootPriv := lowEntropyKey(t, "doctor-root-seed-fetch")
+	memberPub, memberPriv := lowEntropyKey(t, "doctor-member-seed-fetch")
+	raw, nid := buildSignedRegistry(t, rootPub, rootPriv, "agent:mira", memberPub, now)
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "identity-signer.key")
+	writeKeyFile(t, keyPath, 0o600, ed25519.PrivateKeySize)
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       keyPath,
+		SocketPath:    filepath.Join(dir, "missing.sock"),
+		PinnedRootPub: rootPub,
+		NetworkID:     nid,
+		Slug:          "agent:mira",
+		Now:           now,
+		Signer:        &stubSigner{priv: memberPriv},
+		Daemon:        &stubDaemon{directory: raw, whoamiOK: true, root: doctorclient.WellKnownRoot{RootPubKey: b64(rootPub), NetworkID: nid}},
+	})
+	require.NoError(t, err)
+	require.True(t, mi.Authenticated)
+	require.Equal(t, StatusMeshAuthenticated, mi.Status)
+	require.True(t, mi.DaemonReachable)
+}
+
+// --- TIER 3 -----------------------------------------------------------------
+
+func TestMeshDoctor_Tier3_DaemonReachablePlaintext(t *testing.T) {
+	now := time.Now()
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:    filepath.Join(t.TempDir(), "k.key"),
+		SocketPath: filepath.Join(t.TempDir(), "missing.sock"),
+		Now:        now,
+		Daemon: &stubDaemon{
+			whoamiOK: true,
+			rootErr:  doctorclient.ErrNotConfigured, // 404 → plaintext
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, mi.DaemonReachable)
+	require.Equal(t, DaemonModePlaintext, mi.DaemonMode)
+	require.False(t, mi.EnforcementActive)
+}
+
+func TestMeshDoctor_Tier3_DaemonReachableAdvisoryConfigured(t *testing.T) {
+	now := time.Now()
+	rootPub, _ := lowEntropyKey(t, "doctor-tier3-root")
+	nid := registry.NetworkID(rootPub)
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:    filepath.Join(t.TempDir(), "k.key"),
+		SocketPath: filepath.Join(t.TempDir(), "missing.sock"),
+		Now:        now,
+		Daemon: &stubDaemon{
+			whoamiOK: true,
+			root:     doctorclient.WellKnownRoot{RootPubKey: b64(rootPub), NetworkID: nid},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, mi.DaemonReachable)
+	require.Equal(t, DaemonModeAdvisoryConfigured, mi.DaemonMode)
+	require.False(t, mi.EnforcementActive, "enforcement is a no-op today; must never claim active")
+}
+
+func TestMeshDoctor_Tier3_DaemonUnreachable(t *testing.T) {
+	now := time.Now()
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:    filepath.Join(t.TempDir(), "k.key"),
+		SocketPath: filepath.Join(t.TempDir(), "missing.sock"),
+		Now:        now,
+		Daemon:     &stubDaemon{whoamiOK: false},
+	})
+	require.NoError(t, err)
+	require.False(t, mi.DaemonReachable)
+}
+
+func TestMeshDoctor_Tier3_HeartbeatFresh(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	hb := filepath.Join(dir, "mesh-watch.heartbeat")
+	require.NoError(t, os.WriteFile(hb, []byte("x"), 0o600))
+	require.NoError(t, os.Chtimes(hb, now.Add(-10*time.Second), now.Add(-10*time.Second)))
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       filepath.Join(dir, "k.key"),
+		SocketPath:    filepath.Join(dir, "missing.sock"),
+		HeartbeatPath: hb,
+		Now:           now,
+	})
+	require.NoError(t, err)
+	require.True(t, mi.WatcherHeartbeatFresh)
+	require.LessOrEqual(t, mi.WatcherHeartbeatAge, 11)
+}
+
+func TestMeshDoctor_Tier3_HeartbeatStale(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	hb := filepath.Join(dir, "mesh-watch.heartbeat")
+	require.NoError(t, os.WriteFile(hb, []byte("x"), 0o600))
+	require.NoError(t, os.Chtimes(hb, now.Add(-300*time.Second), now.Add(-300*time.Second)))
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       filepath.Join(dir, "k.key"),
+		SocketPath:    filepath.Join(dir, "missing.sock"),
+		HeartbeatPath: hb,
+		Now:           now,
+	})
+	require.NoError(t, err)
+	require.False(t, mi.WatcherHeartbeatFresh)
+	require.NotEmpty(t, mi.Warnings)
+}
+
+func TestMeshDoctor_Tier3_HeartbeatAbsent(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       filepath.Join(dir, "k.key"),
+		SocketPath:    filepath.Join(dir, "missing.sock"),
+		HeartbeatPath: filepath.Join(dir, "nope.heartbeat"),
+		Now:           now,
+	})
+	require.NoError(t, err)
+	require.False(t, mi.WatcherHeartbeatFresh)
+}
+
+// --- presence gating + anchor auto-discovery --------------------------------
+
+func TestMeshDoctor_AnchorAutoDiscoverPin(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rootPub, rootPriv := lowEntropyKey(t, "doctor-anchor-root")
+	memberPub, memberPriv := lowEntropyKey(t, "doctor-anchor-member")
+	raw, nid := buildSignedRegistry(t, rootPub, rootPriv, "agent:mira", memberPub, now)
+
+	// Persist an anchor and resolve the pin from it (no --mesh-root-pubkey).
+	dir := t.TempDir()
+	anchorPath := filepath.Join(dir, "network-roots.json")
+	require.NoError(t, anchor.Upsert(anchorPath, anchor.NetworkAnchor{
+		NetworkID:   nid,
+		RootPubKey:  b64(rootPub),
+		ConfirmedAt: now.Unix(),
+	}))
+	anchors, err := anchor.Load(anchorPath)
+	require.NoError(t, err)
+	a, ok := anchor.Find(anchors, nid)
+	require.True(t, ok)
+	pinnedPub, err := decodeAnchorPub(a)
+	require.NoError(t, err)
+
+	keyPath := filepath.Join(dir, "identity-signer.key")
+	writeKeyFile(t, keyPath, 0o600, ed25519.PrivateKeySize)
+
+	mi, err := BuildMeshIdentity(context.Background(), MeshDoctorInput{
+		KeyPath:       keyPath,
+		SocketPath:    filepath.Join(dir, "missing.sock"),
+		PinnedRootPub: pinnedPub,
+		NetworkID:     nid,
+		RegistryBytes: raw,
+		Slug:          "agent:mira",
+		Now:           now,
+		Signer:        &stubSigner{priv: memberPriv},
+	})
+	require.NoError(t, err)
+	require.True(t, mi.Authenticated)
+}
+
+// helper: base64-std of a pubkey.
+func b64(pub ed25519.PublicKey) string {
+	return base64.StdEncoding.EncodeToString(pub)
+}
+
+// decodeAnchorPub mirrors what cmd does to turn a stored anchor into a pinned
+// ed25519 pubkey, exercised here to prove the round-trip.
+func decodeAnchorPub(a anchor.NetworkAnchor) (ed25519.PublicKey, error) {
+	raw, err := base64.StdEncoding.DecodeString(a.RootPubKey)
+	if err != nil {
+		return nil, err
+	}
+	pk, err := registry.NewPublicKey(raw)
+	if err != nil {
+		return nil, err
+	}
+	return pk.Bytes(), nil
+}
+
+// keyless invariant: verify selfVerify uses a domain-tagged challenge that
+// VerifyCanonical accepts — sanity that the challenge path is wired through the
+// identity primitive, not a bespoke verify.
+func TestMeshDoctor_SelfVerifyUsesIdentityPrimitive(t *testing.T) {
+	pub, priv := lowEntropyKey(t, "doctor-selfverify-prim")
+	challenge := buildSelfVerifyChallenge([]byte("nonce-1234"))
+	sig := ed25519.Sign(priv, challenge.Bytes())
+	ok, err := identity.VerifyCanonical(pub, challenge, sig)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	_, wrongPriv := lowEntropyKey(t, "doctor-selfverify-wrong")
+	badSig := ed25519.Sign(wrongPriv, challenge.Bytes())
+	ok, err = identity.VerifyCanonical(pub, challenge, badSig)
+	require.NoError(t, err)
+	require.False(t, ok)
+}

--- a/internal/query/mesh_doctor_test.go
+++ b/internal/query/mesh_doctor_test.go
@@ -491,6 +491,12 @@ func TestMeshDoctor_Tier3_HeartbeatAbsent(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.False(t, mi.WatcherHeartbeatFresh)
+	require.Zero(t, mi.WatcherHeartbeatAge, "an absent heartbeat has no age")
+	// ABSENT is INFO, not a warning — it must not inflate the warning count for
+	// the many members who have never run the watcher. Only STALE warns.
+	for _, w := range mi.Warnings {
+		require.NotContains(t, w, "heartbeat", "absent heartbeat must not add a warning")
+	}
 }
 
 // --- presence gating + anchor auto-discovery --------------------------------


### PR DESCRIPTION
The member's "am I OK?" mesh health check — slice 2, implementing all four must-fixes from `agent-chat/docs/mesh/doctor-mesh-security-review-2026-06-10.md`. North star: **reserve GREEN for what doctor can cryptographically prove; never paint green over a compromised — or even misconfigured — substrate.**

## Three tiers
- **Tier 1 — custody (keyless, M3):** key exists / 0600 (Lstat) / 64-byte (Stat) — **stat-only, never reads the key**. Signer dial-probe is INFO (on-demand), custody is the only red-eligible part.
- **Tier 2 — binding resolves (authenticated, M1+M3):** GREEN only when the served registry verifies against a **pinned** root (the slice-1 enroll anchor, auto-discovered, or `--mesh-root-pubkey`) AND a keyless **selfVerify** (signer signs a fresh domain-tagged challenge → verified against the resolved binding pubkey) proves possession. Unpinned = self-consistency only → `authenticated:false`, warning, **never green**. Statuses: authenticated / self-consistent-unpinned / not-enrolled / key-mismatch / unverifiable.
- **Tier 3 — chat reachability (honest labels):** daemon "HTTP reachable" (not "verified"); factual served mode that **never implies** message-sig protection (a no-op today); **heartbeat freshness** (not bare pgrep — "present but dead" is a real incident).

## Security posture
- New **loopback-pinned `doctorclient`** (resolve-then-check IsLoopback fail-closed, DialContext IP-pin anti-rebind, refuse-all-redirects, body caps, deadline) — NOT the remote-permissive enroll client.
- **M4:** `authenticated:false` is a top-level boolean + a warning-status; exit stays 0 (no new exit code).
- **Keyless proven 3 ways:** code grep (zero `os.ReadFile/Open` of the key), an AST test that fails on any key read, and a write-only-key test where custody stat still succeeds.

## Verification
- `task check` GREEN — 23 checks, project cov 86.98%; doctorclient 91.2%, query 84.3%.
- TDD; multi-lens review (security lens weighted) + adversarial verify. **The "can this health check lie?" lens found 0 false-green paths.** Two findings fixed (`62feabc`): a HIGH false-not-enrolled from `agent:`-prefixing the slug (registry keys on the bare slug — verified against agent-chat source), and a LOW absent-heartbeat-as-warning.

Companion (separate, not here): `mesh-watch.sh` writes the heartbeat (vaults repo). Next: slice 3 (the quick-start docs).