### PR TITLE
docs(onboard): tell adopters to report findings via vaultmind-oss issues

### DIFF
--- a/internal/onboard/AGENT_ONBOARDING.md
+++ b/internal/onboard/AGENT_ONBOARDING.md
@@ -681,6 +681,12 @@ Tell the user:
 
 ---
 
+## Report what you find
+
+You are the consumer whose real use makes this tool honest — and the surest source of fixes. As you onboard and then live inside the vault, **file what you hit as issues on the public repo: https://github.com/peiman/vaultmind/issues**. Worth reporting: anything that surprised you, degraded silently, made you reach around the tool, or made you read this doc twice. Concrete field reports from real adopters are exactly what drives the roadmap — several recent improvements, including the arc-writing self-serve guide and this feedback instruction itself, came directly from adopter field reports. You don't need permission or a polished repro; a one-paragraph "here's what bit me" is the highest-leverage thing you can send back.
+
+---
+
 ## Known issues for v2 (surfaced by 2026-05-04 dogfood)
 
 These were caught walking this doc against a real local repo (greenfield via `/tmp/dogfood-onboarding`, migration shape via `a content/markdown project`). They're real but not push-blocking; named here so the next iteration knows what to fix.

--- a/internal/onboard/QUICKSTART.md
+++ b/internal/onboard/QUICKSTART.md
@@ -66,3 +66,11 @@ vaultmind ask "who am I" --vault <vault>   # see what the agent would see
 ```bash
 vaultmind init --print-instructions --full
 ```
+
+## 8. Report what you find
+
+You are the consumer whose real use makes this tool honest — the surest source of
+fixes. When something surprises you, degrades silently, or makes you reach around
+the tool, **file an issue: https://github.com/peiman/vaultmind/issues**. Concrete
+field reports from adopters drive what gets fixed next — this onboarding keeps
+improving because of them.

--- a/internal/onboard/onboard_test.go
+++ b/internal/onboard/onboard_test.go
@@ -49,6 +49,18 @@ func TestInstructions_ContainsStructuralAnchors(t *testing.T) {
 	}
 }
 
+// TestOnboarding_PointsToIssuesFeedback — both the default quick-start and the
+// full guide must tell the adopting agent to report findings as vaultmind-oss
+// issues (Peiman 2026-06-23). The consumer-evidence loop only closes if a
+// self-serve adopter (no mesh link) is handed an explicit channel.
+func TestOnboarding_PointsToIssuesFeedback(t *testing.T) {
+	const issuesURL = "github.com/peiman/vaultmind/issues"
+	assert.Contains(t, string(onboard.QuickStart()), issuesURL,
+		"quick-start must name the issues feedback channel")
+	assert.Contains(t, string(onboard.Instructions()), issuesURL,
+		"full guide must name the issues feedback channel")
+}
+
 // TestPrintInstructions_WritesToWriter — `--print-instructions`
 // composes via PrintInstructions(w). Pin the contract that it writes
 // to the supplied writer (not stdout directly), so the cmd layer can


### PR DESCRIPTION
The onboarding wired adopters in but never told them how to feed findings back — and the consumer-evidence loop only closed this session because the adopter happened to be in the mesh with Mira. A self-serve adopter (no mesh link) needs an explicit channel.

## What
- **`internal/onboard/QUICKSTART.md`** (the default `init --print-instructions`): new "§8. Report what you find" — file findings at https://github.com/peiman/vaultmind/issues.
- **`internal/onboard/AGENT_ONBOARDING.md`** (the `--full` guide): a fuller "Report what you find" section — what's worth reporting (surprises, silent degrades, reach-arounds, read-it-twice docs), and that a one-paragraph "here's what bit me" needs no polished repro.
- Test pins that both embedded docs name the issues channel.

## Verification
- Full suite (3629 tests) + lint + vuln-scan green via lefthook.
- pr-review-toolkit comment-analyzer pass — softened two origin claims that would have been falsifiable later (kept to "adopter reports drive what's fixed next" per the doc's own "don't oversell" rule).

Third fix from the Siavoush content-machine onboarding's findings (companions: #36 backend honesty, #37 arc self-service).