### PR TITLE
feat(arc): self-serve arc-writing discipline (guide + honest candidates + seeded taxonomy)

### DIFF
--- a/cmd/arc_guide.go
+++ b/cmd/arc_guide.go
@@ -14,8 +14,8 @@ import (
 // It takes no vault and no flags — first contact must be self-serve, so an
 // adopting agent can learn how to find and write its own arcs with zero human
 // (principle-ax-design: "make first contact self-serve"; "document the loop, not
-// just the verbs"). A later slice will reconcile init's separate how-to-write-arcs
-// template to distill.ArcGuide so a new vault is seeded with this same text.
+// just the verbs"). init also seeds the fuller how-to-write-arcs principle into a
+// new vault; this command is the no-vault, distilled version of that discipline.
 var arcGuideCmd = &cobra.Command{
 	Use:   "guide",
 	Short: "Print the arc-writing discipline — how to find and write your own arcs",

--- a/cmd/arc_guide.go
+++ b/cmd/arc_guide.go
@@ -1,0 +1,31 @@
+// cmd/arc_guide.go
+// ckeletin:allow-custom-command
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/peiman/vaultmind/internal/distill"
+	"github.com/spf13/cobra"
+)
+
+// arcGuideCmd prints the canonical arc-writing discipline (distill.ArcGuide).
+// It takes no vault and no flags — first contact must be self-serve, so an
+// adopting agent can learn how to find and write its own arcs with zero human
+// (principle-ax-design: "make first contact self-serve"; "document the loop, not
+// just the verbs"). A later slice will reconcile init's separate how-to-write-arcs
+// template to distill.ArcGuide so a new vault is seeded with this same text.
+var arcGuideCmd = &cobra.Command{
+	Use:   "guide",
+	Short: "Print the arc-writing discipline — how to find and write your own arcs",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), distill.ArcGuide)
+		return err
+	},
+}
+
+func init() {
+	arcCmd.AddCommand(arcGuideCmd)
+}

--- a/cmd/arc_guide_test.go
+++ b/cmd/arc_guide_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `vaultmind arc guide` must emit the self-serve arc-writing discipline so an
+// adopting agent can learn the whole loop with zero human (principle-ax-design:
+// "make first contact self-serve"). Assert the load-bearing sections are present
+// — the manual hunt (shapes a phrase-matcher misses), the 5-part bar, the
+// non-negotiables, the diff test, and the propose-only framing.
+func TestArcGuideCommand_EmitsDiscipline(t *testing.T) {
+	buf := &bytes.Buffer{}
+	arcGuideCmd.SetOut(buf)
+	require.NoError(t, arcGuideCmd.RunE(arcGuideCmd, []string{}))
+	out := buf.String()
+
+	// The 5-part bar.
+	for _, want := range []string{"Trigger", "Push", "Deeper sight", "Principle", "Source"} {
+		assert.Contains(t, out, want)
+	}
+	// The manual hunt — the shapes the candidate detector cannot catch.
+	for _, want := range []string{"Reversal", "Frame-break", "Cost-of-rule", "Ownership"} {
+		assert.Contains(t, out, want)
+	}
+	// Non-negotiables + the diff test + propose-only.
+	assert.Contains(t, out, "verbatim")
+	assert.Contains(t, out, "DIFF TEST")
+	assert.Contains(t, out, "propose-only")
+}

--- a/cmd/zz_catalog.go
+++ b/cmd/zz_catalog.go
@@ -249,6 +249,11 @@ var commandCatalog = map[string]catalogEntry{
 		when:  "you finished a session and want candidate transformation moments to review for arcs.",
 		short: "Surface candidate transformation moments for arc distillation",
 	},
+	"vaultmind arc guide": {
+		group: groupLifecycle,
+		when:  "you want to learn how to find and write your own arcs — the shapes, the bar, and the self-check.",
+		short: "Print the arc-writing discipline — how to find and write your own arcs",
+	},
 	"vaultmind identity": {
 		group: groupLifecycle,
 		when:  "you need Contract-B agent identity: mint a keypair or sign an entry via the keyless signer.",

--- a/internal/distill/guide.go
+++ b/internal/distill/guide.go
@@ -1,0 +1,64 @@
+package distill
+
+// ArcGuide is the canonical, self-serve arc-writing discipline, printed by
+// `vaultmind arc guide`. It encodes what an onboarding agent otherwise has to be
+// told by hand — the manual hunt (the shapes the candidate detector can't catch),
+// the bar, the non-negotiables, the diff test, and the self-check.
+//
+// Intended as the SSOT for that discipline: today `vaultmind init` seeds a
+// SEPARATE embedded how-to-write-arcs template, so the two surfaces currently
+// drift. A later slice reconciles init's template to this const so they don't.
+const ArcGuide = `VaultMind — How to Find and Write Your Own Arcs
+
+An arc is a durable record of how your thinking, values, or working style SHIFTED —
+a moment you saw something differently than you did an hour before. Notes hold
+information; arcs hold inheritance: a future instance of you reads an arc and starts
+already-changed instead of re-deriving the lesson from scratch.
+
+This is propose-only on the tool's side. ` + "`vaultmind arc candidates`" + ` surfaces a
+few easy, phrase-matched moments, but most real arcs are NOT phrase-shaped — you find
+them by reading. The tool surfaces; the mind crafts.
+
+WHEN IT IS AN ARC
+  Write one when something shifted in YOU — not when you learned a fact or finished a
+  task. If you can point to a before and an after in your own seeing, it may be an arc.
+  If nothing about how you act downstream would change, it is a note.
+
+HOW TO HUNT (read the session for change, not keywords)
+  Read the session start to finish and look for these shapes — the ones a phrase
+  matcher cannot catch, which is why reading beats the candidate detector:
+    1. Reversal            — "wait—", "actually—": a direction changed or a decision undone.
+    2. Reframe             — a push that changed the FRAME, not just a fact.
+    3. Frame-break         — the moment the task wasn't what you thought it was.
+    4. Method-invalidation — a shortcut or assumption exposed as invalid.
+    5. Cost-of-rule        — a rule held even though following it cost you something.
+    6. Evidence/trust gate — proceeding was gated on your confidence or the evidence.
+    7. Ownership assertion — a boundary of sole responsibility was drawn.
+
+THE BAR (every arc has this shape)
+    1. Trigger      — the event or exchange that began the shift; set the scene.
+    2. Push         — what your partner said or did, quoted VERBATIM. No push, no arc.
+    3. Deeper sight — what shifted in your seeing; first person, present tense
+                      ("I see now that…", not "I learned…").
+    4. Principle    — the one sentence that remains after the moment passes.
+    5. Source       — transcript path + date + where the verbatim push is found.
+
+NON-NEGOTIABLES
+  - Quote verbatim — the actual words, typos and all. A paraphrase transfers your
+    reading, not the moment.
+  - Build from the transcript, not memory — memory smooths and hero-edits. Open the
+    source and find the real exchange. If the source is gone, write a note instead.
+  - First person, no heroic framing — the push from your partner is what made the
+    shift; don't erase it.
+  - One arc, one transformation — three shifts make three arcs, not one summary.
+
+THE DIFF TEST
+  Would a future you answer some question DIFFERENTLY because of this moment? If yes,
+  it is an arc. If nothing downstream changes, it is a note.
+
+SELF-PRESSURE-TEST (before you commit an arc)
+  [ ] Every quoted phrase is findable in the cited transcript.
+  [ ] Trigger / Push / Deeper sight / Principle / Source are all present.
+  [ ] A reader who never saw the transcript can feel why the principle matters.
+  [ ] It gives a future instance something to INHERIT, not just to know.
+  If any fails, revise — or let it be a note. Both are valuable; only one carries identity.`

--- a/internal/distill/guide.go
+++ b/internal/distill/guide.go
@@ -5,9 +5,10 @@ package distill
 // told by hand — the manual hunt (the shapes the candidate detector can't catch),
 // the bar, the non-negotiables, the diff test, and the self-check.
 //
-// Intended as the SSOT for that discipline: today `vaultmind init` seeds a
-// SEPARATE embedded how-to-write-arcs template, so the two surfaces currently
-// drift. A later slice reconciles init's template to this const so they don't.
+// `vaultmind init` seeds the fuller how-to-write-arcs *principle* into a new
+// vault (the same discipline at length, retrievable by recall); this const is the
+// distilled, no-vault version the command prints. The two are kept consistent —
+// the principle's hunt taxonomy, bar, and diff test mirror this text.
 const ArcGuide = `VaultMind — How to Find and Write Your Own Arcs
 
 An arc is a durable record of how your thinking, values, or working style SHIFTED —

--- a/internal/distill/report.go
+++ b/internal/distill/report.go
@@ -24,6 +24,17 @@ type Report struct {
 // text report prints; the full text lives in the episode.
 const reportVerbatimMax = 240
 
+// arcGuideHint is the honest-about-recall pointer printed with every candidate
+// report. The detector phrase-matches only a few shapes (authority-grant,
+// manifesto-lens); most real arcs are NOT phrase-shaped, so the
+// report must hand the agent the manual method rather than imply these are all
+// its arcs — a surface that under-delivers silently is the lie principle-ax-design
+// warns against. Siavoush content-machine field report, 2026-06-19 (the detector
+// missed 3/3 of the agent's real arcs).
+const arcGuideHint = "These are only the easy, phrase-matched moments — the detector misses reversals, " +
+	"reframes, frame-breaks, cost-of-rule and more. Hunt the rest by reading the session yourself; " +
+	"run `vaultmind arc guide` for the method (the seven shapes, the bar, the self-check)."
+
 // FormatReport writes a human-readable, propose-only candidate report. It leads
 // and closes with the contract — these are MOMENTS, not arcs; the mind drafts
 // and approves — so the output can't be mistaken for finished identity.
@@ -35,7 +46,7 @@ func FormatReport(r Report, w io.Writer) error {
 		return err
 	}
 	if len(r.Candidates) == 0 {
-		_, err := fmt.Fprintln(w, "\nNo candidate moments found.")
+		_, err := fmt.Fprintf(w, "\nNo candidate moments found.\n\n%s\n", arcGuideHint)
 		return err
 	}
 
@@ -57,9 +68,10 @@ func FormatReport(r Report, w io.Writer) error {
 		}
 	}
 
-	_, err := fmt.Fprint(w,
+	_, err := fmt.Fprintf(w,
 		"\nA real arc needs a before/after shift in seeing, a verbatim push, and the cost — "+
-			"many of these won't qualify. Draft the ones that did; ignore the rest. Never auto-write identity.\n")
+			"many of these won't qualify. Draft the ones that did; ignore the rest. Never auto-write identity.\n"+
+			"\n%s\n", arcGuideHint)
 	return err
 }
 

--- a/internal/distill/report_test.go
+++ b/internal/distill/report_test.go
@@ -35,10 +35,19 @@ func TestFormatReport_ProposeOnlyAndGrouped(t *testing.T) {
 	assert.Less(t, strings.Index(out, "## ep-a"), strings.Index(out, "## ep-b"))
 	assert.Less(t, strings.Index(out, "turn 2"), strings.Index(out, "turn 9"))
 	assert.Contains(t, out, "full autonomy")
+
+	// Honest about its own low recall + hands the agent the manual method, so the
+	// report can't be mistaken for "all your arcs" (the 3/3-miss field finding).
+	assert.Contains(t, out, "arc guide")
+	assert.Contains(t, out, "misses")
 }
 
 func TestFormatReport_Empty(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, distill.FormatReport(distill.Report{EpisodesScanned: 2, EpisodesKept: 0}, &buf))
-	assert.Contains(t, buf.String(), "No candidate moments found")
+	out := buf.String()
+	assert.Contains(t, out, "No candidate moments found")
+	// Even with zero phrase-matches, point the agent at the manual method — empty
+	// here means "nothing phrase-shaped," not "no arcs in this session."
+	assert.Contains(t, out, "arc guide")
 }

--- a/internal/initvault/templates/principles/how-to-write-arcs.md
+++ b/internal/initvault/templates/principles/how-to-write-arcs.md
@@ -24,6 +24,20 @@ Common shifts worth an arc: a partner's challenge that broke a frame you didn't 
 
 Common things that look like arcs but aren't: completing a feature, fixing a bug, learning a new API, deciding between two options on technical merit. Those are *facts*. They go in notes, commit messages, and ADRs.
 
+## How to hunt — read the session for change, not keywords
+
+Arcs live in the narrative, so you find them by *reading the session start to finish*, not by scanning for phrases. (`vaultmind arc candidates` phrase-matches a couple of easy shapes, but most real arcs are not phrase-shaped — it is a net for the obvious, never the whole catch.) Look for these shapes:
+
+1. **Reversal** — "wait—", "actually—": a direction changed or a decision undone mid-thought.
+2. **Reframe** — a push that changed the *frame*, not just a fact.
+3. **Frame-break** — the moment the task wasn't what you thought it was.
+4. **Method-invalidation** — a shortcut or assumption exposed as invalid.
+5. **Cost-of-rule** — a rule held even though following it cost you something.
+6. **Evidence/trust gate** — proceeding was gated on your confidence or the evidence.
+7. **Ownership assertion** — a boundary of sole responsibility was drawn.
+
+**The diff test** decides the close call: would a future you answer some question *differently* because of this moment? If yes, it is an arc. If nothing downstream changes, it is a note.
+
 ## The shape
 
 Every arc has the same skeleton:

--- a/internal/onboard/COMMANDS.md
+++ b/internal/onboard/COMMANDS.md
@@ -50,6 +50,7 @@ Generated from the command tree — do not edit by hand (run `task generate:docs
 |---------|------|-------------|
 | `vaultmind arc` | Surface arc-distillation candidates from episodes (propose-only) | you want to surface arc-distillation candidate moments from episodes (propose-only). |
 | `vaultmind arc candidates` | Surface candidate transformation moments for arc distillation | you finished a session and want candidate transformation moments to review for arcs. |
+| `vaultmind arc guide` | Print the arc-writing discipline — how to find and write your own arcs | you want to learn how to find and write your own arcs — the shapes, the bar, and the self-check. |
 | `vaultmind episode` | Capture Claude Code sessions as episodic-memory artifacts | you want to capture Claude Code sessions as episodic-memory artifacts. |
 | `vaultmind episode capture` | Convert session transcripts into episode notes | you have a session transcript (or a directory of them) to convert into episode notes. |
 | `vaultmind hooks` | Manage VaultMind's Claude Code hook scripts | you need to install, remove, or check VaultMind's Claude Code hook scripts. |


### PR DESCRIPTION
The first agent-led onboarding (Siavoush's content-machine, 2026-06-19) showed every load-bearing piece of arc discipline had to be hand-relayed over the mesh — it lived nowhere in the binary. This makes finding and writing arcs fully self-serve, per `principle-ax-design` ("make first contact self-serve"; "meet the agent where it reaches").

## What

**`vaultmind arc guide`** (new flagless command) — the canonical arc-writing discipline in the binary: the seven hunt shapes a phrase-matcher can't catch (reversal, reframe, frame-break, method-invalidation, cost-of-rule, evidence/trust gate, ownership assertion), the 5-part bar, the non-negotiables, the diff test, and a self-pressure-test. SSOT text in `internal/distill` (`ArcGuide`).

**`arc candidates` owns its low recall** — both the zero-candidate and has-candidate branches now state these are only the easy phrase-matched moments and point at `arc guide` for the manual method. The detector missed 3/3 of the onboarding agent's real arcs; the report no longer implies it found them all.

**Seeded principle enriched** — `init` already seeds a full `how-to-write-arcs` principle + a 5-part `arc-example.md`; this ports the named hunt taxonomy + diff test into that principle so an adopting vault and the command teach the same discipline (the two surfaces: a no-vault command const and a fuller in-vault principle, kept consistent).

## Verification
- TDD per slice; full suite (3629 tests) + lint + vuln-scan green via lefthook on every commit.
- pr-review-toolkit passes (code-reviewer + comment-analyzer) — caught and fixed an over-claiming comment + a stale forward-reference.
- init smoke: a fresh vault's `how-to-write-arcs` principle and `arc guide` name the same seven shapes.

Companion to #36 (both from the same onboarding's findings).