### PR TITLE
fix(doctor): surface broken references + make the json issue-count axes honest

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -189,16 +189,19 @@ func populateDoctorResult(vdb *cmdutil.VaultDB, vaultPath string) (*query.Doctor
 	if result.Types, err = query.CollectTypeBreakdown(vdb.DB, vdb.Config); err != nil {
 		return nil, fmt.Errorf("collecting type breakdown: %w", err)
 	}
-	// Set IssuesSummary to a non-nil pointer in the cmd path so the JSON
+	// Set ValidationSummary to a non-nil pointer in the cmd path so the JSON
 	// envelope distinguishes "validation ran" (&{...}) from "validation not
-	// run" (nil, the raw query.Doctor shape). DoctorResult.IssuesSummary is a
-	// pointer with omitempty precisely so a raw Doctor result omits the field
+	// run" (nil, the raw query.Doctor shape). DoctorResult.ValidationSummary is
+	// a pointer with omitempty precisely so a raw Doctor result omits the field
 	// instead of emitting a false-zero {errors:0,warnings:0}.
+	// ValidationSummary is the RAW validation aggregate; the surfaced/actionable
+	// count lives in result.issues (SurfacedIssueCounts). These are distinct
+	// labeled axes so --json consumers never see two unlabeled "warnings" totals.
 	summary, err := query.SummarizeValidationIssues(vdb.DB, vdb.Reg)
 	if err != nil {
 		return nil, fmt.Errorf("summarizing validation issues: %w", err)
 	}
-	result.IssuesSummary = &summary
+	result.ValidationSummary = &summary
 
 	// Hook-drift detection — embedded canonical vs installed copies in
 	// the project's .claude/scripts/. Resolve the project root by
@@ -262,15 +265,32 @@ func writeDoctorHuman(w io.Writer, result *query.DoctorResult, summaryOnly bool)
 	// Errors/warnings rollup — the cold-start bottom line. Counts come from
 	// query.ResultSurfacedIssueCounts (SSOT) over the SURFACED result.Issues set
 	// PLUS the mesh-identity section's warnings, so the text rollup always agrees
-	// with --json. It deliberately does NOT read result.IssuesSummary: that
+	// with --json. It deliberately does NOT read result.ValidationSummary: that
 	// schema-validation AGGREGATE counts findings doctor never renders as text
-	// lines (and which the --json envelope's surfaced warnings/errors arrays do
-	// not count), which previously overstated warnings (e.g. "0 errors, 96
-	// warnings") against a --json that surfaced none. result.issues_summary stays
-	// in --json untouched.
+	// lines (unknown_type, invalid_status) which previously overstated warnings
+	// (e.g. "0 errors, 96 warnings") against a --json that surfaced none.
+	// result.validation_summary carries the raw aggregate in --json under its
+	// own explicitly-named key so the two axes are never confused.
 	errCount, warnCount := query.ResultSurfacedIssueCounts(result)
 	if _, err := fmt.Fprintf(w, "Issues: %d errors, %d warnings\n", errCount, warnCount); err != nil {
 		return err
+	}
+
+	// When the raw validation aggregate has findings the text report doesn't
+	// surface as lines, note the gap so the operator knows more detail exists in
+	// --json (result.validation_summary). This prevents the hidden-state shape
+	// where the terminal shows "0 warnings" while --json carries a non-zero
+	// aggregate under a different key.
+	if result.ValidationSummary != nil {
+		rawTotal := result.ValidationSummary.Errors + result.ValidationSummary.Warnings
+		surfacedTotal := errCount + warnCount
+		if rawTotal > surfacedTotal {
+			if _, err := fmt.Fprintf(w,
+				"+%d raw validation finding(s) (unknown_type/invalid_status) — see --json result.validation_summary\n",
+				rawTotal-surfacedTotal); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -30,6 +30,13 @@ const embeddingBackendsDocURL = "https://github.com/peiman/vaultmind/blob/main/d
 // consistent instruction.
 const staleIndexRemedy = "vaultmind index --vault <vault>"
 
+// brokenReferencesRemedy is the SSOT drill-down command for the broken-
+// references count. doctor folds broken_reference findings into the surfaced
+// warning rollup, so it must also name the command that lists the per-note
+// details (close the loop — hand the next command). frontmatter validate is
+// the subcommand that reports broken_reference per-note (FrontmatterValidateMetadata).
+const brokenReferencesRemedy = "vaultmind frontmatter validate --vault <path>"
+
 var doctorCmd = MustNewCommand(commands.DoctorMetadata, runDoctor)
 
 func init() {
@@ -257,6 +264,9 @@ func writeDoctorHuman(w io.Writer, result *query.DoctorResult, summaryOnly bool)
 	if err := writeStaleIndex(w, &result.Issues, summaryOnly); err != nil {
 		return err
 	}
+	if err := writeBrokenReferences(w, &result.Issues); err != nil {
+		return err
+	}
 	// Contract-B mesh-identity section (conditionally present, like
 	// writeEmbeddingStatus — nil ⇒ nothing printed).
 	if err := writeMeshIdentity(w, result.MeshIdentity, summaryOnly); err != nil {
@@ -282,12 +292,22 @@ func writeDoctorHuman(w io.Writer, result *query.DoctorResult, summaryOnly bool)
 	// where the terminal shows "0 warnings" while --json carries a non-zero
 	// aggregate under a different key.
 	if result.ValidationSummary != nil {
+		// The gap is the raw validation findings doctor does NOT surface as
+		// per-item lines (unknown_type / invalid_status). The validation
+		// findings that ARE surfaced are exactly MissingRequiredFields +
+		// BrokenReferences — so subtract those, NOT the full surfaced rollup
+		// (errCount+warnCount). The rollup folds in NON-validation surfaced
+		// items (ObsidianIncompatibleLinks, UnresolvedLinks, StaleIndex,
+		// HookDrift, mesh) that are absent from the validation-only aggregate;
+		// subtracting them under-reported the gap and wrongly suppressed this
+		// line when those items were numerous.
 		rawTotal := result.ValidationSummary.Errors + result.ValidationSummary.Warnings
-		surfacedTotal := errCount + warnCount
-		if rawTotal > surfacedTotal {
+		validationSurfaced := result.Issues.MissingRequiredFields + result.Issues.BrokenReferences
+		gap := rawTotal - validationSurfaced
+		if gap > 0 {
 			if _, err := fmt.Fprintf(w,
 				"+%d raw validation finding(s) (unknown_type/invalid_status) — see --json result.validation_summary\n",
-				rawTotal-surfacedTotal); err != nil {
+				gap); err != nil {
 				return err
 			}
 		}
@@ -378,6 +398,24 @@ func writeStaleIndex(w io.Writer, issues *query.DoctorIssues, summaryOnly bool) 
 		}
 	}
 	return nil
+}
+
+// writeBrokenReferences prints the broken-references section. doctor folds
+// broken_reference findings (explicit_relation edges pointing to non-existent
+// notes) into the surfaced WARNING rollup, but carries only the aggregate
+// count — not the per-note list. Without this line the rollup would show "N
+// warnings" with nothing to back N. The line hands the operator the command
+// that lists the per-note details (frontmatter validate). One line always —
+// there are no per-note details here to suppress under --summary, so it takes
+// no summaryOnly flag (same shape as writeLegacyHooksJSON).
+func writeBrokenReferences(w io.Writer, issues *query.DoctorIssues) error {
+	if issues.BrokenReferences == 0 {
+		return nil
+	}
+	_, err := fmt.Fprintf(w,
+		"Broken references: %d (run `%s` for the per-note details)\n",
+		issues.BrokenReferences, brokenReferencesRemedy)
+	return err
 }
 
 // writeTypeBreakdown prints the per-type note counts (with each type's valid

--- a/cmd/doctor_gap_line_test.go
+++ b/cmd/doctor_gap_line_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/query"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteDoctorHuman_GapLineExcludesNonValidationSurfaced is the regression
+// test for the under-reporting gap-line bug (3-lens review of PR #31, Fix 1).
+//
+// The gap line should report exactly the raw validation findings doctor does
+// NOT surface as per-item lines (unknown_type / invalid_status). The surfaced
+// validation findings are precisely MissingRequiredFields + BrokenReferences.
+// The OLD formula subtracted the full surfaced rollup (errCount+warnCount),
+// which folds in NON-validation surfaced items (e.g. ObsidianIncompatibleLinks,
+// UnresolvedLinks) that are NOT in the validation aggregate — under-reporting
+// the gap, and wrongly suppressing the line entirely when non-validation
+// surfaced items are numerous.
+//
+// This fixture has:
+//   - Non-validation surfaced warnings: ObsidianIncompatibleLinks=2, UnresolvedLinks=1
+//   - Validation findings (raw aggregate): Warnings=5 (e.g. 5 unknown_type)
+//   - Surfaced validation findings: MissingRequiredFields=1 + BrokenReferences=1 = 2
+//
+// rawTotal = 0 errors + 5 warnings = 5
+// validationSurfaced = MissingRequiredFields(1) + BrokenReferences(1) = 2
+// CORRECT gap = 5 - 2 = 3
+//
+// The OLD formula computed surfacedTotal = errCount+warnCount which, with the
+// non-validation surfaced items, is much larger than rawTotal (5), so it would
+// suppress the gap line entirely (rawTotal > surfacedTotal is false).
+func TestWriteDoctorHuman_GapLineExcludesNonValidationSurfaced(t *testing.T) {
+	result := &query.DoctorResult{
+		VaultPath: "/tmp/v",
+		ValidationSummary: &query.StatusIssuesSummary{
+			Errors:   0,
+			Warnings: 5, // raw aggregate: 5 validation findings
+		},
+		Issues: query.DoctorIssues{
+			// Surfaced validation findings (these ARE rendered / counted).
+			MissingRequiredFields: 1,
+			BrokenReferences:      1,
+			// Non-validation surfaced items — NOT part of the validation aggregate.
+			ObsidianIncompatibleLinks: 2,
+			IncompatibleLinkDetails: []query.IncompatibleLink{
+				{SourcePath: "x.md", TargetRaw: "Y", SuggestedFix: "y"},
+				{SourcePath: "z.md", TargetRaw: "W", SuggestedFix: "w"},
+			},
+			UnresolvedLinks: 1,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writeDoctorHuman(&buf, result, false))
+	out := buf.String()
+
+	// CORRECT gap = rawTotal(5) - validationSurfaced(MissingRequired 1 + BrokenRef 1 = 2) = 3.
+	require.Contains(t, out, "+3 raw validation finding(s)",
+		"gap must be rawTotal - (MissingRequiredFields+BrokenReferences), not rawTotal - (errCount+warnCount); got:\n%s", out)
+	// It must NOT print the (wrong) under-reported / suppressed value: the OLD
+	// formula would have suppressed the line entirely here.
+	require.Contains(t, out, "--json result.validation_summary",
+		"gap line must point the operator at the --json aggregate")
+}
+
+// TestWriteDoctorHuman_GapLineSuppressedWhenNoUnsurfacedValidation proves the
+// gap line is NOT printed when every validation finding is already surfaced
+// (rawTotal == MissingRequiredFields+BrokenReferences) — guards against a fix
+// that always prints the line.
+func TestWriteDoctorHuman_GapLineSuppressedWhenNoUnsurfacedValidation(t *testing.T) {
+	result := &query.DoctorResult{
+		VaultPath: "/tmp/v",
+		ValidationSummary: &query.StatusIssuesSummary{
+			Errors:   1, // 1 missing_required_field
+			Warnings: 1, // 1 broken_reference
+		},
+		Issues: query.DoctorIssues{
+			MissingRequiredFields: 1,
+			BrokenReferences:      1,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writeDoctorHuman(&buf, result, false))
+	out := buf.String()
+
+	require.NotContains(t, out, "raw validation finding(s)",
+		"gap line must be suppressed when all validation findings are surfaced; got:\n%s", out)
+}
+
+// TestWriteDoctorHuman_BrokenReferencesLine is the regression test for Fix 3:
+// because BrokenReferences now feeds the surfaced WARNING rollup, the human
+// report must also render a per-issue line so the count is not invisible. The
+// line must name the real validate subcommand so the operator can drill in.
+func TestWriteDoctorHuman_BrokenReferencesLine(t *testing.T) {
+	result := &query.DoctorResult{
+		VaultPath: "/tmp/v",
+		Issues: query.DoctorIssues{
+			BrokenReferences: 3,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writeDoctorHuman(&buf, result, false))
+	out := buf.String()
+
+	require.Contains(t, out, "Broken references: 3",
+		"human report must surface a broken-references line when BrokenReferences > 0; got:\n%s", out)
+	require.Contains(t, out, "frontmatter validate",
+		"broken-references line must name the real validate subcommand; got:\n%s", out)
+	// Sanity: the surfaced rollup counts it as a warning, so the line must not
+	// leave the count invisible.
+	require.True(t, strings.Contains(out, "Broken references:"),
+		"broken-references detail line is required when count > 0")
+}
+
+// TestWriteDoctorHuman_BrokenReferencesLineOmittedWhenZero proves the line is
+// absent when there are no broken references (Fix 3, the omit case).
+func TestWriteDoctorHuman_BrokenReferencesLineOmittedWhenZero(t *testing.T) {
+	result := &query.DoctorResult{
+		VaultPath: "/tmp/v",
+		Issues:    query.DoctorIssues{BrokenReferences: 0},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writeDoctorHuman(&buf, result, false))
+	require.NotContains(t, buf.String(), "Broken references:",
+		"broken-references line must be omitted when BrokenReferences == 0")
+}

--- a/cmd/doctor_honest_axes_test.go
+++ b/cmd/doctor_honest_axes_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoctor_JSONHasDistinctlyLabeledAxes asserts that the --json envelope
+// exposes two explicitly-named fields for the two different warnings totals,
+// so callers never encounter two unlabeled "warnings" values for the same run.
+//
+// The AX-design requirement: distinct labeled axes ("make hidden state visible").
+// Before the fix, result.issues_summary and result.issues carried different
+// unlabeled "warnings" counts with no name to distinguish them. After the fix:
+//   - result.validation_summary.warnings = the raw validation aggregate
+//   - The surfaced count lives only in result.issues.* (summed by SurfacedIssueCounts)
+//
+// This test uses buildValidationWarningVault (3 notes with unknown_type), which
+// produces 3 raw validation warnings and 0 surfaced warnings.
+func TestDoctor_JSONHasDistinctlyLabeledAxes(t *testing.T) {
+	chdirToTemp(t)
+	isolateMeshEnv(t)
+	vaultDir := buildValidationWarningVault(t)
+
+	jsonOut, _, err := runRootCmd(t, "doctor", "--vault", vaultDir, "--json")
+	require.NoError(t, err)
+
+	var env struct {
+		Result struct {
+			// The raw validation aggregate must be under a key that names it
+			// unambiguously. Before the fix it was "issues_summary" — the same
+			// word used colloquially for the surfaced count — which is the bug.
+			ValidationSummary *struct {
+				Errors   int `json:"errors"`
+				Warnings int `json:"warnings"`
+			} `json:"validation_summary"`
+			// The old "issues_summary" key must be gone so there is no
+			// ambiguity between the two totals.
+			IssuesSummary *json.RawMessage `json:"issues_summary"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(jsonOut.Bytes(), &env))
+
+	// The raw validation aggregate must be present under the explicit key.
+	require.NotNil(t, env.Result.ValidationSummary,
+		"result.validation_summary must be present in --json so the raw aggregate is visible")
+	require.Equal(t, 3, env.Result.ValidationSummary.Warnings,
+		"result.validation_summary.warnings must hold the raw validation aggregate (3 unknown_type)")
+
+	// The ambiguous old key must be absent from the output.
+	require.Nil(t, env.Result.IssuesSummary,
+		"result.issues_summary must be removed; the raw aggregate lives at result.validation_summary")
+}
+
+// TestDoctor_HumanReportNotesRawValidationGap asserts that when the raw
+// validation aggregate is non-zero but the surfaced count is zero, the human
+// report prints a one-line note so the operator knows more findings exist in
+// --json. This prevents the hidden-state failure where the terminal output
+// shows "0 warnings" while --json carries a non-zero aggregate.
+func TestDoctor_HumanReportNotesRawValidationGap(t *testing.T) {
+	chdirToTemp(t)
+	isolateMeshEnv(t)
+	vaultDir := buildValidationWarningVault(t)
+
+	textOut, _, err := runRootCmd(t, "doctor", "--vault", vaultDir)
+	require.NoError(t, err)
+	text := textOut.String()
+
+	// The human report must surface the gap so the operator is not surprised.
+	// Exact phrasing is flexible; the key signal is the raw-validation count
+	// and a pointer to --json.
+	require.Contains(t, text, "--json",
+		"human report must mention --json when there are raw validation findings not shown in the surfaced set")
+}

--- a/cmd/doctor_mesh.go
+++ b/cmd/doctor_mesh.go
@@ -234,7 +234,9 @@ func slugFromAgentsYAML(registryPath, projectDir string) string {
 	}
 	// registryPath is an operator-controlled env var (AGENT_CHAT_REGISTRY), the
 	// same path the chat MCP itself reads — not attacker-controlled input.
-	// #nosec G304
+	// The newer gosec taint pass (G703) flags the same env-var→ReadFile flow;
+	// the operator-controlled justification above covers it equally.
+	// #nosec G304 G703
 	// nosemgrep: go-path-traversal
 	raw, err := os.ReadFile(registryPath)
 	if err != nil {

--- a/cmd/doctor_rollup_count_test.go
+++ b/cmd/doctor_rollup_count_test.go
@@ -36,9 +36,12 @@ type jsonSurfacedIssues struct {
 			HookDrift                 int  `json:"hook_drift"`
 			LegacyHooksJSON           bool `json:"legacy_hooks_json"`
 		} `json:"issues"`
-		IssuesSummary struct {
+		// ValidationSummary is the explicitly-labeled raw aggregate axis (renamed
+		// from the ambiguous "issues_summary" to prevent confusion with the surfaced
+		// result.issues set). Decoded here to assert it carries the raw count.
+		ValidationSummary struct {
 			Warnings int `json:"warnings"`
-		} `json:"issues_summary"`
+		} `json:"validation_summary"`
 	} `json:"result"`
 }
 
@@ -74,7 +77,7 @@ func chdirToTemp(t *testing.T) {
 // does NOT surface as per-item lines. This is the exact shape that produced the
 // reported divergence: TEXT "Issues: 0 errors, N warnings" while --json's
 // surfaced result.issues block is all zero (the validation warnings live only
-// in the nested result.issues_summary aggregate).
+// in the nested result.validation_summary aggregate).
 func buildValidationWarningVault(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -124,11 +127,12 @@ func readJSONSurfaced(t *testing.T, vault string) jsonSurfacedIssues {
 // block), for a vault whose only findings are schema-validation warnings the
 // TEXT renderer never surfaces as lines.
 //
-// Before the fix the TEXT rollup read result.issues_summary (the validation
-// AGGREGATE: 3 unknown_type warnings) while the surfaced result.issues block
-// was all zero, so the TEXT count OVERSTATED warnings no text line backed —
-// and the aggregate stayed visible in --json's result.issues_summary, proving
-// the two counts came from different sets.
+// Before the fix the TEXT rollup read result.validation_summary (then named
+// result.issues_summary — the validation AGGREGATE: 3 unknown_type warnings)
+// while the surfaced result.issues block was all zero, so the TEXT count
+// OVERSTATED warnings no text line backed — and the aggregate stayed visible
+// in --json's result.validation_summary, proving the two counts came from
+// different sets.
 func TestDoctor_TextRollupCounts_MatchJSONSurfacedSet(t *testing.T) {
 	chdirToTemp(t)
 	isolateMeshEnv(t)
@@ -143,10 +147,11 @@ func TestDoctor_TextRollupCounts_MatchJSONSurfacedSet(t *testing.T) {
 	require.Equal(t, jsonWarnings, textWarnings,
 		"TEXT warning count must equal --json surfaced result.issues warnings")
 
-	// Document the divergence the fix closes: the validation aggregate is
-	// non-zero in --json yet the surfaced counts (and now the text) are zero.
-	require.Equal(t, 3, j.Result.IssuesSummary.Warnings,
-		"validation aggregate still reports 3 warnings in --json")
+	// Document the divergence the fix closes: the raw validation aggregate is
+	// non-zero in --json under its explicitly-named key, yet the surfaced
+	// counts (and now the text) are zero.
+	require.Equal(t, 3, j.Result.ValidationSummary.Warnings,
+		"raw validation aggregate still reports 3 warnings in --json result.validation_summary")
 	require.Equal(t, 0, textWarnings,
 		"text must report the surfaced count (0), not the validation aggregate (3)")
 	require.Equal(t, 0, textErrors, "no surfaced errors")

--- a/cmd/doctor_summary_test.go
+++ b/cmd/doctor_summary_test.go
@@ -37,23 +37,24 @@ func TestDoctor_JSONIncludesPerTypeBreakdown(t *testing.T) {
 		"valid statuses must carry through from the registry")
 }
 
-// doctor JSON also carries the errors/warnings rollup that the cold-start
-// view needs. The clean test vault has zero errors.
-func TestDoctor_JSONIncludesIssuesSummary(t *testing.T) {
+// doctor JSON carries the raw validation aggregate in result.validation_summary
+// (the explicitly-labeled axis for the raw aggregate, distinct from the surfaced
+// result.issues set). The clean test vault has zero errors.
+func TestDoctor_JSONIncludesValidationSummary(t *testing.T) {
 	vault := buildIndexedTestVault(t)
 	out, _, err := runRootCmd(t, "doctor", "--vault", vault, "--json")
 	require.NoError(t, err)
 
 	var env struct {
 		Result struct {
-			IssuesSummary struct {
+			ValidationSummary struct {
 				Errors   int `json:"errors"`
 				Warnings int `json:"warnings"`
-			} `json:"issues_summary"`
+			} `json:"validation_summary"`
 		} `json:"result"`
 	}
 	require.NoError(t, json.Unmarshal(out.Bytes(), &env))
-	assert.Equal(t, 0, env.Result.IssuesSummary.Errors, "clean vault has no errors")
+	assert.Equal(t, 0, env.Result.ValidationSummary.Errors, "clean vault has no errors in validation_summary")
 }
 
 // doctor human output (no --summary) prints the per-type breakdown so the

--- a/internal/query/doctor.go
+++ b/internal/query/doctor.go
@@ -145,9 +145,11 @@ type DoctorIssues struct {
 //
 // It deliberately does NOT fold in DoctorResult.ValidationSummary (the schema
 // VALIDATION aggregate from SummarizeValidationIssues). That aggregate counts
-// findings — unknown_type, invalid_status, broken_reference — that doctor
-// surfaces only in the nested result.validation_summary JSON field, never as a
-// per-item line in the text report. Counting it in the text rollup overstated
+// findings — unknown_type, invalid_status — that doctor surfaces only in the
+// nested result.validation_summary JSON field, never as a per-item line in the
+// text report. (missing_required_field and broken_reference ARE surfaced — via
+// result.issues and, for broken_reference, a dedicated text line.) Counting it
+// in the text rollup overstated
 // warnings (e.g. "0 errors, 96 warnings") against a --json envelope that
 // surfaced none. result.validation_summary stays in --json unchanged; this
 // helper only governs the surfaced-set rollup.

--- a/internal/query/doctor.go
+++ b/internal/query/doctor.go
@@ -14,20 +14,27 @@ import (
 
 // DoctorResult is the JSON-serializable output of the doctor command.
 //
-// Types and IssuesSummary carry the per-type breakdown and errors/warnings
-// rollup that `vault status` used to produce. doctor is now the single health
-// hub, so the cold-start view (`doctor --summary`) and the read-only diagnosis
-// (`doctor`) both surface them. They are populated by the cmd layer (which
-// holds the vault config + schema registry) via the shared status.go helpers —
-// the same place HookDrift is populated — so query.Doctor's signature stays
-// stable.
+// Types and ValidationSummary carry the per-type breakdown and raw validation
+// aggregate that `vault status` used to produce. doctor is now the single
+// health hub, so the cold-start view (`doctor --summary`) and the read-only
+// diagnosis (`doctor`) both surface them. They are populated by the cmd layer
+// (which holds the vault config + schema registry) via the shared status.go
+// helpers — the same place HookDrift is populated — so query.Doctor's
+// signature stays stable.
 //
-// IssuesSummary is a POINTER with omitempty so the unmeasured state (a raw
-// query.Doctor call with no schema registry — e.g. the query-layer tests) omits
-// the field entirely. The earlier non-pointer struct always serialized a
+// ValidationSummary is a POINTER with omitempty so the unmeasured state (a
+// raw query.Doctor call with no schema registry — e.g. the query-layer tests)
+// omits the field entirely. The earlier non-pointer struct always serialized a
 // false-zero {errors:0,warnings:0}, indistinguishable from a measured-healthy
 // vault. nil now means "validation not run"; a non-nil &{0,0} means "ran, found
 // nothing". Types likewise stays omitempty (empty map => omitted).
+//
+// ValidationSummary (JSON: "validation_summary") holds the RAW schema-validation
+// aggregate — all ValidateResult.Issues bucketed by severity. It may be larger
+// than the surfaced result.issues set because it includes unknown_type /
+// invalid_status findings the text report never renders as per-item lines.
+// These are distinct labeled axes: validation_summary is the raw aggregate;
+// result.issues is the surfaced/actionable set.
 type DoctorResult struct {
 	VaultPath         string                    `json:"vault_path"`
 	TotalFiles        int                       `json:"total_files"`
@@ -36,7 +43,7 @@ type DoctorResult struct {
 	IndexStatus       string                    `json:"index_status"`
 	Embeddings        *DoctorEmbeddings         `json:"embeddings,omitempty"`
 	Types             map[string]StatusTypeInfo `json:"types,omitempty"`
-	IssuesSummary     *StatusIssuesSummary      `json:"issues_summary,omitempty"`
+	ValidationSummary *StatusIssuesSummary      `json:"validation_summary,omitempty"`
 	Issues            DoctorIssues              `json:"issues"`
 
 	// MeshIdentity is the Contract-B identity-health section. It is a POINTER
@@ -136,14 +143,14 @@ type DoctorIssues struct {
 // is the single source of truth for the "Issues: E errors, W warnings" text
 // rollup so that count can never again disagree with --json.
 //
-// It deliberately does NOT fold in DoctorResult.IssuesSummary (the schema
+// It deliberately does NOT fold in DoctorResult.ValidationSummary (the schema
 // VALIDATION aggregate from SummarizeValidationIssues). That aggregate counts
 // findings — unknown_type, invalid_status, broken_reference — that doctor
-// surfaces only in the nested result.issues_summary JSON field, never as a
+// surfaces only in the nested result.validation_summary JSON field, never as a
 // per-item line in the text report. Counting it in the text rollup overstated
 // warnings (e.g. "0 errors, 96 warnings") against a --json envelope that
-// surfaced none. result.issues_summary stays in --json unchanged; this helper
-// only governs the surfaced-set rollup.
+// surfaced none. result.validation_summary stays in --json unchanged; this
+// helper only governs the surfaced-set rollup.
 //
 // Severity follows the doctor renderer's own framing: integrity violations
 // that mean data is wrong are errors; advisories that mean the vault is
@@ -230,17 +237,22 @@ func Doctor(db *index.DB, vaultPath string, reg *schema.Registry) (*DoctorResult
 	}
 	result.UnstructuredNotes = result.TotalFiles - result.DomainNotes
 
-	// missing_required_fields — call Validate and count. Single source
-	// of truth for what counts as "missing required field"; doctor
-	// surfaces the aggregate, validate surfaces per-note details.
+	// missing_required_fields and broken_references — call Validate and count.
+	// Single source of truth for what counts as "missing required field" or
+	// "broken reference"; doctor surfaces the aggregate, validate surfaces
+	// per-note details. Both branches use the SSOT rule constants from
+	// validate.go to avoid stringly-typed divergence.
 	if reg != nil {
 		validateRes, err := Validate(db, reg)
 		if err != nil {
 			return nil, fmt.Errorf("validating for missing-required-fields: %w", err)
 		}
 		for _, issue := range validateRes.Issues {
-			if issue.Rule == "missing_required_field" {
+			switch issue.Rule {
+			case RuleMissingRequired:
 				result.Issues.MissingRequiredFields++
+			case RuleBrokenReference:
+				result.Issues.BrokenReferences++
 			}
 		}
 	}

--- a/internal/query/doctor_all.go
+++ b/internal/query/doctor_all.go
@@ -53,12 +53,12 @@ type DoctorRollup struct {
 }
 
 // BuildDoctorRollup aggregates per-vault DoctorResults into a workspace rollup.
-// A vault counts as "having issues" when its IssuesSummary reports any errors or
-// warnings; a nil IssuesSummary (a raw, un-validated result) contributes zero
-// and is treated as clean. The failed slice (vaults that could not be opened) is
-// folded into the honest count breakdown — Discovered = diagnosed + failed — so
-// the rollup never under-reports the number of vaults found. Pure aggregation:
-// no I/O, no mutation of inputs.
+// A vault counts as "having issues" when its ValidationSummary reports any
+// errors or warnings; a nil ValidationSummary (a raw, un-validated result)
+// contributes zero and is treated as clean. The failed slice (vaults that could
+// not be opened) is folded into the honest count breakdown —
+// Discovered = diagnosed + failed — so the rollup never under-reports the
+// number of vaults found. Pure aggregation: no I/O, no mutation of inputs.
 func BuildDoctorRollup(vaults []*DoctorResult, failed []FailedVault) DoctorRollup {
 	diagnosed := len(vaults)
 	discovered := diagnosed + len(failed)
@@ -75,9 +75,9 @@ func BuildDoctorRollup(vaults []*DoctorResult, failed []FailedVault) DoctorRollu
 		}
 		rollup.TotalNotes += v.TotalFiles
 		errs, warns := 0, 0
-		if v.IssuesSummary != nil {
-			errs = v.IssuesSummary.Errors
-			warns = v.IssuesSummary.Warnings
+		if v.ValidationSummary != nil {
+			errs = v.ValidationSummary.Errors
+			warns = v.ValidationSummary.Warnings
 		}
 		rollup.TotalErrors += errs
 		rollup.TotalWarnings += warns

--- a/internal/query/doctor_all_test.go
+++ b/internal/query/doctor_all_test.go
@@ -14,7 +14,7 @@ import (
 // vaults.
 func mkVaultResult(path string, total, errs, warns, unresolved int) *query.DoctorResult {
 	r := &query.DoctorResult{VaultPath: path, TotalFiles: total}
-	r.IssuesSummary = &query.StatusIssuesSummary{Errors: errs, Warnings: warns}
+	r.ValidationSummary = &query.StatusIssuesSummary{Errors: errs, Warnings: warns}
 	r.Issues.UnresolvedLinks = unresolved
 	return r
 }
@@ -74,9 +74,10 @@ func TestBuildDoctorRollup_CleanWorkspaceHasEmptyIssueList(t *testing.T) {
 	assert.Empty(t, rollup.VaultsWithIssues, "a clean workspace lists no problem vaults")
 }
 
-// A nil IssuesSummary (a raw, un-validated DoctorResult) must contribute zero
-// errors/warnings and never panic — defensive parity with the human renderer.
-func TestBuildDoctorRollup_NilIssuesSummaryCountsAsClean(t *testing.T) {
+// A nil ValidationSummary (a raw, un-validated DoctorResult) must contribute
+// zero errors/warnings and never panic — defensive parity with the human
+// renderer.
+func TestBuildDoctorRollup_NilValidationSummaryCountsAsClean(t *testing.T) {
 	clean := &query.DoctorResult{VaultPath: "/raw", TotalFiles: 9}
 	rollup := query.BuildDoctorRollup([]*query.DoctorResult{clean}, nil)
 	assert.Equal(t, 1, rollup.VaultCount)

--- a/internal/query/doctor_broken_refs_test.go
+++ b/internal/query/doctor_broken_refs_test.go
@@ -1,0 +1,67 @@
+package query_test
+
+import (
+	"testing"
+
+	"github.com/peiman/vaultmind/internal/index"
+	"github.com/peiman/vaultmind/internal/query"
+	"github.com/peiman/vaultmind/internal/schema"
+	"github.com/peiman/vaultmind/internal/vault"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoctor_BrokenReferences_PopulatesIssuesField verifies that when a note
+// has a frontmatter explicit_relation edge pointing to a non-existent note ID
+// (a broken reference), Doctor populates BrokenReferences in the returned
+// DoctorIssues — and that SurfacedIssueCounts counts it as a warning.
+//
+// This is the regression test for the silent-under-report bug: the field was
+// declared in DoctorIssues and included in SurfacedIssueCounts, but the
+// query.Doctor loop never assigned to it. Real broken references reached the
+// validator (ValidateResult.Issues with rule="broken_reference") but never
+// reached the surfaced count.
+func TestDoctor_BrokenReferences_PopulatesIssuesField(t *testing.T) {
+	dir := t.TempDir()
+
+	// Build a minimal vault with the notes schema.
+	db, err := index.Open(dir + "/test.db")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// A source note whose frontmatter has an explicit_relation to a
+	// non-existent note ID — this is the "broken reference" shape.
+	_, err = db.Exec(
+		"INSERT INTO notes (id, path, title, hash, mtime, is_domain) VALUES (?, ?, ?, ?, ?, ?)",
+		"broken-ref-src", "broken-ref-src.md", "Broken Ref Source", "deadbeef", 0, true,
+	)
+	require.NoError(t, err)
+
+	// Insert an explicit_relation edge whose dst_raw is an ID that does NOT
+	// exist in the notes table — the shape countBrokenRefs detects.
+	_, err = db.Exec(
+		`INSERT INTO links (src_note_id, dst_note_id, dst_raw, edge_type, resolved, confidence)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		"broken-ref-src", nil, "nonexistent-note-id", "explicit_relation", false, "high",
+	)
+	require.NoError(t, err)
+
+	// A registry with the note's type so the validator processes it (notes
+	// with unknown types are skipped for broken_reference checking in Validate).
+	// Use a type that accepts the note without missing-required-field errors so
+	// the only finding is the broken reference.
+	reg := schema.NewRegistry(map[string]vault.TypeDef{
+		"concept": {Required: []string{"title"}},
+	})
+
+	result, docErr := query.Doctor(db, dir, reg)
+	require.NoError(t, docErr)
+
+	assert.Greater(t, result.Issues.BrokenReferences, 0,
+		"Doctor must populate BrokenReferences when the validator finds broken_reference issues")
+
+	// SurfacedIssueCounts must include BrokenReferences in the warning count.
+	_, warns := query.SurfacedIssueCounts(result.Issues)
+	assert.Greater(t, warns, 0,
+		"SurfacedIssueCounts must count BrokenReferences as warnings")
+}

--- a/internal/query/doctor_broken_refs_test.go
+++ b/internal/query/doctor_broken_refs_test.go
@@ -46,10 +46,11 @@ func TestDoctor_BrokenReferences_PopulatesIssuesField(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// A registry with the note's type so the validator processes it (notes
-	// with unknown types are skipped for broken_reference checking in Validate).
-	// Use a type that accepts the note without missing-required-field errors so
-	// the only finding is the broken reference.
+	// broken_reference checking runs for every domain note regardless of type;
+	// the fixture's type ("concept", with the note's title present) is chosen
+	// only so the note generates NO other finding (no unknown_type, no
+	// missing_required_field), leaving the broken reference as the sole issue
+	// the assertions below isolate.
 	reg := schema.NewRegistry(map[string]vault.TypeDef{
 		"concept": {Required: []string{"title"}},
 	})

--- a/internal/query/doctor_test.go
+++ b/internal/query/doctor_test.go
@@ -35,23 +35,25 @@ func TestDoctor_ReturnsVaultSummary(t *testing.T) {
 	assert.Equal(t, result.TotalFiles, result.DomainNotes+result.UnstructuredNotes)
 }
 
-// A raw query.Doctor result (no cmd layer, so IssuesSummary stays nil) must
-// OMIT issues_summary from its JSON — not emit a false-zero
+// A raw query.Doctor result (no cmd layer, so ValidationSummary stays nil)
+// must OMIT validation_summary from its JSON — not emit a false-zero
 // {errors:0,warnings:0} that's indistinguishable from a measured-healthy
-// vault. The cmd path (doctor --summary) populates it; the omission here is the
-// invariant H3 locks down.
-func TestDoctor_RawResultOmitsIssuesSummary(t *testing.T) {
+// vault. The cmd path (doctor --summary) populates it; the omission here is
+// the invariant H3 locks down.
+func TestDoctor_RawResultOmitsValidationSummary(t *testing.T) {
 	db := buildIndexedDB(t)
 
 	result, err := query.Doctor(db, testVaultPath, nil)
 	require.NoError(t, err)
-	assert.Nil(t, result.IssuesSummary,
-		"raw query.Doctor must leave IssuesSummary unmeasured (nil)")
+	assert.Nil(t, result.ValidationSummary,
+		"raw query.Doctor must leave ValidationSummary unmeasured (nil)")
 
 	raw, err := json.Marshal(result)
 	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "validation_summary",
+		"unmeasured validation_summary must be omitted from the JSON, not false-zeroed")
 	assert.NotContains(t, string(raw), "issues_summary",
-		"unmeasured issues_summary must be omitted from the JSON, not false-zeroed")
+		"the old issues_summary key must not appear in the JSON output")
 }
 
 func TestDoctor_ReportsUnresolvedLinks(t *testing.T) {

--- a/internal/query/validate.go
+++ b/internal/query/validate.go
@@ -8,6 +8,16 @@ import (
 	"github.com/peiman/vaultmind/internal/schema"
 )
 
+// Validate rule identifiers — the SSOT for rule strings used across the
+// query layer. validate.go is the canonical definition site; doctor.go and any
+// other caller must reference these constants instead of inlining the strings.
+const (
+	RuleBrokenReference = "broken_reference"
+	RuleMissingRequired = "missing_required_field"
+	RuleUnknownType     = "unknown_type"
+	RuleInvalidStatus   = "invalid_status"
+)
+
 // ValidateResult is the JSON-serializable output of frontmatter validate.
 type ValidateResult struct {
 	FilesChecked int             `json:"files_checked"`
@@ -68,7 +78,7 @@ func Validate(db *index.DB, reg *schema.Registry) (*ValidateResult, error) {
 		if n.noteType != "" && !reg.HasType(n.noteType) {
 			result.Issues = append(result.Issues, ValidateIssue{
 				Path: n.path, ID: n.id, Severity: "warning",
-				Rule: "unknown_type", Message: fmt.Sprintf("Type %q not in registry", n.noteType),
+				Rule: RuleUnknownType, Message: fmt.Sprintf("Type %q not in registry", n.noteType),
 				Value: n.noteType,
 			})
 			noteHasIssue = true
@@ -82,7 +92,7 @@ func Validate(db *index.DB, reg *schema.Registry) (*ValidateResult, error) {
 				if val == "" {
 					result.Issues = append(result.Issues, ValidateIssue{
 						Path: n.path, ID: n.id, Severity: "error",
-						Rule:    "missing_required_field",
+						Rule:    RuleMissingRequired,
 						Message: fmt.Sprintf("Type %q requires field %q", n.noteType, req),
 						Field:   req,
 					})
@@ -94,7 +104,7 @@ func Validate(db *index.DB, reg *schema.Registry) (*ValidateResult, error) {
 			if n.status != "" && len(td.Statuses) > 0 && !reg.ValidStatus(n.noteType, n.status) {
 				result.Issues = append(result.Issues, ValidateIssue{
 					Path: n.path, ID: n.id, Severity: "warning",
-					Rule:    "invalid_status",
+					Rule:    RuleInvalidStatus,
 					Message: fmt.Sprintf("Status %q not valid for type %q", n.status, n.noteType),
 					Field:   "status", Value: n.status,
 				})
@@ -107,7 +117,7 @@ func Validate(db *index.DB, reg *schema.Registry) (*ValidateResult, error) {
 		if refErr == nil && brokenRefs > 0 {
 			result.Issues = append(result.Issues, ValidateIssue{
 				Path: n.path, ID: n.id, Severity: "warning",
-				Rule:    "broken_reference",
+				Rule:    RuleBrokenReference,
 				Message: fmt.Sprintf("%d frontmatter references do not resolve to existing notes", brokenRefs),
 			})
 			noteHasIssue = true

--- a/internal/query/validate_live.go
+++ b/internal/query/validate_live.go
@@ -88,7 +88,7 @@ func validateDomainNote(
 	if !reg.HasType(noteType) {
 		result.Issues = append(result.Issues, ValidateIssue{
 			Path: path, ID: id, Severity: "warning",
-			Rule:    "unknown_type",
+			Rule:    RuleUnknownType,
 			Message: fmt.Sprintf("Type %q not in registry", noteType),
 			Value:   noteType,
 		})
@@ -101,7 +101,7 @@ func validateDomainNote(
 		if !reg.IsFieldPresent(fm, req) {
 			result.Issues = append(result.Issues, ValidateIssue{
 				Path: path, ID: id, Severity: "error",
-				Rule:    "missing_required_field",
+				Rule:    RuleMissingRequired,
 				Message: fmt.Sprintf("Type %q requires field %q", noteType, req),
 				Field:   req,
 			})
@@ -118,7 +118,7 @@ func validateDomainNote(
 		if len(td.Statuses) > 0 && !reg.ValidStatus(noteType, status) {
 			result.Issues = append(result.Issues, ValidateIssue{
 				Path: path, ID: id, Severity: "warning",
-				Rule:    "invalid_status",
+				Rule:    RuleInvalidStatus,
 				Message: fmt.Sprintf("Status %q not valid for type %q", status, noteType),
 				Field:   "status", Value: status,
 			})

--- a/internal/query/validate_live.go
+++ b/internal/query/validate_live.go
@@ -39,8 +39,10 @@ func ValidateLive(vaultPath string, reg *schema.Registry) (*ValidateResult, erro
 			return nil
 		}
 
-		// path is produced by filepath.WalkDir rooted at vaultPath, not user input.
-		content, readErr := os.ReadFile(path) // #nosec G304
+		// path is produced by filepath.WalkDir rooted at vaultPath, not user input;
+		// the symlink-TOCTOU that gosec G122 warns about is out of scope for a
+		// single-user CLI reading its own local vault.
+		content, readErr := os.ReadFile(path) // #nosec G304 G122
 		if readErr != nil {
 			return fmt.Errorf("reading %s: %w", path, readErr)
 		}


### PR DESCRIPTION
Fixes two honesty defects in `vaultmind doctor`, found by a keeper-verified realm sweep.

## Bug 1 — broken references silently dropped
`DoctorIssues.BrokenReferences` was declared and summed in `SurfacedIssueCounts`, but **never populated** in `query.Doctor` — the loop only had a `missing_required_field` branch. So real broken references were counted only in the hidden aggregate and never reached the doctor/text report (a genuine under-report). Added a sibling branch that populates it from the validator’s `broken_reference` findings, reusing a new SSOT rule constant (`RuleBrokenReference`).

## Bug 2 — `--json` reported two different unlabeled "warnings" totals
`result.issues_summary.warnings` was the raw schema-validation aggregate while the top-level/human report showed the surfaced set — a surface telling two truths for one run (an AX-honesty defect). Renamed `IssuesSummary`→`ValidationSummary` (json `issues_summary`→`validation_summary`) so the two axes are distinctly labeled, and the human report now prints a one-line `+N raw validation finding(s) — see --json` so the bigger number is never hidden. All consumers were internal (Go + tests); no external API depended on the old field name.

## Also: pre-existing lint debt cleared
The branch could not pass local `task check` because the local golangci-lint runs a newer gosec than CI’s pinned `~> v2`, flagging G703/G122 on two `os.ReadFile`s in **untouched** files that already carried justified `#nosec G304`. Extended those directives to name the new rule IDs (CI-safe: the older gosec ignores the extra tokens). This is also why `task lint` is red on `main` locally — see the linter-drift note I’m raising separately.

## Verification
- TDD: each bug has a test that fails before the fix and passes after (broken-refs populated; json axes distinctly labeled; human-report gap line).
- Independent `task check`: **green** — project coverage 88.92% (floor 84%), all per-package floors ✅, `test/integration` 100%.

No `--no-verify`; full pre-commit + pre-push hooks pass.