### PR TITLE
fix: ORT backend honesty (symlink dylib + fail-loud + visibility) and arc-candidate recall

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/peiman/vaultmind/.ckeletin/pkg/config"
 	"github.com/peiman/vaultmind/internal/cmdutil"
 	"github.com/peiman/vaultmind/internal/config/commands"
+	"github.com/peiman/vaultmind/internal/embedding"
 	"github.com/peiman/vaultmind/internal/envelope"
 	"github.com/peiman/vaultmind/internal/hooks"
 	"github.com/peiman/vaultmind/internal/query"
@@ -36,6 +37,25 @@ const staleIndexRemedy = "vaultmind index --vault <vault>"
 // details (close the loop — hand the next command). frontmatter validate is
 // the subcommand that reports broken_reference per-note (FrontmatterValidateMetadata).
 const brokenReferencesRemedy = "vaultmind frontmatter validate --vault <path>"
+
+// minilmRemedy returns the upgrade path for a MiniLM-degraded index, branched on
+// the binary's embedding backend. On an ORT-built binary the binary is ALREADY
+// BGE-M3-capable, so the index↔binary mismatch is fixed by re-embedding — no
+// download or build. On a pure-Go binary the binary itself cannot run BGE-M3
+// indexing, so the remedy is to get an ORT binary (prebuilt archive or source).
+// Naming the right path closes the loop: an adopter holding the good binary but
+// a stale MiniLM index (e.g. after the symlink-dylib fix, Siavoush field report
+// 2026-06-19) must not be told to re-download what they already have.
+func minilmRemedy(backend string) string {
+	if backend == embedding.BackendNameORT {
+		return "this binary is ORT-capable (no download needed) — rebuild the index for the " +
+			"full 4-way BGE-M3 hybrid (dense + sparse + ColBERT):\n" +
+			"  vaultmind index --embed --model bge-m3 --full --vault <vault>"
+	}
+	return "For the full 4-way BGE-M3 hybrid (dense + sparse + ColBERT): on " +
+		"darwin-arm64/linux-amd64 download the prebuilt ORT binary from the release " +
+		"(no build), or build from source — see:\n  " + embeddingBackendsDocURL
+}
 
 var doctorCmd = MustNewCommand(commands.DoctorMetadata, runDoctor)
 
@@ -77,13 +97,12 @@ func writeEmbeddingStatus(w io.Writer, emb *query.DoctorEmbeddings) error {
 		// (full-text + dense) and silently lacks BGE-M3's sparse + ColBERT
 		// lanes. `go install` yields a pure-Go/MiniLM binary, so an adopter
 		// can land here without ever being told their recall is degraded
-		// (focalc field report, P1). Name the cliff at the moment it matters.
+		// (focalc field report, P1). Name the cliff at the moment it matters,
+		// with a remedy tuned to the binary on PATH (minilmRemedy).
 		_, err := fmt.Fprintf(w,
 			"⚠ degraded recall: this vault is indexed with MiniLM — dense-only "+
-				"(2 lanes: full-text + dense). For the full 4-way BGE-M3 hybrid "+
-				"(dense + sparse + ColBERT): on darwin-arm64/linux-amd64 download the "+
-				"prebuilt ORT binary from the release (no build), or build from source — see:\n  %s\n",
-			embeddingBackendsDocURL)
+				"(2 lanes: full-text + dense). %s\n",
+			minilmRemedy(embedding.BackendName()))
 		return err
 	}
 	if emb.Model == "mixed" && len(emb.MixedModel) > 0 {

--- a/cmd/misc_runners_test.go
+++ b/cmd/misc_runners_test.go
@@ -285,7 +285,29 @@ func TestWriteEmbeddingStatus_MiniLMSurfacesDegradedWarning(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "degraded recall")
 	assert.Contains(t, out, "MiniLM")
-	assert.Contains(t, out, "embedding-backends.md")
+	// Backend-agnostic: both remedies (ORT re-embed vs pure-Go download) name the
+	// BGE-M3 hybrid upgrade. The per-backend remedy text is asserted separately
+	// in TestMinilmRemedy_*, so this stays green on both build tags.
+	assert.Contains(t, out, "BGE-M3")
+}
+
+// On an ORT-built binary, a MiniLM index is a binary↔index MISMATCH, not a
+// capability gap: the binary can already run BGE-M3, so the remedy is to
+// re-embed — never to re-download a binary the user already has (Siavoush field
+// report 2026-06-19).
+func TestMinilmRemedy_ORTBinarySaysReembedNoDownload(t *testing.T) {
+	r := minilmRemedy(embedding.BackendNameORT)
+	assert.Contains(t, r, "--model bge-m3 --full", "must hand the re-embed command")
+	assert.Contains(t, r, "no download needed")
+	assert.NotContains(t, r, "embedding-backends.md", "ORT binary needs no download/build path")
+}
+
+// On a pure-Go binary, BGE-M3 indexing cannot run at all — the remedy is to get
+// an ORT binary (prebuilt archive or source), pointing at the backends doc.
+func TestMinilmRemedy_PureGoSaysDownloadOrBuild(t *testing.T) {
+	r := minilmRemedy(embedding.BackendNameGo)
+	assert.Contains(t, r, "embedding-backends.md")
+	assert.Contains(t, r, "prebuilt ORT binary")
 }
 
 // A full BGE-M3 index must NOT emit the degraded-recall warning.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/peiman/vaultmind/internal/embedding"
 	"github.com/spf13/cobra"
 )
 
@@ -47,15 +48,21 @@ func buildVersionInfo(ldVersion, ldCommit, ldDate string, info *debug.BuildInfo,
 // while `--help` listed it under Setup — a first-impression papercut surfaced
 // by the first knowledge-vault adopter (focalc field report, P2). Checking the
 // version is often the very first thing a new user does.
+//
+// The trailing "(backend: …)" names the embedding backend the binary was built
+// against (ort+cpu / ort+coreml / go-cpu). Whether a binary is ORT- or pure-Go
+// is invisible without running an embed pass and reading doctor; an adopter
+// hitting a silent MiniLM degrade (Siavoush field report, 2026-06-19) can now
+// confirm at a glance which binary is on PATH.
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version, commit, and build date",
+	Short: "Print the version, commit, build date, and embedding backend",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		info, ok := debug.ReadBuildInfo()
 		v, c, d := buildVersionInfo(Version, Commit, Date, info, ok)
-		_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s version %s, commit %s, built at %s\n",
-			binaryName, v, c, d)
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s version %s, commit %s, built at %s (backend: %s)\n",
+			binaryName, v, c, d, embedding.Acceleration())
 		return err
 	},
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -100,4 +100,8 @@ func TestVersionCommandOutput(t *testing.T) {
 	assert.Contains(t, out, "version v9.9.9")
 	assert.Contains(t, out, "commit abc1234")
 	assert.Contains(t, out, "built at 2026-01-01_00:00:00")
+	// The embedding backend must be named so an adopter can confirm which binary
+	// is on PATH without running an embed pass (Siavoush field report). Value is
+	// build-tag dependent (go-cpu / ort+cpu / ort+coreml) so assert the label.
+	assert.Contains(t, out, "backend: ")
 }

--- a/internal/distill/candidates.go
+++ b/internal/distill/candidates.go
@@ -21,6 +21,15 @@ const (
 	// principle ("principle 5"). A frequent precursor to a lens-redirected
 	// decision — an arc shape, when the lens actually overrides an instinct.
 	RuleManifestoLens RuleID = "manifesto-lens"
+	// RuleEvidenceGate — the partner makes proceeding conditional on the agent's
+	// OWN confidence or the evidence ("if you're confident, merge"; "only if
+	// you're sure"). A sibling of authority-grant: standing trust gated on the
+	// agent's judgment rather than transferred outright. Marks the moment the
+	// agent's evidence-bar becomes the deciding factor — a recurring arc
+	// precursor that no authority-grant phrase catches (added after the Siavoush
+	// content-machine field report, 2026-06-19: the detector missed an "if you
+	// are confident we merge" arc precisely because it isn't a "you decide").
+	RuleEvidenceGate RuleID = "evidence-gate"
 )
 
 // Candidate is a surfaced transformation moment — a propose-only pointer into
@@ -75,6 +84,21 @@ var manifestoLensLexemes = []string{
 
 var principleNRe = regexp.MustCompile(`principle\s+\d`)
 
+// evidenceGateLexemes are confidence-conditional delegation phrases — the
+// partner hands off the decision contingent on the agent's own certainty
+// ("if you're confident we merge"). Kept deliberately tight (the conditional +
+// a confidence word together) so it stays high-precision like the other rules:
+// bare "confident"/"sure" prose does not fire — only the "if you're <conf>"
+// construction. Matched case-insensitively as substrings.
+var evidenceGateLexemes = []string{
+	"if you're confident", "if you are confident",
+	"if you're sure", "if you are sure",
+	"if you feel confident",
+	"as long as you're confident", "as long as you are confident",
+	"as long as you're sure", "as long as you are sure",
+	"only if you're sure", "only if you are sure",
+}
+
 // ExtractCandidates applies the mechanical rules to an episode's USER turns
 // only. Commit/build/TDD noise lives in ASSISTANT turns, which are never
 // scanned, so it is excluded by construction (no rule can fire on it). A turn
@@ -93,6 +117,9 @@ func ExtractCandidates(ep *Episode) []Candidate {
 			out = append(out, candidate(RuleManifestoLens, ep, t, m))
 		} else if loc := principleNRe.FindString(lower); loc != "" {
 			out = append(out, candidate(RuleManifestoLens, ep, t, loc))
+		}
+		if m := matchAny(lower, evidenceGateLexemes); m != "" {
+			out = append(out, candidate(RuleEvidenceGate, ep, t, m))
 		}
 	}
 	return out

--- a/internal/distill/distill_test.go
+++ b/internal/distill/distill_test.go
@@ -154,6 +154,38 @@ func TestExtractCandidates_AuthorityGrantLexemes(t *testing.T) {
 	}
 }
 
+// The evidence-gate rule fires when the partner makes proceeding conditional on
+// the agent's own confidence — the arc shape the detector missed in the Siavoush
+// content-machine field report (an "if you are confident we merge" arc that no
+// authority-grant phrase caught).
+func TestExtractCandidates_EvidenceGateFires(t *testing.T) {
+	for _, msg := range []string{
+		"if you are confident we merge",
+		"if you're confident, ship it",
+		"only if you are sure — otherwise ask me",
+		"as long as you're sure, go ahead and refactor",
+	} {
+		ep := &distill.Episode{ID: "e", UserTurns: []distill.Turn{{Index: 1, Text: msg}}}
+		cands := distill.ExtractCandidates(ep)
+		require.Len(t, cands, 1, "confidence-conditional delegation %q must fire", msg)
+		assert.Equal(t, distill.RuleEvidenceGate, cands[0].Rule)
+	}
+}
+
+// Precision guard: bare confidence/sureness prose is NOT a delegation gate —
+// only the "if you're <confident>" construction is. Keeps the rule as tight as
+// the others (the 2026-05-31 review's precision bar).
+func TestExtractCandidates_EvidenceGateRejectsBareConfidence(t *testing.T) {
+	for _, msg := range []string{
+		"are you sure about this?",
+		"I'm confident this is right",
+		"make sure the tests pass",
+	} {
+		ep := &distill.Episode{ID: "e", UserTurns: []distill.Turn{{Index: 1, Text: msg}}}
+		assert.Empty(t, distill.ExtractCandidates(ep), "bare confidence prose %q must not fire", msg)
+	}
+}
+
 // The manifesto-lens rule also fires on a numbered-principle citation
 // ("principle 7"), via principleNRe — but not on un-numbered "principled" prose.
 func TestExtractCandidates_PrincipleNFiresManifestoLens(t *testing.T) {

--- a/internal/embedding/default_model.go
+++ b/internal/embedding/default_model.go
@@ -1,5 +1,14 @@
 package embedding
 
+// Backend names reported by BackendName(), which is defined per build tag in
+// session_ort.go (ORT) and session_go.go (pure-Go). Declared here in a
+// non-tagged file so callers in either build can compare against them without
+// duplicating the literals (SSOT).
+const (
+	BackendNameORT = "ort"
+	BackendNameGo  = "go"
+)
+
 // DefaultModel returns the embedding model to use when the operator
 // hasn't picked one explicitly. Adapts to the backend the binary was
 // built against:
@@ -23,7 +32,7 @@ package embedding
 // post-hoc warning. The runtime-aware default closes that gap by
 // matching the model to what the binary can actually run well.
 func DefaultModel() string {
-	if BackendName() == "ort" {
+	if BackendName() == BackendNameORT {
 		return "bge-m3"
 	}
 	return "minilm"

--- a/internal/embedding/session_go.go
+++ b/internal/embedding/session_go.go
@@ -16,7 +16,7 @@ func newBGEM3Session() (*hugot.Session, error) {
 // Consumers (e.g. the index command) use this to warn when BGE-M3 indexing
 // is about to run on the slow pure-Go path so operators don't mistake
 // "hours-long indexing" for a hang or OOM. Reported by the build tag.
-func BackendName() string { return "go" }
+func BackendName() string { return BackendNameGo }
 
 // Acceleration mirrors the ORT-build's Acceleration() so callers don't
 // need to special-case build tags. Pure-Go has no GPU path; "go-cpu"

--- a/internal/embedding/session_ort.go
+++ b/internal/embedding/session_ort.go
@@ -81,7 +81,7 @@ func shouldEnableCoreML() bool {
 // whether to warn about BGE-M3 indexing being about to run on the slow path.
 // Stays "ort" regardless of CoreML state so the slow-backend guard works as
 // a binary check; CoreML status is surfaced separately via Acceleration().
-func BackendName() string { return "ort" }
+func BackendName() string { return BackendNameORT }
 
 // Acceleration reports the active execution-provider stack for this binary
 // at runtime. Useful for the doctor command and index summary so the
@@ -106,29 +106,52 @@ func detectORTLibDir() string {
 	if runtime.GOOS == "darwin" {
 		systemDirs = append([]string{"/opt/homebrew/lib"}, systemDirs...)
 	}
-	exeDir := ""
-	if exe, err := os.Executable(); err == nil {
-		exeDir = filepath.Dir(exe)
-	}
-	return resolveORTLibDir(os.Getenv("ORT_LIB_DIR"), exeDir, libName, systemDirs, func(p string) bool {
+	return resolveORTLibDir(os.Getenv("ORT_LIB_DIR"), executableLibDirs(), libName, systemDirs, func(p string) bool {
 		_, err := os.Stat(p)
 		return err == nil
 	})
 }
 
+// executableLibDirs returns the candidate directories that may hold the bundled
+// libonnxruntime, in priority order: the directory of the invoked executable
+// path, then the directory of its symlink-resolved real path. macOS computes a
+// process's executable path from the SYMLINK used to launch it — os.Executable
+// does not resolve it — so a symlinked-on-PATH install
+// (~/.local/bin/vaultmind → ~/.local/vaultmind/vaultmind) would otherwise look
+// for the dylib next to the symlink, miss the bundle sitting next to the real
+// binary, and silently degrade to MiniLM. Checking the resolved dir too makes a
+// downloaded archive portable through a PATH symlink (Siavoush field report,
+// 2026-06-19).
+func executableLibDirs() []string {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	dirs := []string{filepath.Dir(exe)}
+	if resolved, rerr := filepath.EvalSymlinks(exe); rerr == nil {
+		if d := filepath.Dir(resolved); d != dirs[0] {
+			dirs = append(dirs, d)
+		}
+	}
+	return dirs
+}
+
 // resolveORTLibDir picks the directory to load libonnxruntime from, in priority
-// order: an explicit ORT_LIB_DIR override, then the executable's OWN directory
-// (the prebuilt-release bundle layout — a libonnxruntime shipped next to the
-// binary is found with zero config, so a downloaded archive just runs), then
-// standard system locations (homebrew / /usr/local). Pure and injectable so the
-// order is unit-testable without a real install. Returns "" when none has the
-// library, leaving the runtime to surface its own load error.
-func resolveORTLibDir(ortLibDirEnv, exeDir, libName string, systemDirs []string, fileExists func(string) bool) string {
+// order: an explicit ORT_LIB_DIR override, then each executable-relative
+// directory (the prebuilt-release bundle layout — a libonnxruntime shipped next
+// to the binary, or next to its symlink-resolved real path, is found with zero
+// config so a downloaded archive just runs), then standard system locations
+// (homebrew / /usr/local). Pure and injectable so the order is unit-testable
+// without a real install. Returns "" when none has the library, leaving the
+// runtime to surface its own load error.
+func resolveORTLibDir(ortLibDirEnv string, exeDirs []string, libName string, systemDirs []string, fileExists func(string) bool) string {
 	if ortLibDirEnv != "" {
 		return ortLibDirEnv
 	}
-	if exeDir != "" && fileExists(filepath.Join(exeDir, libName)) {
-		return exeDir
+	for _, dir := range exeDirs {
+		if dir != "" && fileExists(filepath.Join(dir, libName)) {
+			return dir
+		}
 	}
 	for _, dir := range systemDirs {
 		if fileExists(filepath.Join(dir, libName)) {

--- a/internal/embedding/session_ort_test.go
+++ b/internal/embedding/session_ort_test.go
@@ -20,7 +20,7 @@ func TestResolveORTLibDir(t *testing.T) {
 	sys := []string{"/opt/homebrew/lib", "/usr/local/lib", "/usr/lib"}
 
 	t.Run("ORT_LIB_DIR override wins over everything", func(t *testing.T) {
-		got := resolveORTLibDir("/custom/ort", "/app/bin", lib, sys,
+		got := resolveORTLibDir("/custom/ort", []string{"/app/bin"}, lib, sys,
 			has("/app/bin/"+lib, "/opt/homebrew/lib/"+lib)) // both also present
 		if got != "/custom/ort" {
 			t.Fatalf("explicit ORT_LIB_DIR must win, got %q", got)
@@ -28,29 +28,56 @@ func TestResolveORTLibDir(t *testing.T) {
 	})
 
 	t.Run("bundled lib next to the executable is found (the release layout)", func(t *testing.T) {
-		got := resolveORTLibDir("", "/app/bin", lib, sys, has("/app/bin/"+lib))
+		got := resolveORTLibDir("", []string{"/app/bin"}, lib, sys, has("/app/bin/"+lib))
 		if got != "/app/bin" {
 			t.Fatalf("exe-dir bundle must be found, got %q", got)
 		}
 	})
 
 	t.Run("exe-dir beats a system lib when both exist", func(t *testing.T) {
-		got := resolveORTLibDir("", "/app/bin", lib, sys,
+		got := resolveORTLibDir("", []string{"/app/bin"}, lib, sys,
 			has("/app/bin/"+lib, "/usr/local/lib/"+lib))
 		if got != "/app/bin" {
 			t.Fatalf("bundled lib must take priority over system, got %q", got)
 		}
 	})
 
+	t.Run("lib next to the symlink-resolved real dir is found (the symlink-on-PATH layout)", func(t *testing.T) {
+		// The invoked path (~/.local/bin, a symlink dir) has no bundled lib; the
+		// resolved real dir (~/.local/vaultmind) does. macOS leaves os.Executable
+		// unresolved, so without checking the resolved dir this degrades to MiniLM.
+		got := resolveORTLibDir("", []string{"/local/bin", "/local/vaultmind"}, lib, sys,
+			has("/local/vaultmind/"+lib))
+		if got != "/local/vaultmind" {
+			t.Fatalf("symlink-resolved exe dir must be found, got %q", got)
+		}
+	})
+
+	t.Run("the invoked exe dir wins over the resolved dir when both have the lib", func(t *testing.T) {
+		got := resolveORTLibDir("", []string{"/local/bin", "/local/vaultmind"}, lib, sys,
+			has("/local/bin/"+lib, "/local/vaultmind/"+lib))
+		if got != "/local/bin" {
+			t.Fatalf("first exe-dir candidate must win, got %q", got)
+		}
+	})
+
+	t.Run("exe dirs beat a system lib when both exist", func(t *testing.T) {
+		got := resolveORTLibDir("", []string{"/local/bin", "/local/vaultmind"}, lib, sys,
+			has("/local/vaultmind/"+lib, "/usr/local/lib/"+lib))
+		if got != "/local/vaultmind" {
+			t.Fatalf("a bundled lib (even via resolved dir) must beat system, got %q", got)
+		}
+	})
+
 	t.Run("falls back to system locations in order", func(t *testing.T) {
-		got := resolveORTLibDir("", "/app/bin", lib, sys, has("/usr/local/lib/"+lib))
+		got := resolveORTLibDir("", []string{"/app/bin"}, lib, sys, has("/usr/local/lib/"+lib))
 		if got != "/usr/local/lib" {
 			t.Fatalf("system fallback failed, got %q", got)
 		}
 	})
 
 	t.Run("nothing found returns empty", func(t *testing.T) {
-		if got := resolveORTLibDir("", "/app/bin", lib, sys, has()); got != "" {
+		if got := resolveORTLibDir("", []string{"/app/bin"}, lib, sys, has()); got != "" {
 			t.Fatalf("no library anywhere must return empty, got %q", got)
 		}
 	})

--- a/internal/index/embedder_fallback_test.go
+++ b/internal/index/embedder_fallback_test.go
@@ -34,34 +34,53 @@ func failCtor(msg string) embedderCtor {
 	return func() (embedding.Embedder, error) { return nil, errors.New(msg) }
 }
 
-// The headline behavior: bge-m3 requested but unavailable at runtime → use
-// minilm, and report minilm as the model actually used (so the caller stamps
-// and calibrates against reality, not the request).
-func TestLoadEmbedder_FallsBackToMinilmWhenBGEUnavailable(t *testing.T) {
-	e, used, err := loadEmbedder("bge-m3", failCtor("ort runtime unavailable"), okCtor(384))
+// The headline behavior on a PURE-GO binary: bge-m3 requested but unavailable
+// at runtime → use minilm (the only option there), and report minilm as the
+// model actually used (so the caller stamps and calibrates against reality, not
+// the request).
+func TestLoadEmbedder_PureGoFallsBackToMinilmWhenBGEUnavailable(t *testing.T) {
+	e, used, err := loadEmbedder("bge-m3", embedding.BackendNameGo, failCtor("ort runtime unavailable"), okCtor(384))
 	require.NoError(t, err)
 	require.NotNil(t, e)
 	assert.Equal(t, "minilm", used, "fallback must report the model actually used")
 }
 
+// On an ORT-built binary, a bge-m3 load failure is a BROKEN INSTALL (e.g.
+// libonnxruntime not found next to the binary), not an expected capability gap.
+// Silently writing a MiniLM index there masks the breakage. Fail loud instead —
+// and never construct the minilm fallback (Siavoush field report, 2026-06-19).
+func TestLoadEmbedder_ORTBinaryBGEFailure_HardErrors(t *testing.T) {
+	miniCalled := false
+	miniSpy := func() (embedding.Embedder, error) {
+		miniCalled = true
+		return &fakeEmbedder{dims: 384}, nil
+	}
+	e, used, err := loadEmbedder("bge-m3", embedding.BackendNameORT, failCtor("libonnxruntime not found"), miniSpy)
+	require.Error(t, err)
+	assert.Nil(t, e)
+	assert.Empty(t, used)
+	assert.False(t, miniCalled, "ORT binary must NOT silently fall back to minilm")
+	assert.Contains(t, err.Error(), "ORT", "error must name the broken-install cause")
+}
+
 func TestLoadEmbedder_UsesBGEWhenAvailable(t *testing.T) {
-	e, used, err := loadEmbedder("bge-m3", okCtor(1024), failCtor("minilm should not be called"))
+	e, used, err := loadEmbedder("bge-m3", embedding.BackendNameORT, okCtor(1024), failCtor("minilm should not be called"))
 	require.NoError(t, err)
 	require.NotNil(t, e)
 	assert.Equal(t, "bge-m3", used)
 }
 
 func TestLoadEmbedder_NonBGERequestUsesThatModelDirectly(t *testing.T) {
-	e, used, err := loadEmbedder("minilm", failCtor("bge should not be called"), okCtor(384))
+	e, used, err := loadEmbedder("minilm", embedding.BackendNameGo, failCtor("bge should not be called"), okCtor(384))
 	require.NoError(t, err)
 	require.NotNil(t, e)
 	assert.Equal(t, "minilm", used)
 }
 
-// If even the fallback fails, surface a clear combined error (no silent
-// success, no nil embedder).
-func TestLoadEmbedder_BothFail_ReturnsCombinedError(t *testing.T) {
-	e, used, err := loadEmbedder("bge-m3", failCtor("bge boom"), failCtor("minilm boom"))
+// If even the fallback fails on a pure-Go binary, surface a clear combined
+// error (no silent success, no nil embedder).
+func TestLoadEmbedder_PureGoBothFail_ReturnsCombinedError(t *testing.T) {
+	e, used, err := loadEmbedder("bge-m3", embedding.BackendNameGo, failCtor("bge boom"), failCtor("minilm boom"))
 	require.Error(t, err)
 	assert.Nil(t, e)
 	assert.Empty(t, used)

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -126,7 +126,7 @@ func (idx *Indexer) RunEmbed(ctx context.Context, dbPath, model string) (*EmbedR
 	modelUsed := model
 	if embedder == nil {
 		var used string
-		embedder, used, err = loadEmbedder(model,
+		embedder, used, err = loadEmbedder(model, embedding.BackendName(),
 			func() (embedding.Embedder, error) { return embedding.NewBGEM3Embedder(embedding.BGEM3Config()) },
 			func() (embedding.Embedder, error) { return embedding.NewHugotEmbedder(embedding.DefaultHugotConfig()) },
 		)
@@ -187,15 +187,26 @@ func hasBGEM3Embeddings(dbPath string) (bool, error) {
 // logic is unit-testable with injected success/failure.
 type embedderCtor func() (embedding.Embedder, error)
 
-// loadEmbedder builds the embedder for the requested model with a runtime
-// fallback: when bge-m3 is requested but its backend cannot be loaded (e.g. the
-// ORT runtime or the BGE-M3 model files are unavailable), it falls back to
-// minilm with a loud warning, so an embed pass degrades to a working dense-only
-// state instead of hard-failing. This is the runtime half of "bge-m3 first,
-// minilm as fallback" (the build-tag DefaultModel picks bge-m3 on ORT builds;
-// this catches the case where that choice can't actually run). Returns the
-// embedder and the model ACTUALLY used so the caller stamps/calibrates reality.
-func loadEmbedder(model string, newBGE, newMini embedderCtor) (embedding.Embedder, string, error) {
+// errORTBGEUnavailable formats the broken-install error for an ORT-built binary
+// whose bge-m3 embedder failed to load — naming the likely cause (libonnxruntime
+// not found next to the binary) and the remedy, so the failure is actionable
+// rather than a silent MiniLM degrade. See loadEmbedder.
+func errORTBGEUnavailable(cause error) error {
+	return fmt.Errorf("bge-m3 embedder unavailable on an ORT-built binary "+
+		"(broken install, not an expected fallback): %w; confirm libonnxruntime sits next to "+
+		"the vaultmind binary (or set ORT_LIB_DIR), then retry — or rebuild as minilm with "+
+		"'vaultmind index --embed --model minilm --full'", cause)
+}
+
+// loadEmbedder builds the embedder for the requested model, handling a bge-m3
+// load failure differently per backend. On a pure-Go binary it falls back to
+// minilm with a loud warning (minilm is the only option there), so an embed
+// pass degrades to a working dense-only state instead of hard-failing. On an
+// ORT-built binary a bge-m3 failure is a broken install rather than a capability
+// gap, so it returns a hard error naming the remedy — never a silent MiniLM
+// index. Returns the embedder and the model ACTUALLY used so the caller
+// stamps/calibrates reality.
+func loadEmbedder(model, backend string, newBGE, newMini embedderCtor) (embedding.Embedder, string, error) {
 	if model != "bge-m3" {
 		e, err := newMini()
 		if err != nil {
@@ -206,6 +217,16 @@ func loadEmbedder(model string, newBGE, newMini embedderCtor) (embedding.Embedde
 	bge, err := newBGE()
 	if err == nil {
 		return bge, "bge-m3", nil
+	}
+	// On an ORT-built binary, bge-m3 is the whole reason that build exists — a
+	// load failure means a broken install (e.g. libonnxruntime not found next to
+	// the binary, the symlink-on-PATH case), NOT an expected capability gap.
+	// Silently writing a MiniLM index there reports success while degrading
+	// retrieval invisibly. Fail loud with the remedy instead; the graceful
+	// minilm fallback below is for pure-Go binaries, where minilm is the only
+	// option (Siavoush field report, 2026-06-19).
+	if backend == embedding.BackendNameORT {
+		return nil, "", errORTBGEUnavailable(err)
 	}
 	log.Warn().Err(err).Msg("bge-m3 embedder unavailable at runtime; falling back to minilm (run 'task setup:ort' to enable bge-m3)")
 	fallback, ferr := newMini()


### PR DESCRIPTION
Five field-reported issues from the first cross-party agent onboarding (Siavoush's content-machine, 2026-06-19), where an ORT-built binary silently degraded to MiniLM.

## What & why

**1. Symlink-on-PATH → silent MiniLM (`47ca056`)**
macOS leaves `os.Executable()` as the unresolved symlink path, so a symlinked install (`~/.local/bin/vaultmind` → `~/.local/vaultmind/vaultmind`) looked for the bundled `libonnxruntime` next to the symlink, missed the bundle next to the real binary, and fell back to MiniLM. `detectORTLibDir` now also checks the `EvalSymlinks`-resolved dir. Adds SSOT `BackendNameORT`/`BackendNameGo` constants.

**2. Fail loud on ORT bge-m3 failure (`d19267f`)**
On an ORT binary, a bge-m3 load failure is a broken install, not a capability gap — writing a MiniLM index there reports success while degrading retrieval invisibly. `loadEmbedder` now hard-errors (naming the remedy) on ORT; pure-Go keeps the graceful fallback (MiniLM is its only option).

**3. Backend visibility (`d19267f`)**
`version` prints `(backend: …)`. `doctor`'s MiniLM warning branches: an ORT binary with a MiniLM index is told to re-embed (no download); a pure-Go binary to get an ORT build.

**4. Preflight** — subsumed by 1+2 (the embedder load is the preflight) + 3 (visibility); no separate machinery.

**5. Arc-candidate recall (`0d01fea`)**
The detector missed arcs whose push is confidence-conditional delegation ("if you are confident we merge"). Adds `RuleEvidenceGate` with a deliberately tight lexeme set so it stays high-precision. Detector stays propose-only.

## Verification
- TDD test-first per slice; all green on **both** pure-Go and `-tags ORT` builds.
- Full `task check` green; lefthook (3633 tests + lint + vuln-scan) green on each commit.
- Code-review pass caught and fixed a test that would have failed on the ORT release matrix.