### PR TITLE
fix(doctor): reconcile doctor --all rollup totals to the surfaced axis

### DIFF
--- a/cmd/coverage_boost_test.go
+++ b/cmd/coverage_boost_test.go
@@ -341,6 +341,45 @@ func TestWriteRollupHeader_VaultsWithIssues_Listed(t *testing.T) {
 	assert.Contains(t, out, "/vault/broken")
 }
 
+// When the raw schema-validation aggregate exceeds the surfaced headline,
+// writeRollupHeader must note the gap on one honest line pointing at --json —
+// mirroring the single-vault gap line so the two axes never silently diverge.
+func TestWriteRollupHeader_RawValidationGap_ShowsHonestLine(t *testing.T) {
+	var buf bytes.Buffer
+	r := query.DoctorRollup{
+		Discovered:                 1,
+		Diagnosed:                  1,
+		TotalNotes:                 30,
+		TotalErrors:                0,
+		TotalWarnings:              1,  // surfaced headline
+		TotalRawValidationFindings: 58, // raw aggregate (e.g. 1 surfaced + 57 raw-only)
+	}
+	require.NoError(t, writeRollupHeader(&buf, "/root", r))
+	out := buf.String()
+	assert.Contains(t, out, "Total issues: 0 errors, 1 warnings", "headline is the surfaced axis")
+	assert.Contains(t, out, "raw validation finding(s)",
+		"the raw aggregate is surfaced on its own honest line when it exceeds the headline")
+	assert.Contains(t, out, "--json", "the line points the operator at --json for the raw aggregate")
+}
+
+// When there are no raw-only validation findings, writeRollupHeader must NOT
+// emit the gap line — keep it minimal. (RawValidationGap == 0 here because the
+// raw aggregate is zero; the surfaced-validation portion is unexported and
+// summed only inside BuildDoctorRollup.)
+func TestWriteRollupHeader_NoRawValidationGap_NoExtraLine(t *testing.T) {
+	var buf bytes.Buffer
+	r := query.DoctorRollup{
+		Discovered:                 1,
+		Diagnosed:                  1,
+		TotalNotes:                 10,
+		TotalWarnings:              2,
+		TotalRawValidationFindings: 0, // no raw findings → nothing hidden
+	}
+	require.NoError(t, writeRollupHeader(&buf, "/root", r))
+	assert.NotContains(t, buf.String(), "raw validation finding(s)",
+		"no gap line when there are no raw-only validation findings")
+}
+
 // ---------------------------------------------------------------------------
 // runFrontmatterFixCore — tested via the CLI path
 // ---------------------------------------------------------------------------

--- a/cmd/doctor_all_helpers.go
+++ b/cmd/doctor_all_helpers.go
@@ -134,6 +134,20 @@ func writeRollupHeader(w io.Writer, root string, r query.DoctorRollup) error {
 		root, r.Discovered, breakdown, r.TotalNotes, r.TotalErrors, r.TotalWarnings); err != nil {
 		return err
 	}
+	// The "Total issues" line is the SURFACED axis (sum of each per-vault
+	// report). When the RAW schema-validation aggregate carries findings the text
+	// report never surfaces (unknown_type/invalid_status), note the gap on one
+	// honest line pointing at --json, so the terminal never hides a non-zero
+	// aggregate that lives under a different key. Mirrors the single-vault gap
+	// line in writeDoctorHuman; RawValidationGap subtracts the surfaced
+	// validation findings, not the full headline, so it never under-reports.
+	if gap := r.RawValidationGap(); gap > 0 {
+		if _, err := fmt.Fprintf(w,
+			"+%d raw validation finding(s) across vaults (unknown_type/invalid_status) — see --json rollup.total_raw_validation_findings\n",
+			gap); err != nil {
+			return err
+		}
+	}
 	if len(r.VaultsWithIssues) == 0 {
 		return nil
 	}

--- a/cmd/doctor_all_test.go
+++ b/cmd/doctor_all_test.go
@@ -165,6 +165,17 @@ Body without a title.
 // A vault with validation errors must appear in the rollup's "vaults with
 // issues" list — in both the human header and the JSON rollup.
 func TestDoctorAll_RollupListsVaultsWithIssues(t *testing.T) {
+	// The rollup headline now sums the SURFACED axis (ResultSurfacedIssueCounts),
+	// the same axis each per-vault report prints. That axis includes hook-drift
+	// (keyed on the project root's .claude/scripts) and mesh-identity signals, so
+	// isolate both — otherwise the dev-environment's drifted hooks + reachable
+	// daemon would surface warnings on the "clean" vault and the assertion that
+	// only the broken vault is listed would be environment-dependent. With both
+	// neutralized, the surfaced set is determined solely by vault content (the
+	// missing_required_field error in the broken vault).
+	isolateMeshEnv(t)
+	chdirToTemp(t)
+
 	root := t.TempDir()
 	clean := buildIndexedVaultAt(t, filepath.Join(root, "clean-vault"))
 	broken := buildVaultWithValidationError(t, filepath.Join(root, "zbroken-vault"))

--- a/internal/query/doctor_all.go
+++ b/internal/query/doctor_all.go
@@ -38,13 +38,34 @@ type FailedVault struct {
 // be opened. VaultCount is retained as an alias of Discovered for backward
 // compatibility with existing JSON consumers.
 type DoctorRollup struct {
-	VaultCount    int `json:"vault_count"`
-	Discovered    int `json:"discovered"`
-	Diagnosed     int `json:"diagnosed"`
-	Failed        int `json:"failed"`
-	TotalNotes    int `json:"total_notes"`
+	VaultCount int `json:"vault_count"`
+	Discovered int `json:"discovered"`
+	Diagnosed  int `json:"diagnosed"`
+	Failed     int `json:"failed"`
+	TotalNotes int `json:"total_notes"`
+	// TotalErrors/TotalWarnings are the SURFACED set — the sum of each vault's
+	// query.ResultSurfacedIssueCounts, the same axis each per-vault report
+	// prints — so the rollup totals reconcile with summing the per-vault
+	// reports. They deliberately do NOT count the raw schema-validation
+	// aggregate (see TotalRawValidationFindings), which is a different axis.
 	TotalErrors   int `json:"total_errors"`
 	TotalWarnings int `json:"total_warnings"`
+	// TotalRawValidationFindings is the RAW schema-validation aggregate summed
+	// across vaults: each vault's ValidationSummary.Errors+Warnings (nil ⇒ 0).
+	// It is a DIFFERENT axis from TotalErrors/TotalWarnings — it includes
+	// unknown_type / invalid_status findings the per-vault text report never
+	// surfaces as per-item lines. Kept under its own distinctly-labeled key so
+	// the two axes are explicit rather than collapsed, mirroring how the
+	// single-vault envelope keeps validation_summary alongside the surfaced set.
+	TotalRawValidationFindings int `json:"total_raw_validation_findings"`
+	// surfacedValidationFindings is the sum across vaults of the raw-validation
+	// findings that ARE surfaced as text lines (MissingRequiredFields +
+	// BrokenReferences). It is NOT serialized — it exists only so the human
+	// renderer can compute the raw-only gap exactly as the single-vault path
+	// does (gap = TotalRawValidationFindings - surfacedValidationFindings),
+	// rather than subtracting the full surfaced headline (which folds in
+	// non-validation items and would under-report the gap).
+	surfacedValidationFindings int
 	// VaultsWithIssues lists the paths of vaults with errors or warnings, in the
 	// order the vaults were diagnosed (already deterministic — discovery sorts
 	// them). Always non-nil so JSON consumers see [] for a clean workspace
@@ -53,10 +74,15 @@ type DoctorRollup struct {
 }
 
 // BuildDoctorRollup aggregates per-vault DoctorResults into a workspace rollup.
-// A vault counts as "having issues" when its ValidationSummary reports any
-// errors or warnings; a nil ValidationSummary (a raw, un-validated result)
-// contributes zero and is treated as clean. The failed slice (vaults that could
-// not be opened) is folded into the honest count breakdown —
+// The headline TotalErrors/TotalWarnings sum each vault's SURFACED counts
+// (ResultSurfacedIssueCounts — the same axis every per-vault report prints), so
+// `doctor --all` totals reconcile with summing the per-vault reports. A vault
+// counts as "having issues" iff its surfaced errors+warnings > 0, keyed on the
+// same axis. The RAW schema-validation aggregate is not discarded: it is summed
+// separately into TotalRawValidationFindings (each vault's
+// ValidationSummary.Errors+Warnings; a nil ValidationSummary — a raw,
+// un-validated result — contributes zero and never panics). The failed slice
+// (vaults that could not be opened) is folded into the honest count breakdown —
 // Discovered = diagnosed + failed — so the rollup never under-reports the
 // number of vaults found. Pure aggregation: no I/O, no mutation of inputs.
 func BuildDoctorRollup(vaults []*DoctorResult, failed []FailedVault) DoctorRollup {
@@ -74,16 +100,31 @@ func BuildDoctorRollup(vaults []*DoctorResult, failed []FailedVault) DoctorRollu
 			continue
 		}
 		rollup.TotalNotes += v.TotalFiles
-		errs, warns := 0, 0
-		if v.ValidationSummary != nil {
-			errs = v.ValidationSummary.Errors
-			warns = v.ValidationSummary.Warnings
-		}
+		// Headline totals: the SURFACED set, matching each per-vault report.
+		errs, warns := ResultSurfacedIssueCounts(v)
 		rollup.TotalErrors += errs
 		rollup.TotalWarnings += warns
+		// Raw schema-validation aggregate: a separate, distinctly-labeled axis.
+		// nil ValidationSummary (un-validated result) contributes zero.
+		if v.ValidationSummary != nil {
+			rollup.TotalRawValidationFindings += v.ValidationSummary.Errors + v.ValidationSummary.Warnings
+		}
+		// The validation findings that ARE surfaced as text lines — so the
+		// raw-only gap can be computed exactly (see RawValidationGap).
+		rollup.surfacedValidationFindings += v.Issues.MissingRequiredFields + v.Issues.BrokenReferences
 		if errs > 0 || warns > 0 {
 			rollup.VaultsWithIssues = append(rollup.VaultsWithIssues, v.VaultPath)
 		}
 	}
 	return rollup
+}
+
+// RawValidationGap reports how many RAW schema-validation findings are NOT
+// surfaced as per-item text lines across the workspace — the workspace-level
+// analogue of the single-vault gap line. It is TotalRawValidationFindings minus
+// the surfaced validation findings (MissingRequiredFields + BrokenReferences),
+// never the full surfaced headline (which folds in non-validation items and
+// would under-report the gap). A non-positive result means nothing is hidden.
+func (r DoctorRollup) RawValidationGap() int {
+	return r.TotalRawValidationFindings - r.surfacedValidationFindings
 }

--- a/internal/query/doctor_all_test.go
+++ b/internal/query/doctor_all_test.go
@@ -11,10 +11,16 @@ import (
 
 // mkVaultResult builds a minimal DoctorResult for rollup tests without touching
 // a database — BuildDoctorRollup is pure aggregation over already-diagnosed
-// vaults.
+// vaults. The errs/warns params drive the SURFACED axis (the rollup headline
+// now sums ResultSurfacedIssueCounts, matching each per-vault report), so errs
+// maps to a surfaced error bucket (DuplicateIDs) and warns to a surfaced
+// warning bucket (BrokenReferences). unresolved adds further surfaced warnings
+// via UnresolvedLinks. ValidationSummary (the RAW axis) is left nil here; tests
+// that exercise the raw-vs-surfaced distinction set it explicitly.
 func mkVaultResult(path string, total, errs, warns, unresolved int) *query.DoctorResult {
 	r := &query.DoctorResult{VaultPath: path, TotalFiles: total}
-	r.ValidationSummary = &query.StatusIssuesSummary{Errors: errs, Warnings: warns}
+	r.Issues.DuplicateIDs = errs
+	r.Issues.BrokenReferences = warns
 	r.Issues.UnresolvedLinks = unresolved
 	return r
 }
@@ -91,6 +97,97 @@ func TestBuildDoctorRollup_EmptyInput(t *testing.T) {
 	assert.Equal(t, 0, rollup.VaultCount)
 	assert.Equal(t, 0, rollup.TotalNotes)
 	assert.Empty(t, rollup.VaultsWithIssues)
+}
+
+// The headline TotalErrors/TotalWarnings must report the SURFACED set
+// (query.ResultSurfacedIssueCounts) — the same axis each per-vault report
+// prints — so `doctor --all` totals reconcile with summing the per-vault
+// reports. The RAW schema-validation aggregate (ValidationSummary) is a
+// DIFFERENT axis: it counts findings (unknown_type / invalid_status) the text
+// report never surfaces as per-item lines. Collapsing both under the same
+// label is the two-unlabeled-axes bug PR #31 fixed for the single-vault case;
+// this guards the remaining rollup instance.
+func TestBuildDoctorRollup_TotalsAreSurfacedNotRawValidation(t *testing.T) {
+	// Vault A: surfaced advisories only (Obsidian-incompatible + unresolved
+	// links), zero raw validation findings. Surfaced warnings = 2 + 1 = 3.
+	a := &query.DoctorResult{VaultPath: "/a", TotalFiles: 12}
+	a.Issues.ObsidianIncompatibleLinks = 2
+	a.Issues.UnresolvedLinks = 1
+
+	// Vault B: a surfaced broken reference (warning) PLUS several raw-only
+	// unknown_type findings that live in ValidationSummary but are NEVER
+	// surfaced as text lines. Surfaced warnings = 1 (BrokenReferences). The raw
+	// aggregate is far larger (1 surfaced broken_reference + 57 unknown_type).
+	b := &query.DoctorResult{VaultPath: "/b", TotalFiles: 30}
+	b.Issues.BrokenReferences = 1
+	b.ValidationSummary = &query.StatusIssuesSummary{Errors: 0, Warnings: 58}
+
+	vaults := []*query.DoctorResult{a, b}
+	rollup := query.BuildDoctorRollup(vaults, nil)
+
+	// Headline totals == sum of each vault's SURFACED counts (NOT the raw sum).
+	var wantErrs, wantWarns int
+	for _, v := range vaults {
+		e, w := query.ResultSurfacedIssueCounts(v)
+		wantErrs += e
+		wantWarns += w
+	}
+	assert.Equal(t, wantErrs, rollup.TotalErrors,
+		"TotalErrors sums the surfaced set, matching per-vault reports")
+	assert.Equal(t, wantWarns, rollup.TotalWarnings,
+		"TotalWarnings sums the surfaced set, matching per-vault reports")
+	// Concretely: surfaced warnings are 3 (vault A) + 1 (vault B) = 4, NOT the
+	// raw 3 + 58 = 61 the old ValidationSummary-based code reported.
+	assert.Equal(t, 4, rollup.TotalWarnings, "surfaced, not raw, warning total")
+	assert.Equal(t, 0, rollup.TotalErrors)
+
+	// The raw validation aggregate is preserved under its own distinctly-labeled
+	// field — sum of each ValidationSummary.Errors+Warnings (nil ⇒ 0).
+	assert.Equal(t, 58, rollup.TotalRawValidationFindings,
+		"raw schema-validation aggregate is kept, not discarded, under its own field")
+
+	// "Has issues" keys on the surfaced count too: both vaults surface warnings.
+	assert.Equal(t, []string{"/a", "/b"}, rollup.VaultsWithIssues)
+}
+
+// RawValidationGap reports the raw-only findings (those NOT surfaced as text
+// lines) across the workspace: TotalRawValidationFindings minus the surfaced
+// validation findings (MissingRequiredFields + BrokenReferences). It must NOT
+// subtract non-validation surfaced items, so it never under-reports the gap.
+func TestBuildDoctorRollup_RawValidationGap(t *testing.T) {
+	// Vault has: 1 surfaced broken_reference + 1 surfaced missing_required_field
+	// (both ARE validation findings) PLUS surfaced obsidian links (NON-validation)
+	// PLUS a raw aggregate of 60 (= 2 surfaced validation + 58 raw-only).
+	v := &query.DoctorResult{VaultPath: "/v", TotalFiles: 40}
+	v.Issues.BrokenReferences = 1
+	v.Issues.MissingRequiredFields = 1
+	v.Issues.ObsidianIncompatibleLinks = 5 // non-validation surfaced noise
+	v.ValidationSummary = &query.StatusIssuesSummary{Errors: 1, Warnings: 59}
+
+	rollup := query.BuildDoctorRollup([]*query.DoctorResult{v}, nil)
+
+	assert.Equal(t, 60, rollup.TotalRawValidationFindings)
+	// Gap subtracts ONLY the surfaced validation findings (1+1=2), not the
+	// obsidian links — so 60 - 2 = 58 raw-only findings.
+	assert.Equal(t, 58, rollup.RawValidationGap(),
+		"gap subtracts surfaced validation findings only, never the full headline")
+}
+
+// A vault whose ONLY findings are raw-only validation findings (unknown_type)
+// surfaces nothing actionable, so it must NOT count as "has issues" and must
+// NOT inflate the headline warnings — but its raw aggregate is still carried in
+// TotalRawValidationFindings so the information is not lost.
+func TestBuildDoctorRollup_RawOnlyVaultIsNotASurfacedIssue(t *testing.T) {
+	rawOnly := &query.DoctorResult{VaultPath: "/raw-only", TotalFiles: 8}
+	rawOnly.ValidationSummary = &query.StatusIssuesSummary{Errors: 0, Warnings: 57}
+
+	rollup := query.BuildDoctorRollup([]*query.DoctorResult{rawOnly}, nil)
+
+	assert.Equal(t, 0, rollup.TotalWarnings, "raw-only findings are not surfaced warnings")
+	assert.Equal(t, 0, rollup.TotalErrors)
+	assert.Equal(t, 57, rollup.TotalRawValidationFindings, "raw aggregate still carried")
+	assert.Empty(t, rollup.VaultsWithIssues,
+		"a vault with no surfaced issues is not listed even if it has raw findings")
 }
 
 // The combined envelope shape: result.rollup is an object and result.vaults is


### PR DESCRIPTION
Closes the second axis-honesty inconsistency surfaced reviewing PR #31 (the single-vault fix, now merged as #31/`b42cf0e`).

**Problem:** `BuildDoctorRollup` summed each vault's `ValidationSummary` (the RAW schema-validation aggregate — e.g. 57 `unknown_type` findings) into the headline `total_errors`/`total_warnings`, while each per-vault report shows the SURFACED set (`ResultSurfacedIssueCounts`). So `doctor --all` totals never reconciled with summing the per-vault reports — two different axes under one label.

**Fix (mirrors #31 at the rollup level):**
- Headline `TotalErrors`/`TotalWarnings` now sum `ResultSurfacedIssueCounts(v)` — the same function per-vault reports use, so the rollup reconciles by construction.
- The raw aggregate is preserved in a new distinctly-labeled field `total_raw_validation_findings`.
- `RawValidationGap()` subtracts only the surfaced *validation* findings (`MissingRequiredFields + BrokenReferences`) — deliberately NOT the full surfaced rollup, so it does not repeat PR #31's gap-under-report bug.
- `writeRollupHeader` prints one honest gap line when positive.

**Verification:** TDD red→green (totals assert surfaced=4 not raw=58; gap test includes non-validation surfaced noise to catch the #31 bug). `task check` green — 87.04% coverage, all per-package floors green. Independent review: approve.