### PR TITLE
fix: index robustness — surface dropped notes (#40) + skip empty-body on embed (#41)

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -188,6 +188,21 @@ func formatIndexResult(r index.IndexAndEmbedResult, model string, w io.Writer) e
 			return err
 		}
 	}
+	// Surface files that were skipped (read/parse errors) with their cause — a
+	// note dropped from the index must never vanish silently (vaultmind#40: an
+	// unquoted colon in a YAML title made the frontmatter unparseable and the
+	// note disappeared with no visible message; the non-full output didn't even
+	// show the error count). Name the count AND each file's reason here.
+	if r.Index.Errors > 0 {
+		if _, err := fmt.Fprintf(w, "⚠ %d file(s) skipped — not indexed:\n", r.Index.Errors); err != nil {
+			return err
+		}
+		for _, e := range r.Index.ErrorDetails {
+			if _, err := fmt.Fprintf(w, "  - %s (%s): %s\n", e.Path, e.Kind, e.Error); err != nil {
+				return err
+			}
+		}
+	}
 	if r.Embed != nil {
 		// Name the model in the human-readable output. Pure-Go fallback
 		// silently producing minilm-only embeddings was the surprise the

--- a/cmd/remaining_runners_test.go
+++ b/cmd/remaining_runners_test.go
@@ -310,6 +310,53 @@ func TestLintFixLinks_FixRewritesIncompatibleLinksOnDisk(t *testing.T) {
 	}
 }
 
+// vaultmind#40: a note dropped from the index (read/parse error) must be
+// surfaced in the human output — not vanish silently (an unquoted colon in a
+// YAML title made the note unparseable and it disappeared with no message).
+// Both the count and the per-file cause must appear.
+func TestFormatIndexResult_SurfacesSkippedFileErrors(t *testing.T) {
+	var buf bytes.Buffer
+	err := formatIndexResult(index.IndexAndEmbedResult{
+		Index: &index.IndexResult{
+			FullRebuild: false, Skipped: 5,
+			Errors: 1,
+			ErrorDetails: []index.IndexError{
+				{Path: "notes/patterns.md", Kind: "parse", Error: "yaml: mapping values are not allowed here"},
+			},
+		},
+	}, "", &buf)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "1 file(s) skipped")
+	assert.Contains(t, out, "notes/patterns.md")
+	assert.Contains(t, out, "parse")
+	assert.Contains(t, out, "mapping values are not allowed here")
+}
+
+// failAfterNWriter fails on the (ok+1)th Write — drives formatIndexResult's
+// write-error returns inside the #40 skipped-files block.
+type failAfterNWriter struct{ ok int }
+
+func (f *failAfterNWriter) Write(p []byte) (int, error) {
+	if f.ok <= 0 {
+		return 0, assert.AnError
+	}
+	f.ok--
+	return len(p), nil
+}
+
+func TestFormatIndexResult_SkippedErrorsPropagateWriteErrors(t *testing.T) {
+	res := index.IndexAndEmbedResult{
+		Index: &index.IndexResult{
+			Errors:       1,
+			ErrorDetails: []index.IndexError{{Path: "a.md", Kind: "parse", Error: "boom"}},
+		},
+	}
+	// 2nd write = the "⚠ N file(s) skipped" summary; 3rd = the per-file detail.
+	require.Error(t, formatIndexResult(res, "", &failAfterNWriter{ok: 1}))
+	require.Error(t, formatIndexResult(res, "", &failAfterNWriter{ok: 2}))
+}
+
 // formatIndexResult: full rebuild emits "Indexed N notes (...)"; incremental
 // emits the skipped/updated/added/deleted breakdown. Regression: swapping
 // the two paths would confuse the user about whether everything was rebuilt.

--- a/internal/index/embed_notes_test.go
+++ b/internal/index/embed_notes_test.go
@@ -280,6 +280,7 @@ func TestEmbedNotes_EmptyBodySkippedNotFatal(t *testing.T) {
 	require.NoError(t, err, "a NULL/empty body must not hard-error the embed pass (#41)")
 	assert.Equal(t, 2, r.Embedded, "the two real notes embed; the empty-body note is skipped")
 	assert.Equal(t, 0, r.Errors, "skipping an empty body is not an error")
+	assert.Equal(t, 1, r.Skipped, "the empty-body note is counted as skipped, not silently dropped")
 }
 
 // After EmbedNotes runs, HasEmbeddings must report true — this is the

--- a/internal/index/embed_notes_test.go
+++ b/internal/index/embed_notes_test.go
@@ -259,6 +259,29 @@ func TestRunEmbed_LazyLoad_SkipsModelWhenNoPendingWork(t *testing.T) {
 	assert.Equal(t, 3, r2.Skipped, "all 3 already-embedded notes counted as skipped")
 }
 
+// A NULL (or empty) body_text — the empty-placeholder-file case — must NOT
+// hard-error the whole embed pass (vaultmind#41). The note is skipped with a
+// warning; the rest of the vault still embeds.
+func TestEmbedNotes_EmptyBodySkippedNotFatal(t *testing.T) {
+	vaultRoot, dbPath := buildEmbedTestVault(t) // alpha, beta, gamma — all with bodies
+	cfg, err := vault.LoadConfig(vaultRoot)
+	require.NoError(t, err)
+	idxr := index.NewIndexer(vaultRoot, dbPath, cfg)
+
+	// Force one note to have a NULL body_text — historically this crashed the
+	// pass on the string scan ("converting NULL to string is unsupported").
+	db, err := index.Open(dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec("UPDATE notes SET body_text = NULL WHERE id = 'concept-alpha'")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	r, err := idxr.EmbedNotes(context.Background(), dbPath, fakeDenseEmbedder{dims: 8})
+	require.NoError(t, err, "a NULL/empty body must not hard-error the embed pass (#41)")
+	assert.Equal(t, 2, r.Embedded, "the two real notes embed; the empty-body note is skipped")
+	assert.Equal(t, 0, r.Errors, "skipping an empty body is not an error")
+}
+
 // After EmbedNotes runs, HasEmbeddings must report true — this is the
 // signal BuildAutoRetrieverFull reads to decide whether to wire the hybrid
 // retriever or fall back to keyword.

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/peiman/vaultmind/internal/embedding"
@@ -630,10 +631,10 @@ func (idx *Indexer) EmbedNotes(ctx context.Context, dbPath string, embedder embe
 	var skipQuery, pendingQuery string
 	if isFull {
 		// BGE-M3: need notes where any of the 3 embeddings are missing
-		pendingQuery = "SELECT id, body_text FROM notes WHERE embedding IS NULL OR sparse_embedding IS NULL OR colbert_embedding IS NULL"
+		pendingQuery = "SELECT id, COALESCE(body_text, '') FROM notes WHERE embedding IS NULL OR sparse_embedding IS NULL OR colbert_embedding IS NULL"
 		skipQuery = "SELECT COUNT(*) FROM notes WHERE embedding IS NOT NULL AND sparse_embedding IS NOT NULL AND colbert_embedding IS NOT NULL"
 	} else {
-		pendingQuery = "SELECT id, body_text FROM notes WHERE embedding IS NULL"
+		pendingQuery = "SELECT id, COALESCE(body_text, '') FROM notes WHERE embedding IS NULL"
 		skipQuery = "SELECT COUNT(*) FROM notes WHERE embedding IS NOT NULL"
 	}
 
@@ -659,6 +660,14 @@ func (idx *Indexer) EmbedNotes(ctx context.Context, dbPath string, embedder embe
 		if err := rows.Scan(&nt.id, &nt.body); err != nil {
 			_ = rows.Close()
 			return nil, fmt.Errorf("scanning unembedded note: %w", err)
+		}
+		// An empty-body note has nothing to embed. Skip it with a warning rather
+		// than feed "" to the embedder — a NULL body_text used to hard-error the
+		// whole pass (vaultmind#41). One placeholder file must not block embedding
+		// the rest of the vault. (NULL is coalesced to "" by the query above.)
+		if strings.TrimSpace(nt.body) == "" {
+			log.Warn().Str("id", nt.id).Msg("skipping note with empty body — nothing to embed")
+			continue
 		}
 		pending = append(pending, nt)
 	}

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -666,7 +666,10 @@ func (idx *Indexer) EmbedNotes(ctx context.Context, dbPath string, embedder embe
 		// whole pass (vaultmind#41). One placeholder file must not block embedding
 		// the rest of the vault. (NULL is coalesced to "" by the query above.)
 		if strings.TrimSpace(nt.body) == "" {
+			// Count it (not just log) so the skip is auditable in the result —
+			// consistent with surfacing dropped notes (#40), never a silent omission.
 			log.Warn().Str("id", nt.id).Msg("skipping note with empty body — nothing to embed")
+			result.Skipped++
 			continue
 		}
 		pending = append(pending, nt)


### PR DESCRIPTION
Two adopter-reported index-robustness fixes from the content-machine migration.

## #41 — empty-body note crashed the embed pass
A note with NULL `body_text` (an empty placeholder file) crashed the whole `--embed` pass on the string scan ("converting NULL to string is unsupported"), so one empty file blocked embedding the entire vault. Fix: the pending query `COALESCE`s `body_text` to "", and `EmbedNotes` skips empty/whitespace-only bodies with a warning (counted in `Skipped`, so the skip is auditable — not log-only).

## #40 — dropped notes vanished silently
A note with invalid YAML frontmatter (e.g. an unquoted colon in the title) is dropped from the index, but the human output never showed it: the incremental path omitted the error count, and the per-file `ErrorDetails` were never rendered. Fix: `formatIndexResult` now prints "⚠ N file(s) skipped — not indexed" with each file's path, kind, and reason.

## Verification
- New tests: NULL-body doesn't crash + is counted as skipped; dropped-file errors surface in output; write-error propagation.
- Patch coverage 100%; full lefthook suite + coverage floors green.
- pr-review-toolkit code-review: ship (no blocking issues); its one on-theme observation — make the empty-body skip auditable rather than log-only — folded in.

(Smaller siblings of #39, all from the same migration's field report.)