### PR TITLE
fix: bge-m3 embed no longer hangs on large/dense docs (#39)

### DIFF
--- a/internal/embedding/bgem3.go
+++ b/internal/embedding/bgem3.go
@@ -27,6 +27,10 @@ type BGEM3Embedder struct {
 	colbertB  []float32   // [1024] bias
 	dims      int
 	maxTokens int
+	// preprocess tokenizes texts into a batch. In production it is
+	// pipeline.Preprocess; tests substitute a fake so the token-fitting path
+	// (#39) is exercisable without loading the 2.2GB model.
+	preprocess func(*backends.PipelineBatch, []string) error
 }
 
 // NewBGEM3Embedder creates a BGE-M3 embedder with all three heads.
@@ -72,14 +76,15 @@ func NewBGEM3Embedder(cfg HugotConfig) (*BGEM3Embedder, error) {
 	}
 
 	return &BGEM3Embedder{
-		session:   session,
-		pipeline:  pipeline,
-		sparseW:   sparseW[0], // [1][1024] -> [1024]
-		sparseB:   sBias,
-		colbertW:  colbertW,
-		colbertB:  colbertB,
-		dims:      cfg.Dims,
-		maxTokens: cfg.MaxTokens,
+		session:    session,
+		pipeline:   pipeline,
+		sparseW:    sparseW[0], // [1][1024] -> [1024]
+		sparseB:    sBias,
+		colbertW:   colbertW,
+		colbertB:   colbertB,
+		dims:       cfg.Dims,
+		maxTokens:  cfg.MaxTokens,
+		preprocess: pipeline.Preprocess,
 	}, nil
 }
 
@@ -131,23 +136,15 @@ func (e *BGEM3Embedder) EmbedFull(ctx context.Context, text string) (*BGEM3Outpu
 // EmbedFullBatch produces all three embedding types for multiple texts.
 // Bypasses hugot's Postprocess to access raw per-token hidden states.
 func (e *BGEM3Embedder) EmbedFullBatch(_ context.Context, texts []string) ([]*BGEM3Output, error) {
-	// Truncate texts to model's token limit
-	if e.maxTokens > 0 {
-		truncated := make([]string, len(texts))
-		for i, t := range texts {
-			truncated[i] = TruncateForEmbedding(t, e.maxTokens)
-		}
-		texts = truncated
+	// Tokenize into a batch, GUARANTEEING no input exceeds the model's token limit
+	// before the (hang-prone) ONNX forward pass — see preprocessWithinTokenLimit
+	// (#39). Skip Postprocess (mean-pool) so the heads see raw per-token states.
+	batch, err := e.preprocessWithinTokenLimit(texts)
+	if err != nil {
+		return nil, err
 	}
-
-	// Use hugot's Preprocess (tokenize) + Forward (ONNX inference)
-	// but skip Postprocess (which mean-pools the per-token output).
-	batch := backends.NewBatch(len(texts))
 	defer func() { _ = batch.Destroy() }()
 
-	if err := e.pipeline.Preprocess(batch, texts); err != nil {
-		return nil, fmt.Errorf("preprocessing: %w", err)
-	}
 	if err := e.pipeline.Forward(batch); err != nil {
 		return nil, fmt.Errorf("forward pass: %w", err)
 	}
@@ -173,6 +170,101 @@ func (e *BGEM3Embedder) EmbedFullBatch(_ context.Context, texts []string) ([]*BG
 	}
 
 	return outputs, nil
+}
+
+// preprocessWithinTokenLimit tokenizes texts into a batch, guaranteeing no input
+// exceeds maxTokens before the (hang-prone) ONNX forward pass. hugot's Rust
+// tokenizer does NOT truncate to the model limit (only the pure-Go one sets
+// MaxLen), so a note above max_position_embeddings would otherwise reach ORT as
+// an oversized tensor and hang — vaultmind#39. A character estimate
+// (TruncateForEmbedding) cannot guarantee the cap for dense content (code /
+// markdown / non-English tokenize below the assumed chars/token), so we measure
+// the ACTUAL token count from a cheap tokenization pass and shrink any over-limit
+// text by its observed chars/token ratio, looping until every input fits. A
+// halving fallback guarantees termination. The common case (already within limit)
+// is a single Preprocess — no added cost.
+func (e *BGEM3Embedder) preprocessWithinTokenLimit(texts []string) (*backends.PipelineBatch, error) {
+	fitted, err := fitTextsWithinTokenLimit(texts, e.maxTokens, e.tokenCounts)
+	if err != nil {
+		return nil, err
+	}
+	batch := backends.NewBatch(len(fitted))
+	if err := e.preprocess(batch, fitted); err != nil {
+		_ = batch.Destroy()
+		return nil, fmt.Errorf("preprocessing: %w", err)
+	}
+	return batch, nil
+}
+
+// tokenCounts tokenizes texts and returns each one's token count (via a throwaway
+// batch). This is the model-bound step fitTextsWithinTokenLimit calls; injecting
+// e.preprocess lets tests substitute a fake so the fit path needs no model.
+func (e *BGEM3Embedder) tokenCounts(texts []string) ([]int, error) {
+	batch := backends.NewBatch(len(texts))
+	defer func() { _ = batch.Destroy() }()
+	if err := e.preprocess(batch, texts); err != nil {
+		return nil, fmt.Errorf("preprocessing: %w", err)
+	}
+	counts := make([]int, len(texts))
+	for i := range texts {
+		counts[i] = len(batch.Input[i].TokenIDs)
+	}
+	return counts, nil
+}
+
+// fitTextsWithinTokenLimit shrinks each text until its tokenized length (per
+// countTokens) is <= maxTokens, looping with shrinkTowardTokenBudget's halving
+// fallback so it always terminates. countTokens is injected, so the loop is
+// model-free unit-testable. Returns the within-limit texts, or an error if it
+// cannot converge within hardCap (a pathological maxTokens below the tokenizer's
+// special-token floor).
+func fitTextsWithinTokenLimit(texts []string, maxTokens int, countTokens func([]string) ([]int, error)) ([]string, error) {
+	work := make([]string, len(texts))
+	for i, t := range texts {
+		work[i] = t
+		if maxTokens > 0 {
+			work[i] = TruncateForEmbedding(t, maxTokens) // cheap first cut by char estimate
+		}
+	}
+	if maxTokens <= 0 {
+		return work, nil
+	}
+	const hardCap = 16 // halving 16x reduces any input to ~0 — convergence guaranteed well before
+	for iter := 0; ; iter++ {
+		counts, err := countTokens(work)
+		if err != nil {
+			return nil, err
+		}
+		over := false
+		for i := range work {
+			if counts[i] <= maxTokens {
+				continue
+			}
+			over = true
+			work[i] = shrinkTowardTokenBudget(work[i], counts[i], maxTokens, iter)
+		}
+		if !over {
+			return work, nil
+		}
+		if iter >= hardCap {
+			return nil, fmt.Errorf("could not fit input within %d tokens after %d attempts", maxTokens, hardCap)
+		}
+	}
+}
+
+// shrinkTowardTokenBudget shortens text toward maxTokens. Early iterations shrink
+// proportionally using the MEASURED chars/token ratio (with a 10% margin) so it
+// converges in one or two passes for real content; as a guaranteed-converging
+// fallback it halves, so the loop always terminates even on pathological input.
+func shrinkTowardTokenBudget(text string, tokenCount, maxTokens, iter int) string {
+	if iter < 4 && tokenCount > 0 {
+		ratio := float64(len(text)) / float64(tokenCount) // measured chars per token
+		target := int(float64(maxTokens) * ratio * 0.9)   // 10% margin under the limit
+		if target > 0 && target < len(text) {
+			return truncateToChars(text, target)
+		}
+	}
+	return truncateToChars(text, len(text)/2) // monotone shrink → guaranteed convergence
 }
 
 // EmbedSparse produces only the sparse embedding (used by SparseRetriever).

--- a/internal/embedding/bgem3_truncate_test.go
+++ b/internal/embedding/bgem3_truncate_test.go
@@ -1,0 +1,190 @@
+package embedding
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/knights-analytics/hugot/backends"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Pure unit tests (no model needed; always run) ---
+
+func TestTruncateToChars(t *testing.T) {
+	assert.Equal(t, "", truncateToChars("anything", 0), "zero cap returns empty")
+	assert.Equal(t, "short", truncateToChars("short", 100), "under cap is unchanged")
+	long := strings.Repeat("a", 200)
+	assert.LessOrEqual(t, len(truncateToChars(long, 50)), 50, "over cap is capped")
+	// Word-break: cuts at a space near the cap rather than mid-word.
+	got := truncateToChars("alpha beta gamma delta", 12)
+	assert.LessOrEqual(t, len(got), 12)
+	assert.NotContains(t, got, "gamma", "tail past the cap is dropped")
+}
+
+// The #39 content class is dense / non-English; a byte-boundary cut must never
+// split a multi-byte rune into invalid UTF-8.
+func TestTruncateToChars_RuneSafe(t *testing.T) {
+	cjk := strings.Repeat("中", 100) // 3 bytes each, no spaces to break on
+	got := truncateToChars(cjk, 50) // 50 is not a multiple of 3
+	assert.True(t, utf8.ValidString(got), "must not emit invalid UTF-8")
+	assert.LessOrEqual(t, len(got), 50)
+}
+
+// shrinkTowardTokenBudget must ALWAYS reduce an over-budget input, and its halving
+// fallback must guarantee convergence regardless of how wrong the measured ratio
+// is — the property that stops #39 from ever hanging the forward pass.
+func TestShrinkTowardTokenBudget_AlwaysShrinks(t *testing.T) {
+	text := strings.Repeat("word ", 1000) // 5000 bytes
+	got := shrinkTowardTokenBudget(text, 4000, 50, 0)
+	assert.Less(t, len(got), len(text), "an over-budget input must get shorter")
+}
+
+func TestShrinkTowardTokenBudget_FallbackHalves(t *testing.T) {
+	text := strings.Repeat("x", 1000)
+	got := shrinkTowardTokenBudget(text, 999, 10, 5) // iter>=4 → halving fallback
+	assert.InDelta(t, 500, len(got), 1, "the fallback halves the input")
+}
+
+// Convergence: repeatedly applying the shrink (worst case: the halving fallback)
+// drives any input under the cap within the hardCap (16) iterations the real loop
+// uses — so preprocessWithinTokenLimit can never spin forever.
+func TestShrinkTowardTokenBudget_ConvergesWithinHardCap(t *testing.T) {
+	text := strings.Repeat("x", 100000)
+	const maxTokens = 10
+	for iter := 0; iter < 16; iter++ {
+		text = shrinkTowardTokenBudget(text, len(text), maxTokens, iter) // 1 char/token: worst case
+		if len(text) <= maxTokens {
+			return
+		}
+	}
+	assert.LessOrEqual(t, len(text), maxTokens, "must converge within 16 iterations")
+}
+
+// --- Token-fit loop tests (model-free: the tokenizer is injected) ---
+
+// fakeCountByLen treats each byte as one token — a deterministic stand-in for the
+// real tokenizer so the fit loop is testable without the model.
+func fakeCountByLen(texts []string) ([]int, error) {
+	c := make([]int, len(texts))
+	for i, s := range texts {
+		c[i] = len(s)
+	}
+	return c, nil
+}
+
+func TestFitTextsWithinTokenLimit_UnderLimitUnchanged(t *testing.T) {
+	got, err := fitTextsWithinTokenLimit([]string{"hi"}, 10, fakeCountByLen)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "hi", got[0], "an under-limit input is returned unchanged")
+}
+
+func TestFitTextsWithinTokenLimit_ShrinksOverLimit(t *testing.T) {
+	got, err := fitTextsWithinTokenLimit([]string{strings.Repeat("a", 500)}, 10, fakeCountByLen)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(got[0]), 10, "an over-limit input is shrunk to the cap")
+}
+
+func TestFitTextsWithinTokenLimit_MixedBatch(t *testing.T) {
+	got, err := fitTextsWithinTokenLimit([]string{"ok", strings.Repeat("b", 300)}, 10, fakeCountByLen)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "ok", got[0], "under-limit input untouched")
+	assert.LessOrEqual(t, len(got[1]), 10, "over-limit input shrunk")
+}
+
+func TestFitTextsWithinTokenLimit_MaxTokensZeroSkips(t *testing.T) {
+	called := false
+	got, err := fitTextsWithinTokenLimit([]string{"anything"}, 0, func([]string) ([]int, error) { called = true; return nil, nil })
+	require.NoError(t, err)
+	assert.Equal(t, []string{"anything"}, got)
+	assert.False(t, called, "maxTokens<=0 skips tokenization entirely")
+}
+
+func TestFitTextsWithinTokenLimit_CounterErrorPropagates(t *testing.T) {
+	_, err := fitTextsWithinTokenLimit([]string{"x"}, 10, func([]string) ([]int, error) { return nil, assert.AnError })
+	require.Error(t, err)
+}
+
+func TestFitTextsWithinTokenLimit_NonConvergenceErrorsNotHangs(t *testing.T) {
+	// A counter that never reports within-limit must hit hardCap and ERROR — never
+	// loop forever. This is the anti-hang guarantee at the loop level.
+	stuck := func(ts []string) ([]int, error) {
+		c := make([]int, len(ts))
+		for i := range ts {
+			c[i] = 9999
+		}
+		return c, nil
+	}
+	_, err := fitTextsWithinTokenLimit([]string{strings.Repeat("a", 100)}, 10, stuck)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not fit")
+}
+
+// preprocessWithinTokenLimit + tokenCounts, exercised with a FAKE preprocess (no
+// model): proves the wrapper builds a within-cap batch from a mixed input.
+func TestPreprocessWithinTokenLimit_FakePipeline(t *testing.T) {
+	fake := func(b *backends.PipelineBatch, texts []string) error {
+		b.Input = make([]backends.TokenizedInput, len(texts))
+		for i, s := range texts {
+			b.Input[i] = backends.TokenizedInput{TokenIDs: make([]uint32, len(s))} // 1 token/byte
+		}
+		return nil
+	}
+	e := &BGEM3Embedder{maxTokens: 10, preprocess: fake}
+	batch, err := e.preprocessWithinTokenLimit([]string{"ok", strings.Repeat("a", 500)})
+	require.NoError(t, err)
+	defer func() { _ = batch.Destroy() }()
+	require.Len(t, batch.Input, 2)
+	assert.LessOrEqual(t, len(batch.Input[0].TokenIDs), 10)
+	assert.LessOrEqual(t, len(batch.Input[1].TokenIDs), 10)
+}
+
+// --- ORT integration test (real tokenizer; gated by env + needs the model) ---
+
+// On the ORT build the Rust tokenizer does not truncate, so dense content stays
+// oversized past the char-estimate pre-cut (#39). This proves the token-accurate
+// loop caps it via the REAL tokenizer. Self-validating: it first confirms the
+// char-pre-cut input is genuinely over the cap, so it can never pass trivially.
+func TestPreprocessWithinTokenLimit_CapsDenseInput(t *testing.T) {
+	if os.Getenv("VAULTMIND_TEST_BGEM3") == "" {
+		t.Skip("set VAULTMIND_TEST_BGEM3=1 (loads the BGE-M3 model + tokenizer)")
+	}
+	e, err := NewBGEM3Embedder(BGEM3Config())
+	require.NoError(t, err)
+	defer func() { _ = e.Close() }()
+
+	e.maxTokens = 40
+	// Dense, symbol-heavy content — the #39 class (code/markdown tokenizes well
+	// below the assumed chars/token, so the char pre-cut leaves it oversized).
+	dense := strings.Repeat("a1=b2;c3{d4}e5[f6]:g7,h8|i9/j0\\", 80)
+
+	// Precondition: the char pre-cut must STILL be over the cap, or the test
+	// isn't exercising the token-accurate loop (the actual fix).
+	pre := TruncateForEmbedding(dense, e.maxTokens)
+	rawBatch := backends.NewBatch(1)
+	require.NoError(t, e.pipeline.Preprocess(rawBatch, []string{pre}))
+	rawN := len(rawBatch.Input[0].TokenIDs)
+	_ = rawBatch.Destroy()
+	require.Greaterf(t, rawN, e.maxTokens,
+		"precondition: char-pre-cut input must exceed the cap to exercise the loop (got %d tokens) — make `dense` denser", rawN)
+
+	// The fix: the token-accurate loop brings it within the cap.
+	batch, err := e.preprocessWithinTokenLimit([]string{dense})
+	require.NoError(t, err)
+	defer func() { _ = batch.Destroy() }()
+	assert.LessOrEqualf(t, len(batch.Input[0].TokenIDs), e.maxTokens,
+		"preprocessWithinTokenLimit must cap the tokenized input at maxTokens (#39 fix); got %d", len(batch.Input[0].TokenIDs))
+
+	// Mixed batch (under + over): exercises the per-element loop — only the
+	// over-limit input is shrunk, and every input ends within the cap.
+	mixed, err := e.preprocessWithinTokenLimit([]string{"hello world", dense})
+	require.NoError(t, err)
+	defer func() { _ = mixed.Destroy() }()
+	require.Len(t, mixed.Input, 2)
+	assert.LessOrEqual(t, len(mixed.Input[0].TokenIDs), e.maxTokens, "short input stays within cap")
+	assert.LessOrEqual(t, len(mixed.Input[1].TokenIDs), e.maxTokens, "dense input is capped")
+}

--- a/internal/embedding/hugot.go
+++ b/internal/embedding/hugot.go
@@ -3,6 +3,7 @@ package embedding
 import (
 	"context"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/knights-analytics/hugot"
 	"github.com/knights-analytics/hugot/pipelines"
@@ -44,16 +45,31 @@ func TruncateForEmbedding(text string, maxTokens int) string {
 	if maxTokens <= 0 {
 		return ""
 	}
-	maxChars := maxTokens * approxCharsPerToken
+	return truncateToChars(text, maxTokens*approxCharsPerToken)
+}
+
+// truncateToChars cuts text to at most maxChars bytes, breaking at a word
+// boundary when one is within ~40 bytes of the cut. Shared by the char-estimate
+// pre-truncation (TruncateForEmbedding) and the token-accurate shrink loop
+// (BGEM3Embedder.preprocessWithinTokenLimit, #39).
+func truncateToChars(text string, maxChars int) string {
+	if maxChars <= 0 {
+		return ""
+	}
 	if len(text) <= maxChars {
 		return text
 	}
 	cut := text[:maxChars]
-	// Find last space for clean word break
 	for i := len(cut) - 1; i > maxChars-40 && i > 0; i-- {
 		if cut[i] == ' ' {
 			return cut[:i]
 		}
+	}
+	// No nearby space: back off any partial trailing rune so we never emit
+	// invalid UTF-8. The #39 content class is dense / non-English (e.g. CJK),
+	// where a byte-boundary cut would split a multi-byte rune.
+	for len(cut) > 0 && !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
 	}
 	return cut
 }


### PR DESCRIPTION
Fixes #39 (serious, adopter-blocking — found by the content-machine migration: bge-m3 froze forever on large docs).

## Root cause
hugot's Rust tokenizer (the ORT path) doesn't truncate to the model's token limit — only the pure-Go tokenizer sets MaxLen. So a note above max_position_embeddings (8192) reached ORT as an oversized tensor and **hung** (pegged a core; the all-or-nothing embed pass then saved zero embeddings). The prior char-estimate truncation couldn't guarantee the cap for dense content (code/markdown/non-English tokenize below the assumed chars/token).

## Fix
`EmbedFullBatch` now fits inputs to the limit before the forward pass. The fit loop measures the **actual** token count and shrinks any over-limit text by its observed chars/token ratio (halving fallback guarantees termination), then runs forward. Common case (within limit) adds only a cheap tokenize pass. `truncateToChars` is now rune-safe (the #39 content class is non-English).

The token-fit loop (`fitTextsWithinTokenLimit`) takes the tokenizer as an injected dependency, so it is unit-testable without loading the 2.2GB model.

## Verification
- Model-free unit tests cover the fit loop, shrink/convergence (incl. the anti-hang hardCap error path), rune-safety, and the wrapper via a fake tokenizer — **patch coverage 83.95%**.
- Self-validating ORT integration test (real Rust tokenizer, gated by VAULTMIND_TEST_BGEM3): confirms the input is genuinely over the cap before asserting the loop fixes it (dense + mixed batch) — verified green locally.
- Full lefthook suite + coverage floors green; pure-Go and -tags ORT both green.
- pr-review-toolkit code-review pass (ship); its suggestions (rune-safety, mixed-batch coverage, loop testability) all folded in.